### PR TITLE
Fix list view and template for vCard authors

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-informationResourceInAuthorship.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-informationResourceInAuthorship.xml
@@ -64,7 +64,7 @@
                 bind ( COALESCE(?firstName, "") As ?firstName1) .
                 bind ( COALESCE(?middleName, "") As ?middleName1) .
                 bind ( COALESCE(?lastName, "") As ?lastName1) .
-                bind (concat(str(?lastName1 + ", "),str(?firstName1 + " "),str(?middleName1)) as ?authorName) .
+                bind (concat(str(?lastName1),", ",str(?firstName1)," ",str(?middleName1)) as ?authorName) .
 
                 OPTIONAL {
                     <precise-subquery>?subject ?property ?authorship .

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-informationResourceInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-informationResourceInAuthorship.ftl
@@ -19,7 +19,7 @@
 			<#if statement.authorName?replace(" ","")?length == statement.authorName?replace(" ","")?last_index_of(",") + 1 >
         		${statement.authorName?replace(",","")}
 			<#else>
-				${statement.authorName}
+				${statement.authorName!i18n().missing_author}
 			</#if>
     	<#else>
         	<a href="${profileUrl(statement.uri("author"))}" title="${i18n().author_name}">${statement.authorName}</a>


### PR DESCRIPTION
 **[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1603)**: https://jira.duraspace.org/browse/VIVO-1603

# What does this pull request do?
Fixes a problem with authors modeled as vcard:Individual

# What's new?
Authors modeled as vcard:Individual did not work when their names included language tags. This PR solves the problem by changing the concatenation logic and additionally adds a 'missing author' string if the name is missing.

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
Add a vcard author with language tags on the name strings. 
Example name from Mike:
 ```
<http://vivo.mydomain.edu/individual/n1112>
        a             vcard:Name ;
        vcard:familyName "Veronique"@en ;
        vcard:givenName "Al"@en .
```
The publication for the author will not be rendered, it will throw a Freemarker error.
* Test that the pull request does what is intended.
View publication after applying changes, it should work.

# Interested parties
@mconlon17 
