### PR TITLE
VIVO-669: remove ARQ functions `substring` and `now`

### DIFF
--- a/productMods/config/listViewConfig-authorInAuthorship.xml
+++ b/productMods/config/listViewConfig-authorInAuthorship.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt; 
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;

--- a/productMods/config/listViewConfig-awardOrHonor.xml
+++ b/productMods/config/listViewConfig-awardOrHonor.xml
@@ -6,7 +6,6 @@
 <list-view-config>
     <query-select>    
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo:  &lt;http://purl.org/ontology/bibo/&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX owl:   &lt;http://www.w3.org/2002/07/owl#&gt;

--- a/productMods/config/listViewConfig-awardOrHonorGiven.xml
+++ b/productMods/config/listViewConfig-awardOrHonorGiven.xml
@@ -6,7 +6,6 @@
 <list-view-config>
     <query-select>    
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo:  &lt;http://purl.org/ontology/bibo/&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX owl:   &lt;http://www.w3.org/2002/07/owl#&gt;

--- a/productMods/config/listViewConfig-degreeEarned.xml
+++ b/productMods/config/listViewConfig-degreeEarned.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;   
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         
         SELECT DISTINCT ?awardedDegree

--- a/productMods/config/listViewConfig-editorship.xml
+++ b/productMods/config/listViewConfig-editorship.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt; 
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;

--- a/productMods/config/listViewConfig-educationalTraining.xml
+++ b/productMods/config/listViewConfig-educationalTraining.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;   
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         

--- a/productMods/config/listViewConfig-hasClinicalActivity.xml
+++ b/productMods/config/listViewConfig-hasClinicalActivity.xml
@@ -5,7 +5,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;

--- a/productMods/config/listViewConfig-hasRole.xml
+++ b/productMods/config/listViewConfig-hasRole.xml
@@ -5,7 +5,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;

--- a/productMods/config/listViewConfig-informationResourceInAuthorship.xml
+++ b/productMods/config/listViewConfig-informationResourceInAuthorship.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;

--- a/productMods/config/listViewConfig-informationResourceInEditorship.xml
+++ b/productMods/config/listViewConfig-informationResourceInEditorship.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX fn:   &lt;http://www.w3.org/2005/xpath-functions#&gt;

--- a/productMods/config/listViewConfig-orcidId.xml
+++ b/productMods/config/listViewConfig-orcidId.xml
@@ -7,7 +7,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;  
         SELECT ?value
         WHERE {
                 ?subject ?property ?value 

--- a/productMods/config/listViewConfig-organizationForPosition.xml
+++ b/productMods/config/listViewConfig-organizationForPosition.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX fn:   &lt;http://www.w3.org/2005/xpath-functions#&gt;
@@ -41,7 +40,7 @@
             }
             # Get current positions only: end date is either null or not in the past
               FILTER ( !bound(?dateTimeEnd) ||                        
-                       afn:substring(str(?dateTimeEnd), 0, 4) &gt;= afn:substring(str(afn:now()), 0, 4) )
+                       substr(str(?dateTimeEnd), 1, 4) &gt;= substr(str(now()), 1, 4) )
               <critical-data-required>
               FILTER ( bound(?person) )
               </critical-data-required>

--- a/productMods/config/listViewConfig-organizationForTraining.xml
+++ b/productMods/config/listViewConfig-organizationForTraining.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;   
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         

--- a/productMods/config/listViewConfig-personInPosition.xml
+++ b/productMods/config/listViewConfig-personInPosition.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX obo:   &lt;http://purl.obolibrary.org/obo/&gt;
         

--- a/productMods/config/listViewConfig-publicationVenueFor.xml
+++ b/productMods/config/listViewConfig-publicationVenueFor.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt; 
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;

--- a/productMods/config/listViewConfig-publisherOf.xml
+++ b/productMods/config/listViewConfig-publisherOf.xml
@@ -7,7 +7,6 @@
     <query-select>    
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt; 
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;

--- a/productMods/config/listViewConfig-researchActivities.xml
+++ b/productMods/config/listViewConfig-researchActivities.xml
@@ -5,7 +5,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;

--- a/productMods/config/listViewConfig-researchAreaOf.xml
+++ b/productMods/config/listViewConfig-researchAreaOf.xml
@@ -7,7 +7,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; 
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt; 

--- a/productMods/config/listViewConfig-roleContributesTo.xml
+++ b/productMods/config/listViewConfig-roleContributesTo.xml
@@ -8,7 +8,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;

--- a/productMods/config/listViewConfig-roleRealizedIn.xml
+++ b/productMods/config/listViewConfig-roleRealizedIn.xml
@@ -5,7 +5,6 @@
 
 <list-view-config>
     <query-select>    
-        PREFIX afn:   &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;

--- a/rdf/display/everytime/vivoConceptDataGetters.n3
+++ b/rdf/display/everytime/vivoConceptDataGetters.n3
@@ -6,7 +6,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix core: <http://vivoweb.org/ontology/core#> .
 @prefix vivoweb: <http://vivoweb.org/ontology#> .
-@prefix afn:  <http://jena.hpl.hp.com/ARQ/function#> .
 
  
 #### n3 for research areas ####
@@ -25,7 +24,6 @@ display:getDepartmentDataGetter
         """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
-        PREFIX afn:  <http://jena.hpl.hp.com/ARQ/function#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         SELECT DISTINCT (str(?departmentLabel) AS ?deptLabel) ?dept
         WHERE {
@@ -41,7 +39,7 @@ display:getDepartmentDataGetter
                      }
             }
             FILTER ( !bound(?endDate) ||                        
-                      afn:substring(str(?endDate), 0, 4) >= afn:substring(str(afn:now()), 0, 4) )
+                      substr(str(?endDate), 1, 4) >= substr(str(now()), 1, 4) )
         }
         ORDER BY ?deptLabel
         """ .

--- a/rdf/display/everytime/vivoOrganizationDataGetters.n3
+++ b/rdf/display/everytime/vivoOrganizationDataGetters.n3
@@ -6,7 +6,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix core: <http://vivoweb.org/ontology/core#> .
 @prefix vivoweb: <http://vivoweb.org/ontology#> .
-@prefix afn:  <http://jena.hpl.hp.com/ARQ/function#> .
 
  
 #### n3 for research areas ####
@@ -31,7 +30,6 @@ display:getResearchAreaDataGetter
         """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
-        PREFIX afn:  <http://jena.hpl.hp.com/ARQ/function#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         SELECT DISTINCT (str(?researchAreaLabel) AS ?raLabel) ?ra
         WHERE {
@@ -47,7 +45,7 @@ display:getResearchAreaDataGetter
                      }
             }
             FILTER ( !bound(?endDate) ||                        
-                      afn:substring(str(?endDate), 0, 4) >= afn:substring(str(afn:now()), 0, 4) )
+                      substr(str(?endDate), 1, 4) >= substr(str(now()), 1, 4) )
         }
         ORDER BY ?raLabel
         """ .
@@ -144,7 +142,6 @@ display:getGrantsDataGetter
         """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
-        PREFIX afn:   <http://jena.hpl.hp.com/ARQ/function#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         SELECT DISTINCT ?grant
         WHERE {
@@ -159,7 +156,7 @@ display:getGrantsDataGetter
             ?grant vivo:dateTimeInterval ?dti .
             ?dti vivo:end ?end.
             ?end vivo:dateTime ?dt
-            FILTER (?dt > afn:now())
+            FILTER (?dt > now())
         }
         LIMIT 1
         """ .
@@ -179,7 +176,6 @@ display:getGrantsDataGetter
         """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
-        PREFIX afn:   <http://jena.hpl.hp.com/ARQ/function#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
         SELECT DISTINCT (str (?gLabel) AS ?grantLabel) ?dt (str(?departmentLabel) AS ?deptLabel) ?grant
         WHERE {
@@ -196,7 +192,7 @@ display:getGrantsDataGetter
              ?grant vivo:dateTimeInterval ?dti .
              ?dti vivo:end ?end.
              ?end vivo:dateTime ?dt
-             FILTER (?dt > afn:now())
+             FILTER (?dt > now())
         }
         ORDER BY ?gLabel
         """ ;

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/OrganizationToGrantsForSubOrganizationsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/OrganizationToGrantsForSubOrganizationsModelConstructor.java
@@ -68,7 +68,7 @@ public class OrganizationToGrantsForSubOrganizationsModelConstructor implements 
 		+ "     ?Grant rdf:type core:Grant . "
 		+ "     ?Grant rdfs:label ?grantLabel . "
 		+ "      "
-		+ "     LET(?now := afn:now()) "
+		+ "     LET(?now := now()) "
 		+ " } ";
 
 		String justDateTimeOnGrantsQuery = ""
@@ -103,7 +103,7 @@ public class OrganizationToGrantsForSubOrganizationsModelConstructor implements 
 //			+ "             ?endDateForGrant core:dateTime ?endDateTimeValueForGrant   "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		String justDateTimeOnRolesQuery = ""
@@ -138,7 +138,7 @@ public class OrganizationToGrantsForSubOrganizationsModelConstructor implements 
 //			+ "             ?endDate core:dateTime ?endDateTimeValue .           "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		differentPerspectiveQueries.add(justGrantsQuery);

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/OrganizationToPublicationsForSubOrganizationsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/OrganizationToPublicationsForSubOrganizationsModelConstructor.java
@@ -75,7 +75,7 @@ public class OrganizationToPublicationsForSubOrganizationsModelConstructor imple
 		+ "     		?journal rdfs:label ?journalLabel .  "
 		+ "         }  "
 		+ "          "
-		+ "         LET(?now := afn:now()) "
+		+ "         LET(?now := now()) "
 		+ " } ";
 
 	}

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PeopleToGrantsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PeopleToGrantsModelConstructor.java
@@ -57,7 +57,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
 			+ "     ?Grant rdf:type core:Grant . "
 			+ "     ?Grant rdfs:label ?grantLabel . "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 
 		String justDateTimeOnGrantsQuery = ""
@@ -83,7 +83,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
 //			+ "             ?endDateForGrant core:dateTime ?endDateTimeValueForGrant   "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		String justDateTimeOnRolesQuery = ""
@@ -109,7 +109,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
 //			+ "             ?endDate core:dateTime ?endDateTimeValue .           "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		differentPerspectiveQueries.add(justGrantsQuery);

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PeopleToPublicationsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PeopleToPublicationsModelConstructor.java
@@ -65,7 +65,7 @@ public class PeopleToPublicationsModelConstructor implements ModelConstructor {
 		+ "     		?journal rdfs:label ?journalLabel .  "
 		+ "         }  "
 		+ "          "
-		+ "         LET(?now := afn:now()) "
+		+ "         LET(?now := now()) "
 		+ " } ";
 	}
 	

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PersonToGrantsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PersonToGrantsModelConstructor.java
@@ -60,7 +60,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
     		+ "     ?Grant rdf:type core:Grant . "
 			+ "     ?Grant rdfs:label ?grantLabel . "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 
 		String justDateTimeOnGrantsQuery = ""
@@ -86,7 +86,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
 //			+ "             ?endDateForGrant core:dateTime ?endDateTimeValueForGrant   "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		String justDateTimeOnRolesQuery = ""
@@ -112,7 +112,7 @@ private Set<String> constructPersonGrantsQueryTemplate(String constructProperty,
 //			+ "             ?endDate core:dateTime ?endDateTimeValue .           "
 //			+ "         }     "
 			+ "      "
-			+ "     LET(?now := afn:now()) "
+			+ "     LET(?now := now()) "
 			+ " } ";
 		
 		differentPerspectiveQueries.add(justGrantsQuery);

--- a/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PersonToPublicationsModelConstructor.java
+++ b/src/edu/cornell/mannlib/vitro/webapp/visualization/modelconstructor/PersonToPublicationsModelConstructor.java
@@ -67,7 +67,7 @@ public class PersonToPublicationsModelConstructor implements ModelConstructor {
 		+ "     		?journal rdfs:label ?journalLabel .  "
 		+ "         }  "
 		+ "          "
-		+ "         LET(?now := afn:now()) "
+		+ "         LET(?now := now()) "
 		+ " } ";
 	}
 	


### PR DESCRIPTION
This partially addresses [VIVO-669](https://jira.duraspace.org/browse/VIVO-669)

Still need to find replacements for afn:localname and afn:namespace. Since they do not have analogs in the SPARQL 1.1 spec, it will likely require something a bit more complicated.

Also, I removed the afn prefix declaration from a number of listViewConfigs that did not need it (less temptation to use it in the future).