### PR TITLE
handle doi url

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
@@ -10,7 +10,12 @@
 <@showStatement statement property />
 
 <#macro showStatement statement property>
-    <#assign doi = (statement.value!).toLowerCase().replace("http://doi.org/", "").replace("https://doi.org/", "").replace("http://dx.doi.org/", "").replace("https://dx.doi.org/", "")>
+    <#assign doi = (statement.value!).toLowerCase().
+                    replace("http://doi.org/", "").
+                    replace("https://doi.org/", "").
+                    replace("http://dx.doi.org/", "").
+                    replace("https://dx.doi.org/", "").
+                    replace("doi:", "").trim()>
     <a href="https://doi.org/${doi}" title="${i18n().doi_link}" target="_blank">${doi}</a>
     <@lmt.addCitationMetaTag uri=(property.uri!) content=(doi) />
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
@@ -10,8 +10,9 @@
 <@showStatement statement property />
 
 <#macro showStatement statement property>
-    <a href="https://doi.org/${statement.value!}" title="${i18n().doi_link}" target="_blank">${statement.value!}</a>
-    <@lmt.addCitationMetaTag uri=(property.uri!) content=(statement.value!) />
+    <#assign doi = (statement.value!).replace("http://doi.org/", "").replace("https://doi.org/", "")>
+    <a href="https://doi.org/${doi}" title="${i18n().doi_link}" target="_blank">${doi}</a>
+    <@lmt.addCitationMetaTag uri=(property.uri!) content=(doi) />
 </#macro>
 
 

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-doi.ftl
@@ -10,7 +10,7 @@
 <@showStatement statement property />
 
 <#macro showStatement statement property>
-    <#assign doi = (statement.value!).replace("http://doi.org/", "").replace("https://doi.org/", "")>
+    <#assign doi = (statement.value!).toLowerCase().replace("http://doi.org/", "").replace("https://doi.org/", "").replace("http://dx.doi.org/", "").replace("https://dx.doi.org/", "")>
     <a href="https://doi.org/${doi}" title="${i18n().doi_link}" target="_blank">${doi}</a>
     <@lmt.addCitationMetaTag uri=(property.uri!) content=(doi) />
 </#macro>


### PR DESCRIPTION
don't complete the URL if the full URL is given;

supported doi variants:
- http://doi.org/[doi]
- https://doi.org/[doi]
- http://dx.doi.org/[doi]
- https://dx.doi.org/[doi]
- doi:[doi]

https://jira.duraspace.org/browse/VIVO-1527