### PR TITLE
removed extra } from title attributes to reflect fixes in vitro template...

### DIFF
--- a/productMods/templates/freemarker/body/partials/shortview/view-browse-people.ftl
+++ b/productMods/templates/freemarker/body/partials/shortview/view-browse-people.ftl
@@ -9,11 +9,11 @@
 <#if (individual.thumbUrl)??>
     <img src="${individual.thumbUrl}" width="90" alt="${individual.name}" />
     <h1 class="thumb">
-        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}">${individual.name}</a>
     </h1>
 <#else>
     <h1>
-        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="${i18n().view_profile_page_for} ${individual.name}">${individual.name}</a>
     </h1>
 </#if>
 

--- a/utilities/acceptance-tests/suites/ShortViews/view-browse-faculty.ftl
+++ b/utilities/acceptance-tests/suites/ShortViews/view-browse-faculty.ftl
@@ -7,11 +7,11 @@
 <#if (individual.thumbUrl)??>
     <img src="${individual.thumbUrl}" width="90" alt="${individual.name}" />
     <h1 class="thumb">
-        <a href="${individual.profileUrl}" title="View the profile page for ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="View the profile page for ${individual.name}">${individual.name}</a>
     </h1>
 <#else>
     <h1>
-        <a href="${individual.profileUrl}" title="View the profile page for ${individual.name}}">${individual.name}</a>
+        <a href="${individual.profileUrl}" title="View the profile page for ${individual.name}">${individual.name}</a>
     </h1>
 </#if>
 


### PR DESCRIPTION
Simple syntax fix for title attribute on group pages. The string had an additional } appended to the end. This is related to the Vitro pull request: https://github.com/vivo-project/Vitro/pull/11