### PR TITLE
Change project version from 2.0.0-SNAPSHOT to 1.10.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/home/pom.xml
+++ b/home/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-home</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-installer-home</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-installer</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>VIVO Installer</name>

--- a/installer/solr/pom.xml
+++ b/installer/solr/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-installer-solr</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-installer-vivo</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-installer</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-project</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>VIVO</name>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>org.vivoweb</groupId>
     <artifactId>vivo-webapp</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <parent>
         <groupId>org.vivoweb</groupId>
         <artifactId>vivo-project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vivo-api</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>1.10.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/VIVO-1479

# What does this pull request do?
Change project version from 2.0.0-SNAPSHOT to 1.10.0-SNAPSHOT

# How should this be tested?
This is only a Maven project version change. 
Success is if the project continues to build and deploy.

# Interested parties
@VIVO-project/vivo-committers
