### PR TITLE
VIVO-1258 derive location of log files from CATALINA_BASE instead of …

### DIFF
--- a/installer/solr/src/main/webResources/WEB-INF/classes/log4j.properties
+++ b/installer/solr/src/main/webResources/WEB-INF/classes/log4j.properties
@@ -1,5 +1,5 @@
 log4j.appender.AllAppender=org.apache.log4j.RollingFileAppender 
-log4j.appender.AllAppender.File= ${catalina.home}/logs/${app-name}solr.log
+log4j.appender.AllAppender.File= ${catalina.base}/logs/${app-name}solr.log
 log4j.appender.AllAppender.MaxFileSize=10MB 
 log4j.appender.AllAppender.MaxBackupIndex=10 
 log4j.appender.AllAppender.layout=org.apache.log4j.PatternLayout 

--- a/installer/webapp/src/main/webResources/WEB-INF/classes/log4j.properties
+++ b/installer/webapp/src/main/webResources/WEB-INF/classes/log4j.properties
@@ -24,7 +24,7 @@
 # debug.log4j.properties exists will be used instead, if it exists, but is not stored in Subversion.
 
 log4j.appender.AllAppender=org.apache.log4j.RollingFileAppender
-log4j.appender.AllAppender.File= ${catalina.home}/logs/${app-name}.all.log
+log4j.appender.AllAppender.File= ${catalina.base}/logs/${app-name}.all.log
 log4j.appender.AllAppender.MaxFileSize=10MB
 log4j.appender.AllAppender.MaxBackupIndex=10
 log4j.appender.AllAppender.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Location of log files should be derived from CATALINA_BASE, instead of CATALINA_HOME. On a server with one instance of Tomcat, this will make no difference. On servers with two instances of Tomcat, it keeps the logs separate.

See: 
https://tomcat.apache.org/tomcat-7.0-doc/RUNNING.txt
https://tomcat.apache.org/tomcat-8.0-doc/RUNNING.txt
and, more conversationally:
https://dzone.com/articles/running-multiple-tomcat