### PR TITLE
Vivo 1630 Start Year field keeps the same label even when language is changed

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-adviseeIn.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-adviseeIn.xml
@@ -31,7 +31,7 @@
             ?adviseeRole a core:AdviseeRole .
             ?adviseeRole core:relatedBy ?advisingRel .
             ?advisingRel a core:AdvisingRelationship .
-            LET ( ?localName := afn:localname(?advisingRel) )
+            LET ( ?localName := REPLACE(STR(?advisingRel),"^.*(#)(.*)$", "$2") )
             OPTIONAL {
                 <precise-subquery>?subject ?property ?adviseeRole .
                 ?adviseeRole a core:AdviseeRole .

--- a/webapp/src/main/webapp/config/listViewConfig-advisorIn.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-advisorIn.xml
@@ -31,7 +31,7 @@
             ?advisorRole a core:AdvisorRole .
             ?advisorRole core:relatedBy ?advisingRel .
             ?advisingRel a core:AdvisingRelationship .
-            LET ( ?localName := afn:localname(?advisingRel) )
+            LET ( ?localName := REPLACE(STR(?advisingRel),"^.*(#)(.*)$", "$2") )
             OPTIONAL {
                 <precise-subquery>?subject ?property ?advisorRole .
                 ?advisorRole a core:AdvisorRole .

--- a/webapp/src/main/webapp/config/listViewConfig-dateTimeInterval.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-dateTimeInterval.xml
@@ -24,7 +24,7 @@
             OPTIONAL {
                 <precise-subquery>?subject ?property ?dateTimeInterval .</precise-subquery>
                 ?dateTimeInterval core:start ?valueStart .
-                LET (?valueStartName := afn:localname(?valueStart))
+                LET (?valueStartName := REPLACE(STR(?valueStart),"^.*(#)(.*)$", "$2"))
 
                 OPTIONAL {
                     <precise-subquery>?subject ?property ?dateTimeInterval .
@@ -35,13 +35,13 @@
                     <precise-subquery>?subject ?property ?dateTimeInterval .
                     ?dateTimeInterval core:start ?valueStart .</precise-subquery>
                     ?valueStart core:dateTimePrecision ?dateTimePrecisionStart .
-                    LET (?precisionStart := afn:localname(?dateTimePrecisionStart))
+                    LET (?precisionStart := REPLACE(STR(?dateTimePrecisionStart),"^.*(#)(.*)$", "$2"))
                 }
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?dateTimeInterval .</precise-subquery>
                 ?dateTimeInterval core:end ?valueEnd .
-                LET (?valueEndName := afn:localname(?valueEnd))
+                LET (?valueEndName := REPLACE(STR(?valueEnd),"^.*(#)(.*)$", "$2"))
                 OPTIONAL {
                     <precise-subquery>?subject ?property ?dateTimeInterval .
                     ?dateTimeInterval core:end ?valueEnd .</precise-subquery>
@@ -51,7 +51,7 @@
                     <precise-subquery>?subject ?property ?dateTimeInterval .
                     ?dateTimeInterval core:end ?valueEnd .</precise-subquery>
                     ?valueEnd core:dateTimePrecision ?dateTimePrecisionEnd .
-                    LET (?precisionEnd := afn:localname(?dateTimePrecisionEnd))
+                    LET (?precisionEnd := REPLACE(STR(?dateTimePrecisionEnd),"^.*(#)(.*)$", "$2"))
                 }
             }
             OPTIONAL {

--- a/webapp/src/main/webapp/config/listViewConfig-dateTimeValue.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-dateTimeValue.xml
@@ -10,7 +10,7 @@
         PREFIX afn:  &lt;http://jena.apache.org/ARQ/function#&gt;
         
         SELECT DISTINCT ?dateTimeValue 
-                        (afn:localname(?dateTimePrecision) AS ?precision) 
+                        (REPLACE(STR(?dateTimePrecision),"^.*(#)(.*)$", "$2") AS ?precision) 
                         ?dateTime
         WHERE {
             ?subject ?property ?dateTimeValue .

--- a/webapp/src/main/webapp/config/listViewConfig-default.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-default.xml
@@ -25,7 +25,7 @@
         WHERE
         {
             ?subject ?property ?object .
-             LET (?localName := REPLACE(STR(?object), "^.*(#)(.*)$", "$2"))
+            LET (?localName := REPLACE(STR(?object), "^.*(#)(.*)$", "$2"))
 
             OPTIONAL {
                 <precise-subquery>?subject ?property ?object .</precise-subquery>

--- a/webapp/src/main/webapp/config/listViewConfig-default.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-default.xml
@@ -25,7 +25,7 @@
         WHERE
         {
             ?subject ?property ?object .
-            LET (?localName := afn:localname(?object))
+             LET (?localName := REPLACE(STR(?object), "^.*(#)(.*)$", "$2"))
 
             OPTIONAL {
                 <precise-subquery>?subject ?property ?object .</precise-subquery>

--- a/webapp/src/main/webapp/config/listViewConfig-fauxPropertyDefault.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-fauxPropertyDefault.xml
@@ -26,7 +26,7 @@
         {
             ?subject ?property ?object .
             ?object a ?objectType .
-            LET (?localName := afn:localname(?object))
+            LET (?localName := REPLACE(STR(?object),"^.*(#)(.*)$", "$2"))
 
             OPTIONAL {
                 <precise-subquery>?subject ?property ?object .

--- a/webapp/src/main/webapp/config/listViewConfig-hasAssociatedConcept.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasAssociatedConcept.xml
@@ -13,7 +13,7 @@
         SELECT ?concept ?conceptLabel ?conceptName ?vocabularySource ?vocabularySourceName
         WHERE {
          	?subject ?property ?concept .
-         	LET (?conceptName := afn:localname(?concept)) 
+         	LET (?conceptName := REPLACE(STR(?concept),"^.*(#)(.*)$", "$2")) 
          	OPTIONAL {
                 <precise-subquery>?subject ?property ?concept .</precise-subquery>
                 ?concept rdfs:label ?conceptLabel .

--- a/webapp/src/main/webapp/config/listViewConfig-hasAttendeeRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasAttendeeRole.xml
@@ -55,7 +55,7 @@
                 }
                 </collated>
 
-                LET (?event1Name := afn:localname(?event1))
+                LET (?event1Name := REPLACE(STR(?event1),"^.*(#)(.*)$", "$2"))
 
                 OPTIONAL {
                     <precise-subquery>

--- a/webapp/src/main/webapp/config/listViewConfig-hasCoPrincipalInvestigatorRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasCoPrincipalInvestigatorRole.xml
@@ -32,7 +32,7 @@
                 ?role core:relatedBy ?activity .
                 ?activity a core:Contract .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity)) .
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2")) .
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .
@@ -40,7 +40,7 @@
                 ?role core:relatedBy ?activity .
                 ?activity a core:Grant .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity)) .
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2")) .
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .

--- a/webapp/src/main/webapp/config/listViewConfig-hasEditorRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasEditorRole.xml
@@ -14,7 +14,7 @@
                         ?role
                         ?subclassLabel
                         ?activity 
-                        (afn:localname(?activity) AS ?activityLocal)
+                        (REPLACE(STR(?activity),"^.*(#)(.*)$", "$2") AS ?activityLocal)
                         ?activityName
                         ?dateTimeStart 
                         ?dateTimeEnd 

--- a/webapp/src/main/webapp/config/listViewConfig-hasInvestigatorRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasInvestigatorRole.xml
@@ -32,7 +32,7 @@
                 ?role &lt;http://vivoweb.org/ontology/core#relatedBy&gt; ?activity .
                 ?activity a core:Contract .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity))
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2"))
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .
@@ -57,7 +57,7 @@
                 ?role &lt;http://vivoweb.org/ontology/core#relatedBy&gt; ?activity .
                 ?activity a core:Grant .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity))
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2"))
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .

--- a/webapp/src/main/webapp/config/listViewConfig-hasPresenterRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasPresenterRole.xml
@@ -38,7 +38,7 @@
                 ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?presentation .
                 ?presentation a vivo:Presentation .
                 ?presentation rdfs:label ?presentationLabel .
-                LET (?presentationName := afn:localname(?presentation))
+                LET (?presentationName := REPLACE(STR(?presentation),"^.*(#)(.*)$", "$2"))
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .

--- a/webapp/src/main/webapp/config/listViewConfig-hasPrincipalInvestigatorRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasPrincipalInvestigatorRole.xml
@@ -34,7 +34,7 @@
                 ?role core:relatedBy ?activity .
                 ?activity a core:Contract .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity)) .
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2")) .
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .
@@ -59,7 +59,7 @@
                 ?role core:relatedBy ?activity .
                 ?activity a core:Grant .
                 ?activity rdfs:label ?activityLabel .
-                LET (?activityName := afn:localname(?activity)) .
+                LET (?activityName := REPLACE(STR(?activity),"^.*(#)(.*)$", "$2")) .
             }
             OPTIONAL {
                 <precise-subquery>?subject ?property ?role .

--- a/webapp/src/main/webapp/config/listViewConfig-hasReviewerRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-hasReviewerRole.xml
@@ -14,7 +14,7 @@
                         ?role
                         ?subclassLabel
                         ?activity 
-                        (afn:localname(?activity) AS ?activityLocal)
+                        (REPLACE(STR(?activity),"^.*(#)(.*)$", "$2") AS ?activityLocal)
                         ?activityName
                         ?dateTimeStart 
                         ?dateTimeEnd 

--- a/webapp/src/main/webapp/config/listViewConfig-issuedCredential.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-issuedCredential.xml
@@ -26,7 +26,7 @@
         WHERE {
             ?subject ?property ?issuedCredential .
             ?issuedCredential a core:IssuedCredential .
-            LET (?issuedCredentialLocal := afn:localname(?issuedCredential))
+            LET (?issuedCredentialLocal := REPLACE(STR(?issuedCredential),"^.*(#)(.*)$", "$2"))
             OPTIONAL {
                 <precise-subquery>?subject ?property ?issuedCredential .
                 ?issuedCredential a core:IssuedCredential .</precise-subquery>
@@ -39,7 +39,7 @@
                 ?credential a core:Credential .
                 ?credential core:relatedBy ?issuedCredential .
                 ?credential rdfs:label ?credentialLabel .
-                LET (?credentialLocal := afn:localname(?credential))
+                LET (?credentialLocal := REPLACE(STR(?credential),"^.*(#)(.*)$", "$2"))
             }
              OPTIONAL {
                 <precise-subquery>?subject ?property ?issuedCredential .

--- a/webapp/src/main/webapp/config/listViewConfig-rangeUnion.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-rangeUnion.xml
@@ -24,7 +24,7 @@
         WHERE
         {
             ?subject ?property ?object .
-            LET (?localName := afn:localname(?object))
+            LET (?localName := REPLACE(STR(?object),"^.*(#)(.*)$", "$2"))
 
             OPTIONAL {
                 <precise-subquery>?subject ?property ?object .</precise-subquery>

--- a/webapp/src/main/webapp/config/listViewConfig-relatedRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-relatedRole.xml
@@ -18,7 +18,7 @@
                         ?property
                         ?role   
                         ?roleLabel ?roleTypeLabel                          
-                        ?indivInRole (afn:localname(?indivInRole) AS ?indivName)
+                        ?indivInRole (REPLACE(STR(?indivInRole),"^.*(#)(.*)$", "$2") AS ?indivName)
                         ?indivLabel
                         ?dateTimeInterval ?dateTimeStart ?dateTimeEnd ?objectType
         WHERE {

--- a/webapp/src/main/webapp/config/listViewConfig-webpage.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-webpage.xml
@@ -13,7 +13,7 @@
         PREFIX vcard: &lt;http://www.w3.org/2006/vcard/ns#&gt;
 
         SELECT ?vcard ?link 
-               (afn:localname(?link) AS ?linkName) 
+               (REPLACE(STR(?link),"^.*(#)(.*)$", "$2") AS ?linkName) 
                (group_concat(distinct ?linkLabel;separator="/") as ?label)
                ?url 
                ?rank

--- a/webapp/src/main/webapp/i18n/vivo_all.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all.properties
@@ -810,3 +810,7 @@ role_in_presentation_capitalized=Role in Presentation
 advisee_capitalized_first_name=First Name
 advisee_capitalized_lastname=Last Name
 
+
+label.addRoleToPersonTwoStage.start_capitalized = Start
+label.addRoleToPersonTwoStage.end_capitalized = End
+

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
@@ -195,12 +195,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
             <#else>
                 <h4 class="label">${i18n().years_participating} </h4>
                 <#if htmlForElements?keys?seq_contains("startField")>
-                	    <label class="dateTime" for="startField">${i18n().start_capitalized}</label>
+                	    <label class="dateTime" for="startField">${i18n()[('label.addRoleToPersonTwoStage.start_capitalized')]}</label>
                		    ${htmlForElements["startField"]} ${yearHint}
                </#if>
                <p></p>
                <#if htmlForElements?keys?seq_contains("endField")>
-               		    <label class="dateTime" for="endField">${i18n().end_capitalized}</label>
+               		    <label class="dateTime" for="endField">${i18n()[('label.addRoleToPersonTwoStage.end_capitalized')]}</label>
                		    ${htmlForElements["endField"]} ${yearHint}
                </#if>
             </#if>


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/projects/VIVO)**: https://jira.duraspace.org/browse/VIVO-1630

# What does this pull request do?
use of a"context" for the start/end label 

Example:
edit an individual role

# How should this be tested?
edit an individual role and change locale

# Additional Notes:
VIVO-1641 is a prerequisite because i cant start the serverwith blazegraph othervise

# Interested parties
@VIVO-project/vivo-committers
