### PR TITLE
Fixed query variables for organizationForTraining list view config; JIRA...

### DIFF
--- a/productMods/config/listViewConfig-organizationForTraining.xml
+++ b/productMods/config/listViewConfig-organizationForTraining.xml
@@ -167,13 +167,13 @@
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;   
         CONSTRUCT { 
             ?subject ?property ?edTraining .
-            ?leaderRole core:dateTimeInterval ?dateTimeInterval .
+            ?edTraining core:dateTimeInterval ?dateTimeInterval .
             ?dateTimeInterval core:start ?dateTimeStartValue .
             ?dateTimeStartValue core:dateTime ?dateTimeStart 
         } WHERE {
             ?subject ?property ?edTraining .
             ?edTraining a core:EducationalProcess .
-            ?leaderRole core:dateTimeInterval ?dateTimeInterval .
+            ?edTraining core:dateTimeInterval ?dateTimeInterval .
             ?dateTimeInterval core:start ?dateTimeStartValue .
             ?dateTimeStartValue core:dateTime ?dateTimeStart 
         } 
@@ -183,15 +183,15 @@
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;   
         CONSTRUCT { 
             ?subject ?property ?edTraining .
-            ?leaderRole core:dateTimeInterval ?dateTimeInterval .
+            ?edTraining core:dateTimeInterval ?dateTimeInterval .
             ?dateTimeInterval core:end ?dateTimeEndValue .
-            ?dateTimeStartValue core:dateTime ?dateTimeEnd 
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd 
         } WHERE {
             ?subject ?property ?edTraining .
             ?edTraining a core:EducationalProcess .
-            ?leaderRole core:dateTimeInterval ?dateTimeInterval .
+            ?edTraining core:dateTimeInterval ?dateTimeInterval .
             ?dateTimeInterval core:end ?dateTimeEndValue .
-            ?dateTimeStartValue core:dateTime ?dateTimeEnd
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd
         } 
     </query-construct>
     


### PR DESCRIPTION
... VIVO-932

Fixed a runaway query that was causing University  pages (or anything using organizationForTraining) to run several minutes before loading.

Further information on this issue can be found at https://jira.duraspace.org/browse/VIVO-932
