### PR TITLE
Fix/capability map label

### DIFF
--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -68,7 +68,7 @@ var Person = function(info) {
     this.setInfo(info);
 }
 Person.prototype.fullname = function() {
-    return this.info["md_Z"] + " " + this.info["md_A"] + " " + this.info["md_B"];
+    return this.info["md_A"] + " " + this.info["md_B"] + ", " + this.info["md_Z"];
 }
 Person.prototype.queryText = function(capabilities) {
     return ("\"" + this.info["md_A"] + "+" + this.info["md_B"] + "\"+[" + capabilities.map(function(a) { return decodeURIComponent(a.term); }).join("+") + "]").replace(/<\/?strong>/g, "");

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -62,7 +62,7 @@ ${stylesheets.add(
             </p>
             <h3>Getting Started</h3>
             <p>
-                Enter a research area into the search field above and press ‘Search’.
+                Enter a research area into the search field above and press 'Search'.
                 The resulting diagram displays the search term, rendered in orange,
                 connected to the blue group of researchers that are active in that area.
                 Enter another search term to see how researchers from both searches relate.
@@ -76,7 +76,7 @@ ${stylesheets.add(
             <p>
                 By clicking on any node in the visualisation,
                 additional information can be viewed in the
-                ‘Info’ tab on the right-hand side.
+                'Info' tab on the right-hand side.
                 For groups of people, the participants in the group
                 and their information can be viewed,
                 and individual researchers can be removed from the graph.


### PR DESCRIPTION
Capability map labels for researchers with titles stored in VIVO were rendering as:

`MD Jane Smith`

rather than

`Jane Smith, MD`. 

This fixes that. 

I also changed the single quotes on the capability map overview to plain text.
 