### PR TITLE
Fix Altmetric badge display for publications with only PMID

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
@@ -41,7 +41,7 @@
             OPTIONAL { ?infoResource bibo:pageStart ?startPage }
             OPTIONAL { ?infoResource bibo:pageEnd ?endPage }
             OPTIONAL { ?infoResource bibo:doi ?doi }
-            OPTIONAL { ?infoResource bibo:pmid ?doi }
+            OPTIONAL { ?infoResource bibo:pmid ?pmid }
             OPTIONAL { ?infoResource bibo:isbn10 ?isbn10 }
             OPTIONAL { ?infoResource bibo:isbn13 ?isbn13 }
             OPTIONAL { ?infoResource core:placeOfPublication ?locale }

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
@@ -115,7 +115,7 @@
         <#if altmetricEnabled??>
             <#if statement.doi??>
                 <div data-badge-popover="right" data-badge-type="4" data-doi="${statement.doi}" data-hide-no-mentions="true" class="altmetric-embed" style="display: inline;"></div>
-            <#elseif statement.pimd??>
+            <#elseif statement.pmid??>
                 <div data-badge-popover="right" data-badge-type="4" data-pmid="${statement.pmid}" data-hide-no-mentions="true" class="altmetric-embed" style="display: inline;"></div>
             <#elseif statement.isbn10??>
                 <div data-badge-popover="right" data-badge-type="4" data-isbn="${statement.isbn10}" data-hide-no-mentions="true" class="altmetric-embed" style="display: inline;"></div>


### PR DESCRIPTION
When you have an artifact with a PMID but no DOI, the Altmetric badge isn't displayed. Technically there are two changes in one commit here, but they're both one-liners.