### PR TITLE
[VIVO-1547] Fix service provider template

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addServiceProviderRoleToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addServiceProviderRoleToPerson.ftl
@@ -25,6 +25,8 @@ roleExamples-->
 <#assign acMultipleTypes = "'true'" />
 <#assign acTypes = "{activity: 'http://xmlns.com/foaf/0.1/Organization,http://xmlns.com/foaf/0.1/Group,http://purl.obolibrary.org/obo/OBI_0000835,http://purl.org/NET/c4dm/event.owl#Event'}" />
 
+<#assign editTitle = "${i18n().edit_entry_for_service_provider_role}"/>
+<#assign createTitle = "${i18n().create_entry_for_service_provider_role}"/>
 
 <#--Each of the two stage forms will include the form below-->
 <#include "addRoleToPersonTwoStage.ftl">


### PR DESCRIPTION
**[VIVO-1547](https://jira.duraspace.org/browse/VIVO-1547)**:

# What does this pull request do?
Fixes a bug in the create service provider role that causes the template to throw an internal server error

# How should this be tested?
For a person, add a service provider role - the form to add a new role should display, and allow you to submit / create a service provider entry.
(Prior to the fix, the form would throw an error instead of displaying)

# Interested parties
@VIVO-project/vivo-committers
