### PR TITLE
[VIVO 1652] - Add vivo:AdministrativeUnit as a subclass of foaf:Organization

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -9341,6 +9341,20 @@ This class allows for linking an author to a publication while indicating inform
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Legal (department within a company); Use for any non-academic department</obo:IAO_0000112>
     </owl:Class>
     
+    <!-- http://vivoweb.org/ontology/core#AdministrativeUnit -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#AdministrativeUnit">
+        <rdfs:label xml:lang="en">Administrative Unit</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The Health Science Center of the University of Florida is an administrative unit of the university. It is not a center.</obo:IAO_0000112><!-- example of usage -->
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/><!-- curation status: ready for release -->
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A part of an organization that is not recognized as a department or other part of an organization.</obo:IAO_0000115><!-- definition -->
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Not to be confused with local administrative unit that Wikipedia uses to describe parts of countries.  VIVO will likely add the term LocalAdministrativeUnit in the future. See Wikipedia. https://en.wikipedia.org/wiki/Local_administrative_unit</obo:IAO_0000116><!-- editor's administrative note -->
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Not to be confused with administrative department which does not yet exist in VIVO.  Administrative departments are departments.  Administrative units are not departments. VIVO will likely add the term AdministrativeDepartment in the future, as many organizations in the VIVO domain have a common practice to classify some departments as administrative and others as academic.</obo:IAO_0000116><!-- editor's administrative note -->
+        <obo:IAO_0000117 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERSON: Michael Conlon</obo:IAO_0000117><!-- name of editor -->
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organization Administrative Unit</obo:IAO_0000118><!-- alternative name for term -->
+    </owl:Class>
+    
 
 
     <!-- http://vivoweb.org/ontology/core#Division -->

--- a/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
+++ b/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
@@ -3041,6 +3041,20 @@ bibo:Conference
       vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGroupevents> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
+              
+
+vivo:AdministrativeUnit
+      vitro:displayLimitAnnot
+              "-1"^^xsd:int ;
+      vitro:displayRankAnnot
+              "-1"^^xsd:int ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:hiddenFromPublishBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGrouporganizations> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
 vivo:Department
       vitro:displayLimitAnnot


### PR DESCRIPTION
**[VIVO-1652](https://jira.duraspace.org/browse/VIVO-1652)**

# What does this pull request do?
Adds a new class to the VIVO ontology -- AdministrativeUnit. Administrative  Unit is a part of an organization not otherwise identifiable as a department or school, college, etc.

Example:  The UF Health Science Center is an administrative unit (not a center)

AdministrativeUnit is not:
* a department.  We plan to add AdministrativeDepartment in the future.  AdministrativeDepartment is the counter part to AcademicDepartment and should clarify organizational representation in VIVO.
* an administrative unit of a country.  Wikipedia uses the term local administrative department to represent administrative divisions in countries not otherwise classified as states, counties, municipalities.  Administrative Unit is analogous for organizations. VIVO will likely add LocalAdministrativeUnit as a term for countries in the future.

# What's new?
* Changes to vivo.owl to define AdministrativeUnit in the VIVO ontology.
* Changes to vitroAnnotations.n3 to support use of AdministrativeUnit in the VIVO application.

# How should this be tested?
1. Build
1. Empty database (to force reread of vitroAnnotations.n3)
1. Start Tomcat
3. Use SysAdmin menu to add a new Administrative Unit (available under the Organizations heading)
1. Confirm new Administrative Unit in the Index under Organizations

# Additional Notes:
* The ontology file with its annotations serves as documentation.  The file can be opened in ontology tools and visualizers to see structure.
* When a new version of VIVO is released, the version of the ontology corresponding to the ontology is placed at http://vivoweb.org/ontology/core

# Interested parties
@VIVO-project/vivo-committers @vivo-project/contributors  @vivo-project/vivo-developers @mjaved495 @marijane @brianjlowe @tawahle
