### PR TITLE
Remove reference to prototype vivosearch.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ VIVO is an open source semantic web tool for research discovery -- finding peopl
 
 VIVO supports editing, searching, browsing and visualizing research activity in order to discover people, programs, 
 facilities, funding, scholarly works and events. VIVO's search returns results faceted by type for rapid retrieval of 
-desired information across disciplines at one institution or, through a prototype at vivosearch.org, across multiple 
-distributed institutions. 
+desired information across disciplines.
 
 ## Resources
 


### PR DESCRIPTION
Updated the README.md file to remove reference to vivosearch.org.  In general, VIVO materials should not refer to future work.  Specifically, vivosearch.org is not active, and there are no plans to activate it.