### PR TITLE
Support vCard editors in list views

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
@@ -10,75 +10,101 @@
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        PREFIX obo: &lt;http://purl.obolibrary.org/obo/&gt;
 
-        SELECT DISTINCT ?subclass
+        SELECT DISTINCT
             ?authorship
             ?infoResource ?infoResourceName
-            ?dateTime
-            ?journal
-            ?volume
-            ?startPage
-            ?endPage
-            ?doi
-            ?pmid
-            ?isbn10
-            ?isbn13
-            ?publisher
-            ?locale
-            ?appearsIn
-            ?partOf
-            ?editor
-            ?hideThis
+            (sample(?irsubclass) as ?subclass)
+            (sample(?irdateTime) as ?dataTime)
+            (sample(?irjournal) as ?journal)
+            (sample(?irvolume) as ?volume)
+            (sample(?irstartPage) as ?startPage)
+            (sample(?irendPage) as ?endPage)
+            (sample(?irdoi) as ?doi)
+            (sample(?irpmid) as ?pmid)
+            (sample(?irisbn10) as ?isbn10)
+            (sample(?irisbn13) as ?isbn13)
+            (sample(?irpublisher) as ?publisher)
+            (sample(?irappearsIn) as ?appearsIn)
+            (sample(?irpartOf) as ?partOf)
+            (sample(?irlocale) as ?locale)
+            (sample(?irhideThis) as ?hideThis)
+            (group_concat(DISTINCT ?editor; separator='; ') as ?editors)
+            (group_concat(DISTINCT ?editorName; separator = '; ') as ?editorNames)
+            (group_concat(DISTINCT ?editorsubclass; separator='; ') as ?editorsubclasses)
         WHERE
-        {
+        { {
             ?subject ?property ?authorship .
             ?authorship a core:Authorship .
             ?authorship core:relates ?infoResource .
-            ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+            ?infoResource a obo:IAO_0000030 .
             ?infoResource rdfs:label ?infoResourceName .
-            OPTIONAL { ?infoResource vitro:mostSpecificType ?subclass }
-            OPTIONAL { ?infoResource bibo:volume ?volume }
-            OPTIONAL { ?infoResource bibo:pageStart ?startPage }
-            OPTIONAL { ?infoResource bibo:pageEnd ?endPage }
-            OPTIONAL { ?infoResource bibo:doi ?doi }
-            OPTIONAL { ?infoResource bibo:pmid ?doi }
-            OPTIONAL { ?infoResource bibo:isbn10 ?isbn10 }
-            OPTIONAL { ?infoResource bibo:isbn13 ?isbn13 }
-            OPTIONAL { ?infoResource core:placeOfPublication ?locale }
+            OPTIONAL { ?infoResource vitro:mostSpecificType ?irsubclass }
+            OPTIONAL { ?infoResource bibo:volume ?irvolume }
+            OPTIONAL { ?infoResource bibo:pageStart ?irstartPage }
+            OPTIONAL { ?infoResource bibo:pageEnd ?irendPage }
+            OPTIONAL { ?infoResource bibo:doi ?irdoi }
+            OPTIONAL { ?infoResource bibo:pmid ?irpmid }
+            OPTIONAL { ?infoResource bibo:isbn10 ?irisbn10 }
+            OPTIONAL { ?infoResource bibo:isbn13 ?irisbn13 }
+            OPTIONAL { ?infoResource core:placeOfPublication ?irlocale }
             OPTIONAL
             {
                 ?infoResource bibo:reproducedIn ?appearsInObj .
-                ?appearsInObj rdfs:label ?appearsIn .
+                ?appearsInObj rdfs:label ?irappearsIn .
             }
             OPTIONAL
             {
                 ?infoResource core:publisher ?publisherObj .
-                ?publisherObj rdfs:label ?publisher .
+                ?publisherObj rdfs:label ?irpublisher .
             }
             OPTIONAL
             {
-                ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
-                ?partOfObj rdfs:label ?partOf .
+                ?infoResource obo:BFO_0000050 ?partOfObj .
+                ?partOfObj rdfs:label ?irpartOf .
             }
             OPTIONAL
             {
                 ?infoResource core:hasPublicationVenue ?publishedIn .
-                ?publishedIn  rdfs:label ?journal .
+                ?publishedIn  rdfs:label ?irjournal .
             }
             OPTIONAL
             {
                 ?infoResource core:dateTimeValue ?dateTimeValue .
-                ?dateTimeValue core:dateTime ?dateTime .
+                ?dateTimeValue core:dateTime ?irdateTime .
             }
-            OPTIONAL
-            {
-                ?infoResource core:relatedBy ?editorship .
+            OPTIONAL {
+              { ?infoResource ?property ?editorship .
                 ?editorship a core:Editorship .
-                ?editorship core:relates ?editorObj .
-                ?editorObj rdfs:label ?editor .
+                ?editorship core:relates ?editor .
+                ?editor a vcard:Kind .
+                ?editor vcard:hasName ?vName .
+                ?vName vcard:familyName ?lastName .
+                OPTIONAL { ?vName vcard:givenName ?firstName . }
+                OPTIONAL { ?vName core:middleName ?middleName . }
+                bind ( COALESCE(?firstName, "") As ?firstName1) .
+                bind ( COALESCE(?middleName, "") As ?middleName1) .
+                bind ( COALESCE(?lastName, "") As ?lastName1) .
+                bind (concat(str(?lastName1),IF(bound(?firstName), str(", " + ?firstName1),''),IF(bound(?middleName), str(" " + ?middleName1), '')) as ?editorName) .
+              }
+                UNION {
+                  ?infoResource ?property ?editorship .
+                  ?editorship a core:Editorship .
+                  ?editorship core:relates ?editor .
+                  ?editor a foaf:Agent .
+                  ?editor rdfs:label ?editorName .
+                  OPTIONAL {
+                    ?editor vitro:mostSpecificType ?editorsubclass .
+                    ?editorsubclass rdfs:subClassOf foaf:Agent .
+                  }
+                }
             }
-            OPTIONAL { ?authorship core:hideFromDisplay ?hideThis }
-        } ORDER BY ?subclass  DESC(?dateTime) ?infoResourceName
+            OPTIONAL { ?authorship core:hideFromDisplay ?irhideThis }
+          }
+        } GROUP BY ?authorship ?infoResource ?infoResourceName
+        ORDER BY ?subclass  DESC(?dateTime) ?infoResourceName
     </query-select>
 
     <query-construct>
@@ -87,13 +113,16 @@
         PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
         PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        PREFIX obo: &lt;http://purl.obolibrary.org/obo/&gt;
+
         CONSTRUCT
         {
             ?subject ?property ?authorship .
             ?authorship a core:Authorship .
             ?authorship core:hideFromDisplay ?hideThis .
             ?authorship core:relates ?infoResource .
-            ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+            ?infoResource a obo:IAO_0000030 .
             ?infoResource vitro:mostSpecificType ?subclass .
             ?infoResource rdfs:label ?infoResourceName .
             ?infoResource bibo:volume ?volume .
@@ -116,14 +145,9 @@
             ?infoResource core:dateTimeValue ?dateTimeValue .
             ?dateTimeValue core:dateTime ?dateTime .
 
-            ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
+            ?infoResource obo:BFO_0000050 ?partOfObj .
             ?partOfObj rdfs:label ?partOf .
 
-            ?infoResource core:relatedBy ?editorship .
-            ?editorship a core:Editorship .
-            ?editorship core:relates ?editorObj .
-            ?editorObj a foaf:Person .
-            ?editorObj rdfs:label ?editor .
         }
         WHERE
         {
@@ -142,14 +166,14 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
             }
             UNION
             {
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource vitro:mostSpecificType ?subclass .
             }
             UNION
@@ -157,7 +181,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource rdfs:label ?infoResourceName
             }
             UNION
@@ -165,7 +189,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:volume ?volume .
             }
             UNION
@@ -173,7 +197,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:pageStart ?startPage .
             }
             UNION
@@ -181,7 +205,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:pageEnd ?endPage .
             }
             UNION
@@ -189,7 +213,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:doi ?doi .
             }
             UNION
@@ -197,7 +221,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:pmid ?pmid .
             }
             UNION
@@ -205,7 +229,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:isbn10 ?isbn10 .
             }
             UNION
@@ -213,7 +237,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:isbn13 ?isbn13 .
             }
             UNION
@@ -221,7 +245,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource core:placeOfPublication ?locale .
             }
             UNION
@@ -229,7 +253,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource bibo:reproducedIn ?appearsInObj .
                 ?appearsInObj rdfs:label ?appearsIn .
             }
@@ -238,7 +262,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource core:publisher ?publisherObj .
                 ?publisherObj rdfs:label ?publisher .
             }
@@ -247,7 +271,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource core:dateTimeValue ?dateTimeValue .
                 ?dateTimeValue core:dateTime ?dateTime .
             }
@@ -256,7 +280,7 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource core:hasPublicationVenue ?publishedIn .
                 ?publishedIn  rdfs:label ?journal .
             }
@@ -265,34 +289,102 @@
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
-                ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
+                ?infoResource a obo:IAO_0000030 .
+                ?infoResource obo:BFO_0000050 ?partOfObj .
                 ?partOfObj rdfs:label ?partOf .
             }
-            UNION
+
+        }
+    </query-construct>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
+        PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        PREFIX obo: &lt;http://purl.obolibrary.org/obo/&gt;
+
+        CONSTRUCT
+        {
+            ?subject ?property ?authorship .
+            ?authorship a core:Authorship .
+            ?authorship core:relates ?infoResource .
+            ?infoResource a obo:IAO_0000030 .
+
+            ?infoResource core:relatedBy ?editorship .
+            ?editorship a core:Editorship .
+            ?editorship core:relates ?editorObj .
+            ?editorObj a foaf:Agent .
+            ?editorObj rdfs:label ?editorName .
+            ?editorObj vitro:mostSpecificType ?editorAgentMST .
+            ?editorAgentMST rdfs:subClassOf foaf:Agent .
+
+            ?editorship core:relates ?editorVCard .
+            ?editorVCard a vcard:Kind .
+            ?editorVCard vitro:mostSpecificType ?editorVCardMST .
+            ?editorVCardMST rdfs:subClassOf vcard:Kind .
+
+            ?editorVCard vcard:hasName ?vName .
+            ?vName ?vNameProperty ?vNameValue .
+        }
+        WHERE
+        {
             {
                 ?subject ?property ?authorship .
-                ?authorship a core:Authorship .
-                ?authorship core:relates ?infoResource .
-                ?infoResource a bibo:Book .
-                ?infoResource core:relatedBy ?editorship .
-                ?editorship a core:Editorship .
-                ?editorship core:relates ?editorObj .
-                ?editorObj a foaf:Person .
-                ?editorObj rdfs:label ?editor .
+                ?authorship a core:Authorship
             }
             UNION
             {
                 ?subject ?property ?authorship .
                 ?authorship a core:Authorship .
                 ?authorship core:relates ?infoResource .
-                ?infoResource a bibo:BookSection .
+                ?infoResource a obo:IAO_0000030 .
                 ?infoResource core:relatedBy ?editorship .
                 ?editorship a core:Editorship .
                 ?editorship core:relates ?editorObj .
-                ?editorObj a foaf:Person .
-                ?editorObj rdfs:label ?editor .
+                ?editorObj a foaf:Agent .
+                ?editorObj vitro:mostSpecificType ?editorAgentMST .
             }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a obo:IAO_0000030 .
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorObj .
+                ?editorObj a foaf:Agent .
+                ?editorObj rdfs:label ?editorName
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a obo:IAO_0000030 .
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorVCard .
+                ?editorVCard a vcard:Kind .
+                ?editorVCard vitro:mostSpecificType ?editorVCardMST .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a obo:IAO_0000030 .
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorVCard .
+                ?editorVCard a vcard:Kind .
+                ?editorVCard vcard:hasName ?vName .
+                ?vName ?vNameProperty ?vNameValue .
+            }
+
         }
     </query-construct>
 

--- a/webapp/src/main/webapp/config/listViewConfig-informationResourceInEditorship.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-informationResourceInEditorship.xml
@@ -4,74 +4,114 @@
 <!-- See guidelines at https://wiki.duraspace.org/x/eYXVAw -->
 
 <list-view-config>
-    <query-select>    
-        PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
+    <query-select>
+        PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
         PREFIX fn:   &lt;http://www.w3.org/2005/xpath-functions#&gt;
-        
-        SELECT DISTINCT <collated> ?subclass </collated>
-                        ?editorship
-                        ?person ?personName 
+
+        SELECT DISTINCT ?subclass
+            ?editorship
+            ?editor ?editorName
         WHERE {
-                ?subject ?property ?editorship .
-                OPTIONAL { ?editorship core:rank ?rank } 
-                OPTIONAL { ?editorship core:relates ?person .
-                           ?person a foaf:Person .                      
-                           ?person rdfs:label ?personName 
+            ?subject ?property ?editorship .
+            OPTIONAL { ?editorship core:rank ?rank }
+            OPTIONAL { ?editorship core:relates ?editor .
+                ?editor a foaf:Agent .
+                ?editor rdfs:label ?editorName .
+
+                OPTIONAL { ?editorship core:relates ?editor .
+                    ?editor a foaf:Agent .
+                    ?editor vitro:mostSpecificType ?subclass .
+                    ?subclass rdfs:subClassOf foaf:Agent .
                 }
-                <collated> 
-                OPTIONAL { ?editorship core:relates ?person .
-                           ?person a foaf:Person .
-                           ?person vitro:mostSpecificType ?subclass .
-                           ?subclass rdfs:subClassOf foaf:Person 
-                } 
-                </collated>
-            <critical-data-required>
-            FILTER ( bound(?person) )
-            </critical-data-required>
-        } ORDER BY <collated> ?subclass </collated> ?rank (fn:lower-case(?personName))   
+            }
+            OPTIONAL { ?editorship core:relates ?editor .
+                ?editor a vcard:Kind .
+                ?editor vcard:hasName ?vName .
+                ?vName vcard:familyName ?lastName .
+                OPTIONAL { ?vName vcard:givenName ?firstName . }
+                OPTIONAL { ?vName core:middleName ?middleName . }
+                bind ( COALESCE(?firstName, "") As ?firstName1) .
+                bind ( COALESCE(?middleName, "") As ?middleName1) .
+                bind ( COALESCE(?lastName, "") As ?lastName1) .
+                bind (concat(str(?lastName1 + ", "),str(?firstName1 + " "),str(?middleName1)) as ?editorName) .
+
+                OPTIONAL { ?editorship core:relates ?editor .
+                    ?editor a vcard:Kind .
+                    ?editor vitro:mostSpecificType ?subclass .
+                    ?subclass rdfs:subClassOf vcard:Kind .
+                }
+            }
+        <critical-data-required>
+            FILTER ( bound(?editor) )
+        </critical-data-required>
+        } ORDER BY <collated> ?subclass </collated> ?rank (fn:lower-case(?editorName))
     </query-select>
 
     <query-construct>
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
-        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; 
-        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt; 
-        PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt; 
-        CONSTRUCT { 
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX foaf:  &lt;http://xmlns.com/foaf/0.1/&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        CONSTRUCT {
             ?subject ?property ?editorship .
+
             ?editorship a core:Editorship .
             ?editorship core:rank ?rank .
-            ?editorship core:relates ?person .
-            ?person a foaf:Person .
-            ?person rdfs:label ?personName .
-            ?person vitro:mostSpecificType ?subclass .
-            ?subclass rdfs:subClassOf foaf:Person          
+
+            ?editorship core:relates ?editorAgent .
+            ?editorAgent a foaf:Agent .
+            ?editorAgent rdfs:label ?editorName .
+            ?editorAgent vitro:mostSpecificType ?editorAgentMST .
+            ?editorAgentMST rdfs:subClassOf foaf:Agent .
+
+            ?editorship core:relates ?editorVCard .
+            ?editorVCard a vcard:Kind .
+            ?editorVCard vitro:mostSpecificType ?editorVCardMST .
+            ?editorVCardMST rdfs:subClassOf vcard:Kind .
+
+            ?editorVCard vcard:hasName ?vName .
+            ?vName ?vNameProperty ?vNameValue .
         } WHERE {
             {
                 ?subject ?property ?editorship .
-                ?editorship a core:Editorship 
+                ?editorship a core:Editorship
             } UNION {
                 ?subject ?property ?editorship .
                 ?editorship a core:Editorship .
-                ?editorship core:rank ?rank 
+                ?editorship core:rank ?rank .
             } UNION {
                 ?subject ?property ?editorship .
                 ?editorship a core:Editorship .
-                ?editorship core:relates ?person .
-                ?person a foaf:Person .                      
-                ?person rdfs:label ?personName  
+                ?editorship core:relates ?editorAgent .
+                ?editorAgent a foaf:Agent .
+                ?editorAgent vitro:mostSpecificType ?editorAgentMST .
             } UNION {
                 ?subject ?property ?editorship .
                 ?editorship a core:Editorship .
-                ?editorship core:relates ?person .
-                ?person a foaf:Person .
-                ?person rdfs:label ?personName . 
-                ?person vitro:mostSpecificType ?subclass .
+                ?editorship core:relates ?editorAgent .
+                ?editorAgent a foaf:Agent .
+                ?editorAgent rdfs:label ?editorName
+            } UNION {
+                ?subject ?property ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorVCard .
+                ?editorVCard a vcard:Kind .
+                ?editorVCard vitro:mostSpecificType ?editorVCardMST .
+            } UNION {
+                ?subject ?property ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorVCard .
+                ?editorVCard a vcard:Kind .
+                ?editorVCard vcard:hasName ?vName .
+                ?vName ?vNameProperty ?vNameValue .
             }
-        } 
+        }
     </query-construct>
-    
+
     <template>propStatement-informationResourceInEditorship.ftl</template>
 </list-view-config>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
@@ -1,11 +1,11 @@
 <#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
 
 <#-- Custom object property statement view for faux property "selected publications". See the PropertyConfig.n3 file for details.
-    
+
      This template must be self-contained and not rely on other variables set for the individual page, because it
-     is also used to generate the property statement during a deletion.  
+     is also used to generate the property statement during a deletion.
  -->
- 
+
 <#import "lib-sequence.ftl" as s>
 <#import "lib-datetime.ftl" as dt>
 
@@ -49,8 +49,8 @@
                 <#elseif statement.partOf??>
                     <em>${statement.partOf!}</em>.
                 </#if>
-                <#if statement.editor??>
-                    ${i18n().editor_abbreviated}&nbsp;${statement.editor!}.&nbsp;
+                <#if statement.editors??>
+                  ${i18n().editor_abbreviated}&nbsp;${statement.editorNames!}.&nbsp;
                 </#if>
                 <#if statement.locale?? && statement.publisher??>
                     ${statement.locale!}:&nbsp;${statement.publisher!}.
@@ -68,8 +68,8 @@
                 <#if statement.volume?? && (statement.volume!?length > 0 )>
                     ${i18n().volume_abbreviated}&nbsp;${statement.volume!}.&nbsp;
                 </#if>
-                <#if statement.editor??>
-                    ${i18n().editor_abbreviated}&nbsp;${statement.editor!}.&nbsp;
+                <#if statement.editors??>
+                    ${i18n().editor_abbreviated}&nbsp;${statement.editorNames!}.&nbsp;
                 </#if>
                 <#if statement.locale?? && statement.publisher??>
                     ${statement.locale!}:&nbsp;${statement.publisher!}.
@@ -87,7 +87,7 @@
                     <em>${statement.partOf!}</em>.
                 </#if>
                 <#if statement.editor??>
-                    ${i18n().editor_abbreviated} ${statement.editor!}.&nbsp;
+                    ${i18n().editor_abbreviated}&nbsp;${statement.editorNames!}.&nbsp;
                 </#if>
                 <#if statement.startPage?? && statement.endPage??>
                     ${statement.startPage!}-${statement.endPage!}.

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
@@ -86,7 +86,7 @@
                 <#elseif statement.partOf??>
                     <em>${statement.partOf!}</em>.
                 </#if>
-                <#if statement.editor??>
+                <#if statement.editors??>
                     ${i18n().editor_abbreviated}&nbsp;${statement.editorNames!}.&nbsp;
                 </#if>
                 <#if statement.startPage?? && statement.endPage??>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-informationResourceInEditorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-informationResourceInEditorship.ftl
@@ -1,9 +1,9 @@
 <#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
 
 <#-- Custom object property statement view for faux property "editors". See the PropertyConfig.n3 file for details.
-    
+
      This template must be self-contained and not rely on other variables set for the individual page, because it
-     is also used to generate the property statement during a deletion.  
+     is also used to generate the property statement during a deletion.
  -->
 
 <#import "lib-sequence.ftl" as s>
@@ -12,8 +12,16 @@
 <#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
      next statement -->
 <#macro showEditorship statement>
-    <#if statement.person??>
-        <a href="${profileUrl(statement.uri("person"))}" title="${i18n().editor_name}">${statement.personName}</a>
+    <#if statement.editor??>
+        <#if statement.subclass?? && statement.subclass?contains("vcard")>
+            <#if statement.editorName?replace(" ","")?length == statement.editorName?replace(" ","")?last_index_of(",") + 1 >
+                	${statement.editorName?replace(",","")}
+            <#else>
+                  ${statement.editorName}
+            </#if>
+        <#else>
+            <a href="${profileUrl(statement.uri("editor"))}" title="${i18n().editor_name}">${statement.editorName}</a>
+        </#if>
     <#else>
         <#-- This shouldn't happen, but we must provide for it -->
         <a href="${profileUrl(statement.uri("editorship"))}" title="${i18n().missing_editor}">${i18n().missing_editor}</a>


### PR DESCRIPTION
Per [this discussion](https://groups.google.com/d/topic/vivo-tech/EwDXvadDuL8/discussion), makes it possible to model an editor as a vCard instead of a foaf:Person and display them in the list views for publications and people.