### PR TITLE
[VIVO-1340] Fix links to documentation in example.runtime.properties

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -7,6 +7,11 @@
 # Save a copy of this file as runtime.properties in your VIVO home directory, 
 # and edit the properties as needed for your installation.
 #
+# For more information on specific properties, see the configuration reference
+# or installation options section of the technical documentation for the
+# version of VIVO you are running:
+# https://wiki.duraspace.org/display/VIVO/VIVO+Technical+Documentation 
+#
 # -----------------------------------------------------------------------------
 
 
@@ -295,8 +300,6 @@ VitroConnection.DataSource.validationQuery = SELECT 1
   #  
   # When the following flag is set to enabled, the VIVO home page displays a 
   # global map highlighting the geographical focus of foaf:person individuals. 
-  # For information on the maps, refer to this wiki page:
-  # https://wiki.duraspace.org/x/c4XVAw
   #
 #homePage.geoFocusMaps=enabled
 
@@ -306,9 +309,6 @@ VitroConnection.DataSource.validationQuery = SELECT 1
   # and a "quick" page view that emphasizes the individual's webpage presence. 
   # Implementing this feature requires an installation to develop a web service
   # that captures images of web pages or to use an existing service outside of VIVO. 
-  # 
-  # For more information on implementing multiple profile pages, refer to this 
-  # wiki page: https://wiki.duraspace.org/x/doXVAw
   #
 #multiViews.profilePageTypes=enabled
 
@@ -316,9 +316,6 @@ VitroConnection.DataSource.validationQuery = SELECT 1
   #
   # Tell VIVO to generate HTTP headers on its responses to facilitate caching the 
   # profile pages that it creates. 
-  #
-  # For more information, see this wiki page: 
-  # https://wiki.duraspace.org/x/5sQQAg
   #
   # Developers will likely want to leave caching disabled, since a change to a
   # Freemarker template or to a Java class would not cause the page to be 


### PR DESCRIPTION
**[VIVO-1340](https://jira.duraspace.org/browse/VIVO-1340)**

Fixes links to documentation in example.runtime.properties

# What does this pull request do?
Removes broken links to version-specific documentation for properties. Adds link to top-level documentation page for all versions, with pointer to sections for configuration reference (recent versions) or installation properties (older versions).

# Additional Notes:
Assumes that the wiki will continue to have a page listing all documentation versions. 

# Interested parties
@VIVO-project/vivo-committers
