### PR TITLE
[VIVO-1607] Populate build number within installer directory

### DIFF
--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -16,6 +16,8 @@
         <vitro-version>${project.version}</vitro-version>
         <maven-site-plugin.skip>true</maven-site-plugin.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
     </properties>
 
     <build>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -19,6 +19,13 @@
 
     <name>VIVO Install Web App</name>
 
+    <scm>
+        <connection>scm:git:git@github.com:vivo-project/VIVO.git</connection>
+        <developerConnection>scm:git:git@github.com:vivo-project/VIVO.git</developerConnection>
+        <url>git@github.com:vivo-project/VIVO.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <profiles>
         <profile>
             <id>package</id>
@@ -28,6 +35,24 @@
             <build>
                 <finalName>${app-name}</finalName>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>buildnumber-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>create</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <doCheck>false</doCheck>
+                            <doUpdate>false</doUpdate>
+                            <shortRevisionLength>7</shortRevisionLength>
+                            <revisionOnScmFailure>Detached</revisionOnScmFailure>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>

--- a/installer/webapp/src/main/webResources/WEB-INF/resources/revisionInfo.txt
+++ b/installer/webapp/src/main/webResources/WEB-INF/resources/revisionInfo.txt
@@ -1,0 +1,2 @@
+${build.timestamp}
+VIVO ~ ${project.version} ~ ${buildNumber}


### PR DESCRIPTION
**[VIVO-1607](https://jira.duraspace.org/browse/VIVO-1607)**: ${buildNumber} does not populate

# What does this pull request do?
Resolves a problem where ${buildNumber} was never populated in revisionInfo.txt, therefore the app just displayed "${buildNumber}" instead of the actually hash code.

# What's new?
Runs the codemojo build number plugin and calculates the build date from within the installer directory.

# How should this be tested?
* Reproduce the problem you are fixing (if applicable)
Install VIVO without the changes. Login as a site admin. Click the the VIVO version number at the bottom of the page (or just go to http://localhost:8080/vivo/revisionInfo). The revision info will just say "${buildNumber}." 

* Test that the pull request does what is intended.
Install VIVO with changes. Do the same as above, the revision info should now have an actual hash value calculated from the git commit.

# Additional Notes:
The revision info worked with Vitro, but not with VIVO. I'm not exactly sure why this is. There might be a better, less naive way to accomplish this task if we can figure that out. Is it possible to install VIVO without the installer directory? If not, the plugin task and timestamp calculation can be removed from VIVO/pom.xml so they won't have to be performed twice. 

# Interested parties
@grahamtriggs @awoods 
