### PR TITLE
Revert "Start ABox recompute after searchindexer"

### DIFF
--- a/productMods/WEB-INF/resources/startup_listeners.txt
+++ b/productMods/WEB-INF/resources/startup_listeners.txt
@@ -35,6 +35,9 @@ edu.cornell.mannlib.vitro.webapp.servlet.setup.FileGraphSetup
 edu.cornell.mannlib.vitro.webapp.servlet.setup.UpdateKnowledgeBase
 edu.cornell.mannlib.vitro.webapp.migration.Release18Migrator
 
+edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl$ReasonersSetup
+edu.cornell.mannlib.vitro.webapp.servlet.setup.SimpleReasonerSetup
+
 # Must run after JenaDataSourceSetup
 edu.cornell.mannlib.vitro.webapp.servlet.setup.ThemeInfoSetup
 
@@ -62,10 +65,6 @@ edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup
 # The search indexer uses a "public" permission, so the PropertyRestrictionPolicyHelper 
 #   and the PermissionRegistry must already be set up.
 edu.cornell.mannlib.vitro.webapp.searchindex.SearchIndexerSetup
-
-# Must run after the search indexer setup
-edu.cornell.mannlib.vitro.webapp.application.ApplicationImpl$ReasonersSetup
-edu.cornell.mannlib.vitro.webapp.servlet.setup.SimpleReasonerSetup
 
 edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerSetup
 edu.cornell.mannlib.vitro.webapp.freemarker.config.FreemarkerConfiguration$Setup


### PR DESCRIPTION
Reverts vivo-project/VIVO#16 - while it might be preferable to start the search indexer before the reasoners, it is not clear that the dozen or so other initializers would not be affected by this change.