### PR TITLE
shorten ORCID reg-ex to increase legibility

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/ontologies/update15to16/sparqlConstructs/additions/orcid.sparql
+++ b/webapp/src/main/webapp/WEB-INF/ontologies/update15to16/sparqlConstructs/additions/orcid.sparql
@@ -7,6 +7,6 @@ CONSTRUCT {
 } WHERE {
     ?s vivo:orcidId ?orcidString 
     FILTER(isLiteral(?orcidString))
-    FILTER (regex(str(?orcidString), "^[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9]([0-9]|X)$"))
+    FILTER (regex(str(?orcidString), "^([0-9]{4}-){3}[0-9]{3}([0-9]|X)$"))
     BIND(IRI(concat("http://orcid.org/", str(?orcidString))) AS ?orcidURI)
 }

--- a/webapp/src/main/webapp/WEB-INF/ontologies/update15to16/sparqlConstructs/deletions/orcidDel.sparql
+++ b/webapp/src/main/webapp/WEB-INF/ontologies/update15to16/sparqlConstructs/deletions/orcidDel.sparql
@@ -6,5 +6,5 @@ CONSTRUCT {
 } WHERE {
     ?s vivo:orcidId ?orcidString 
     FILTER(isLiteral(?orcidString))
-    FILTER (regex(str(?orcidString), "^[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9]([0-9]|X)$"))
+    FILTER (regex(str(?orcidString), "^([0-9]{4}-){3}[0-9]{3}([0-9]|X)$"))
 }


### PR DESCRIPTION
Hello!

Is there a specific reason your ORCID reg-ex are so long? The [`blame`](https://github.com/vivo-project/VIVO/blame/47f1408b3e9db4934c33f321689ef307b9cf4bdd/webapp/src/main/webapp/WEB-INF/ontologies/update15to16/sparqlConstructs/additions/orcid.sparql) didn't specify one, so I thought this suggested shortening might be useful. Probably, more refactoring would be possible. Let's discuss, if there was indeed no specific reason for the in-reg-ex redundancy.

Cheers :-)