### PR TITLE
has collaborator is symmetric

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -1911,7 +1911,7 @@ there is a measurement process p that has specified output m, a measurement datu
     <!-- http://vivoweb.org/ontology/core#hasCollaborator -->
 
     <owl:ObjectProperty rdf:about="http://vivoweb.org/ontology/core#hasCollaborator">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ReflexiveProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <rdfs:label xml:lang="en">has collaborator</rdfs:label>

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -1911,12 +1911,16 @@ there is a measurement process p that has specified output m, a measurement datu
     <!-- http://vivoweb.org/ontology/core#hasCollaborator -->
 
     <owl:ObjectProperty rdf:about="http://vivoweb.org/ontology/core#hasCollaborator">
-        <rdfs:label xml:lang="en">has collaborator</rdfs:label>
-        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ReflexiveProperty"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <rdfs:label xml:lang="en">has collaborator</rdfs:label>
+        <obo:IAO_0000112 xml:lang="en">Fran has collaborator Jim, they work together regularly.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">Two agents are collaborators if they work together to produce common results.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Michael Conlon</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Merriam Webster (https://www.merriam-webster.com/dictionary/collaborator)</obo:IAO_0000119>
     </owl:ObjectProperty>
-    
-
 
     <!-- http://vivoweb.org/ontology/core#hasEquipment -->
 


### PR DESCRIPTION
# Add SymmetricProperty to has collaborator

[VIVO-1364](https://jira.duraspace.org/browse/VIVO-1364)

# What does this pull request do?
Adds a declaration that has collaborator is a symmetric object property.  This means if A has Collaborator B, then the inferencer can add B has collaborator A.

Adds four annotations to the data property to 1) define it; 2) give and example of usage; 3) provide the editor's name; 4) provide a citation for the definition.

# How should this be tested?
Before this pull request, declaring A has collaborator B does not establish B as a collaborator of A.
After the pull request, the inferencer adds B is a collaborator of A.

# Additional Notes
Sites should be alerted of this change.  While the change is in keeping with common use of the term "collaborator," the provision of a new assertion is a change for VIVO.

A socialization process defines collaboration.  A and B agree that they are collaborators.

# Interested parties
@VIVO-project/vivo-committers, @marijane, @vioil, @mjaved495, @hauschke, @brianjlowe 
