### PR TITLE
[VIVO-1447] Move ontology prefixes into separate file in filegraph directory

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
@@ -5,8 +5,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:vitro="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#">
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <owl:Ontology rdf:about="http://xmlns.com/foaf/0.1/"/>
     <owl:Ontology rdf:about="http://purl.org/NET/c4dm/event.owl"/>
     <owl:Ontology rdf:about="http://vitro.mannlib.cornell.edu/ns/vitro/public"/>
@@ -29,73 +28,4 @@
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/ro.owl"/>
     <owl:Ontology rdf:about="http://www.ebi.ac.uk/efo/swo/"/>
 
-    <rdf:Description rdf:about="http://aims.fao.org/aos/geopolitical.owl">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">geo</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">Geopolitical Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obo</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">OBO Foundry</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/NET/c4dm/event.owl">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">event</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">Event Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/net/OCRe/research.owl">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ocrer</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">OCRe Research</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/net/OCRe/study_design.owl">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ocresd</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">OCRe Study Design</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/ontology/bibo/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bibo</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">Bibliographic Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/spar/c4o/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c4o</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">Citation Counting and Context Characterization Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/spar/cito/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cito</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">CiTO (Citation Typing Ontology)</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://purl.org/spar/fabio/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fabio</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">FaBiO (FRBR-Aligned Bibliographic Ontology)</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://vivoweb.org/ontology/core">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vivo</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://vivoweb.org/ontology/scientific-research">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scires</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">VIVO Scientific Research Ontology</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">skos</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">SKOS (Simple Knowledge Organization System)</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vcard</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">VCard</rdfs:label>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/">
-        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">foaf</vitro:ontologyPrefixAnnot>
-        <rdfs:label xml:lang="en-US">FOAF (Friend of a Friend)</rdfs:label>
-    </rdf:Description>
-</rdf:RDF>
+</rdf:RDF> 

--- a/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
@@ -12,7 +12,7 @@
     <owl:Ontology rdf:about="http://purl.org/ontology/bibo/"/>
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core"/>
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/"/>
-    <owl:Ontology rdf:about="http://www.w3.org/2006/vcard/ns"/>
+    <owl:Ontology rdf:about="http://www.w3.org/2006/vcard/ns"/>   
     <owl:Ontology rdf:about="http://aims.fao.org/aos/geopolitical.owl"/>
     <owl:Ontology rdf:about="http://purl.org/net/OCRe/research.owl"/>
     <owl:Ontology rdf:about="http://purl.org/net/OCRe/study_design.owl"/>
@@ -27,5 +27,5 @@
     <owl:Ontology rdf:about="http://purl.org/vocab/vann/"/>
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/ro.owl"/>
     <owl:Ontology rdf:about="http://www.ebi.ac.uk/efo/swo/"/>
-
+    
 </rdf:RDF> 

--- a/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/ontologies.owl
@@ -5,14 +5,15 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:vitro="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#">
     <owl:Ontology rdf:about="http://xmlns.com/foaf/0.1/"/>
     <owl:Ontology rdf:about="http://purl.org/NET/c4dm/event.owl"/>
     <owl:Ontology rdf:about="http://vitro.mannlib.cornell.edu/ns/vitro/public"/>
     <owl:Ontology rdf:about="http://purl.org/ontology/bibo/"/>
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core"/>
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/"/>
-    <owl:Ontology rdf:about="http://www.w3.org/2006/vcard/ns"/>   
+    <owl:Ontology rdf:about="http://www.w3.org/2006/vcard/ns"/>
     <owl:Ontology rdf:about="http://aims.fao.org/aos/geopolitical.owl"/>
     <owl:Ontology rdf:about="http://purl.org/net/OCRe/research.owl"/>
     <owl:Ontology rdf:about="http://purl.org/net/OCRe/study_design.owl"/>
@@ -27,5 +28,74 @@
     <owl:Ontology rdf:about="http://purl.org/vocab/vann/"/>
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/ro.owl"/>
     <owl:Ontology rdf:about="http://www.ebi.ac.uk/efo/swo/"/>
-    
-</rdf:RDF> 
+
+    <rdf:Description rdf:about="http://aims.fao.org/aos/geopolitical.owl">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">geo</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">Geopolitical Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obo</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">OBO Foundry</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/NET/c4dm/event.owl">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">event</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">Event Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/net/OCRe/research.owl">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ocrer</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">OCRe Research</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/net/OCRe/study_design.owl">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ocresd</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">OCRe Study Design</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/ontology/bibo/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bibo</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">Bibliographic Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/spar/c4o/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c4o</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">Citation Counting and Context Characterization Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/spar/cito/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cito</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">CiTO (Citation Typing Ontology)</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://purl.org/spar/fabio/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fabio</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">FaBiO (FRBR-Aligned Bibliographic Ontology)</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://vivoweb.org/ontology/core">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vivo</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://vivoweb.org/ontology/scientific-research">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scires</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">VIVO Scientific Research Ontology</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.w3.org/2004/02/skos/core">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">skos</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">SKOS (Simple Knowledge Organization System)</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vcard</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">VCard</rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/">
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">foaf</vitro:ontologyPrefixAnnot>
+        <rdfs:label xml:lang="en-US">FOAF (Friend of a Friend)</rdfs:label>
+    </rdf:Description>
+</rdf:RDF>

--- a/home/src/main/resources/rdf/tbox/filegraph/ontologyPrefixes.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/ontologyPrefixes.n3
@@ -32,7 +32,7 @@ bibo:
 skos:
       rdfs:label "SKOS (Simple Knowledge Organization System)"@en-US ;
       vitro:ontologyPrefixAnnot "skos" .
-      
+
 vivo:
       rdfs:label "VIVO Core Ontology"@en-US ;
       vitro:ontologyPrefixAnnot "vivo" .
@@ -40,35 +40,35 @@ vivo:
 ocrer:
       rdfs:label "OCRe Research"@en-US ;
       vitro:ontologyPrefixAnnot "ocrer" .
-      
+
 ocresd:
       rdfs:label "OCRe Study Design"@en-US ;
       vitro:ontologyPrefixAnnot "ocresd" .
-      
+
 ocresp:
       rdfs:label "OCRe Study Protocol"@en-US ;
       vitro:ontologyPrefixAnnot "ocresp" .
-      
+
 ocrest:
       rdfs:label "OCRe Statistics"@en-US ;
       vitro:ontologyPrefixAnnot "ocresst" .
-      
+
 geo:
       rdfs:label "Geopolitical Ontology"@en-US ;
       vitro:ontologyPrefixAnnot "geo" .
-      
+
 event:
       rdfs:label "Event Ontology"@en-US ;
       vitro:ontologyPrefixAnnot "event" .
 
-obo:  
+obo:
       rdfs:label "OBO Foundry"@en-US ;
       vitro:ontologyPrefixAnnot "obo" .
-              
+
 vcard:
       rdfs:label "VCard"@en-US ;
       vitro:ontologyPrefixAnnot "vcard" .
-              
+
 foaf:
       rdfs:label "FOAF (Friend of a Friend)"@en-US ;
       vitro:ontologyPrefixAnnot "foaf" .
@@ -88,19 +88,19 @@ c4o:
 cito:
       rdfs:label "CiTO (Citation Typing Ontology)"@en-US ;
       vitro:ontologyPrefixAnnot "cito" .
-    
+
 dcterms:
       rdfs:label "Dublin Core Terms"@en-US ;
-      vitro:ontologyPrefixAnnot "dcterms" .  
-    
+      vitro:ontologyPrefixAnnot "dcterms" .
+
 vann:
       rdfs:label "Vocabulary for Annotating Vocabulary Descriptions"@en-US ;
       vitro:ontologyPrefixAnnot "vann" .
-      
+
 ro:
       rdfs:label "Relations Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "ro" .    
-      
+      vitro:ontologyPrefixAnnot "ro" .
+
 swo:
       rdfs:label "Software Ontology"@en-US ;
       vitro:ontologyPrefixAnnot "swo" . 

--- a/home/src/main/resources/rdf/tbox/filegraph/ontologyPrefixes.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/ontologyPrefixes.n3
@@ -1,0 +1,106 @@
+@prefix bibo:    <http://purl.org/ontology/bibo/> .
+@prefix cito:    <http://purl.org/spar/cito/> .
+@prefix c4o:     <http://purl.org/spar/c4o/> .
+@prefix dcterms:   <http://purl.org/dc/terms/> .
+@prefix event:   <http://purl.org/NET/c4dm/event.owl> .
+@prefix fabio:   <http://purl.org/spar/fabio/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix geo:     <http://aims.fao.org/aos/geopolitical.owl> .
+@prefix obo:     <http://purl.obolibrary.org/obo/> .
+@prefix ocrer:   <http://purl.org/net/OCRe/research.owl> .
+@prefix ocresd:   <http://purl.org/net/OCRe/study_design.owl> .
+@prefix ocresp:   <http://purl.org/net/OCRe/study_protocol.owl> .
+@prefix ocrest:   <http://purl.org/net/OCRe/statistics.owl> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ro:      <http://purl.obolibrary.org/obo/ro.owl> .
+@prefix scires:  <http://vivoweb.org/ontology/scientific-research> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core> .
+@prefix swo:     <http://www.ebi.ac.uk/efo/swo/> .
+@prefix vann:    <http://purl.org/vocab/vann/> .
+@prefix vcard:   <http://www.w3.org/2006/vcard/ns> .
+@prefix vitro:   <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> .
+@prefix vitro-public:  <http://vitro.mannlib.cornell.edu/ns/vitro/public#> .
+@prefix vivo:    <http://vivoweb.org/ontology/core#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+bibo:
+      rdfs:label "Bibliographic Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "bibo" .
+
+skos:
+      rdfs:label "SKOS (Simple Knowledge Organization System)"@en-US ;
+      vitro:ontologyPrefixAnnot "skos" .
+      
+vivo:
+      rdfs:label "VIVO Core Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "vivo" .
+
+ocrer:
+      rdfs:label "OCRe Research"@en-US ;
+      vitro:ontologyPrefixAnnot "ocrer" .
+      
+ocresd:
+      rdfs:label "OCRe Study Design"@en-US ;
+      vitro:ontologyPrefixAnnot "ocresd" .
+      
+ocresp:
+      rdfs:label "OCRe Study Protocol"@en-US ;
+      vitro:ontologyPrefixAnnot "ocresp" .
+      
+ocrest:
+      rdfs:label "OCRe Statistics"@en-US ;
+      vitro:ontologyPrefixAnnot "ocresst" .
+      
+geo:
+      rdfs:label "Geopolitical Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "geo" .
+      
+event:
+      rdfs:label "Event Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "event" .
+
+obo:  
+      rdfs:label "OBO Foundry"@en-US ;
+      vitro:ontologyPrefixAnnot "obo" .
+              
+vcard:
+      rdfs:label "VCard"@en-US ;
+      vitro:ontologyPrefixAnnot "vcard" .
+              
+foaf:
+      rdfs:label "FOAF (Friend of a Friend)"@en-US ;
+      vitro:ontologyPrefixAnnot "foaf" .
+
+scires:
+      rdfs:label "VIVO Scientific Research Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "scires" .
+
+fabio:
+      rdfs:label "FaBiO (FRBR-Aligned Bibliographic Ontology)"@en-US ;
+      vitro:ontologyPrefixAnnot "fabio" .
+
+c4o:
+      rdfs:label "Citation Counting and Context Characterization Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "c4o" .
+
+cito:
+      rdfs:label "CiTO (Citation Typing Ontology)"@en-US ;
+      vitro:ontologyPrefixAnnot "cito" .
+    
+dcterms:
+      rdfs:label "Dublin Core Terms"@en-US ;
+      vitro:ontologyPrefixAnnot "dcterms" .  
+    
+vann:
+      rdfs:label "Vocabulary for Annotating Vocabulary Descriptions"@en-US ;
+      vitro:ontologyPrefixAnnot "vann" .
+      
+ro:
+      rdfs:label "Relations Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "ro" .    
+      
+swo:
+      rdfs:label "Software Ontology"@en-US ;
+      vitro:ontologyPrefixAnnot "swo" . 

--- a/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
+++ b/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
@@ -25,86 +25,6 @@
 @prefix vivo:    <http://vivoweb.org/ontology/core#> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
-bibo:
-      rdfs:label "Bibliographic Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "bibo" .
-
-skos:
-      rdfs:label "SKOS (Simple Knowledge Organization System)"@en-US ;
-      vitro:ontologyPrefixAnnot "skos" .
-      
-vivo:
-      rdfs:label "VIVO Core Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "vivo" .
-
-ocrer:
-      rdfs:label "OCRe Research"@en-US ;
-      vitro:ontologyPrefixAnnot "ocrer" .
-      
-ocresd:
-      rdfs:label "OCRe Study Design"@en-US ;
-      vitro:ontologyPrefixAnnot "ocresd" .
-      
-ocresp:
-      rdfs:label "OCRe Study Protocol"@en-US ;
-      vitro:ontologyPrefixAnnot "ocresp" .
-      
-ocrest:
-      rdfs:label "OCRe Statistics"@en-US ;
-      vitro:ontologyPrefixAnnot "ocresst" .
-      
-geo:
-      rdfs:label "Geopolitical Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "geo" .
-      
-event:
-      rdfs:label "Event Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "event" .
-
-obo:  
-      rdfs:label "OBO Foundry"@en-US ;
-      vitro:ontologyPrefixAnnot "obo" .
-              
-vcard:
-      rdfs:label "VCard"@en-US ;
-      vitro:ontologyPrefixAnnot "vcard" .
-              
-foaf:
-      rdfs:label "FOAF (Friend of a Friend)"@en-US ;
-      vitro:ontologyPrefixAnnot "foaf" .
-
-scires:
-      rdfs:label "VIVO Scientific Research Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "scires" .
-
-fabio:
-      rdfs:label "FaBiO (FRBR-Aligned Bibliographic Ontology)"@en-US ;
-      vitro:ontologyPrefixAnnot "fabio" .
-
-c4o:
-      rdfs:label "Citation Counting and Context Characterization Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "c4o" .
-
-cito:
-      rdfs:label "CiTO (Citation Typing Ontology)"@en-US ;
-      vitro:ontologyPrefixAnnot "cito" .
-    
-dcterms:
-      rdfs:label "Dublin Core Terms"@en-US ;
-      vitro:ontologyPrefixAnnot "dcterms" .  
-    
-vann:
-      rdfs:label "Vocabulary for Annotating Vocabulary Descriptions"@en-US ;
-      vitro:ontologyPrefixAnnot "vann" .
-      
-ro:
-      rdfs:label "Relations Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "ro" .    
-      
-swo:
-      rdfs:label "Software Ontology"@en-US ;
-      vitro:ontologyPrefixAnnot "swo" . 
-
 vivo:pmcid
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
@@ -2095,9 +2015,6 @@ vivo:Location
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
-<http://purl.org/net/OCRe/study_design.owl>
-      vitro:ontologyPrefixAnnot "ocresd"^^xsd:string .
-
 vivo:WorkingPaper
       vitro:displayLimitAnnot
               "-1"^^xsd:int ;
@@ -2504,7 +2421,7 @@ obo:ERO_0000044
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:inPropertyGroupAnnot
               <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
-              
+
 obo:ERO_0001261
       vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGroupactivities> .
 
@@ -2662,7 +2579,7 @@ obo:ERO_0000045
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:inPropertyGroupAnnot
               <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
- 
+
 vivo:Division
       vitro:displayLimitAnnot
               "-1"^^xsd:int ;
@@ -4079,10 +3996,6 @@ geo:codeUNDP
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
-foaf:
-      vitro:ontologyPrefixAnnot
-              "foaf"^^xsd:string .
-
 geo:hasMaxLatitude
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
@@ -4634,7 +4547,7 @@ obo:ERO_0000482 # deprecated
 #              "true"^^xsd:boolean ;
 #      vitro:inPropertyGroupAnnot
 #              <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
-              
+
 vivo:ResearchProposal
       vitro:displayLimitAnnot
               "-1"^^xsd:int ;
@@ -4796,10 +4709,6 @@ bibo:Chapter
       vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGrouppublications> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
-
-<http://www.w3.org/2006/vcard/ns>
-      vitro:ontologyPrefixAnnot
-              "vcard"^^xsd:string .
 
 vivo:Committee
       vitro:displayLimitAnnot
@@ -5315,7 +5224,7 @@ geo:agriculturalAreaYear
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
-        
+
 vivo:providesFundingThrough
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -5516,10 +5425,6 @@ vivo:start
       vitro:selectFromExistingAnnot
               "false"^^xsd:boolean .
 
-<http://vitro.mannlib.cornell.edu/ns/vitro/public>
-      vitro:ontologyPrefixAnnot
-              "vitro-public"^^xsd:string .
-
 geo:group
       vitro:displayLimitAnnot
               "-1"^^xsd:int ;
@@ -5658,13 +5563,6 @@ vivo:MemberRole
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
-
-bibo:
-      vitro:ontologyPrefixAnnot
-              "bibo"^^xsd:string .
-
-<http://purl.org/net/OCRe/research.owl>
-      vitro:ontologyPrefixAnnot "ocrer"^^xsd:string .
 
 geo:special_group
       vitro:displayLimitAnnot
@@ -6178,7 +6076,7 @@ obo:ERO_0000033
               "true"^^xsd:boolean ;
       vitro:inPropertyGroupAnnot
               <http://vivoweb.org/ontology#vitroPropertyGroupoutreach> .
-              
+
 obo:ERO_0000397
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -7323,10 +7221,6 @@ obo:RO_0001015
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
-<http://vivoweb.org/ontology/core>
-      vitro:ontologyPrefixAnnot
-              "vivo"^^xsd:string .
-
 vivo:dateTime
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -7366,7 +7260,7 @@ obo:ERO_0000919
               "true"^^xsd:boolean ;
       vitro:offerCreateNewOptionAnnot
               "true"^^xsd:boolean .
-              
+
 bibo:status
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -7450,7 +7344,7 @@ geo:validUntil
       vitro:hiddenFromPublishBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
- 
+
 vivo:hasEquipment
       vitro:displayRankAnnot
               "80"^^xsd:int ;
@@ -7508,41 +7402,38 @@ vivo:hasEquipment
       vitro:displayRankAnnot
               "1"^^xsd:int .
 
-<http://purl.obolibrary.org/obo/RO_0000053> 
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot 
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
-
-<http://purl.obolibrary.org/obo/ARG_2000028> 
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot 
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
-  
-vivo:relates 
+<http://purl.obolibrary.org/obo/RO_0000053>
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
-vivo:relatedBy 
+<http://purl.obolibrary.org/obo/ARG_2000028>
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
-vivo:assigns 
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot 
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
-
-vivo:assignedBy 
+vivo:relates
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
+vivo:relatedBy
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
+vivo:assigns
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
 
+vivo:assignedBy
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1447)**: VIVO-1447

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Moves ontology prefixes from vitroAnnotations.n3 in the tbox/firsttime directory into a new file in tbox/filegraph.

# What's new?
Nothing new, just moved some triples from one file to another.

# How should this be tested?
* Reproduce the problem you are fixing (if applicable)
Upgrade VIVO with existing database ([instructions here](https://wiki.duraspace.org/display/VIVODOC110x/Upgrading+VIVO)) to develop branch. After upgrade, go to Site Admin > Ontology list. Prefixes are missing.
![Missing prefixes screenshot](https://jira.duraspace.org/secure/attachment/18862/18862_Screen+Shot+2018-05-01+at+10.02.19+AM.png)

* Test that the pull request does what is intended.
Rebuild VIVO with this PR and follow steps above. All prefixes should be present.

# Additional Notes:
This only affects users upgrading.

# Interested parties
@mconlon17 @mjaved495 