### PR TITLE
Grant sorting on profile pages

### DIFF
--- a/productMods/config/listViewConfig-hasInvestigatorRole.xml
+++ b/productMods/config/listViewConfig-hasInvestigatorRole.xml
@@ -61,7 +61,7 @@
             <critical-data-required>
             FILTER ( bound(?activity) )
             </critical-data-required>
-        } ORDER BY DESC(?dateTimeEnd) DESC(?dateTimeStart) ?activityLabel ?activityName
+        } ORDER BY DESC(?dateTimeEndRole) DESC(?dateTimeStartRole) ?activityLabel ?activityName
     </query-select>
     
     <query-construct>


### PR DESCRIPTION
We noticed the grants section wasn't sorting by date.  I adjusted the SPARQL query in the listViewConfig-hasInvestigatorRole.xml to use the dateTimeInterval end and start values from the InvestigatorRole.  
