### PR TITLE
[VIVO-1655] Updating AGROVOC REST API base URL

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
+++ b/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
@@ -58,7 +58,7 @@ public class AgrovocService implements ExternalConceptService {
 	protected final String dbpedia_endpoint = " http://dbpedia.org/sparql";
 	// URL to get all the information for a concept
 	
-	protected final String conceptSkosMosBase = "http://artemide.art.uniroma2.it:8081/skosmos/rest/v1/";
+	protected final String conceptSkosMosBase = "http://agrovoc.uniroma2.it/agrovoc/rest/v1/";
 	protected final String conceptsSkosMosSearch = conceptSkosMosBase + "search?";
 	protected final String conceptSkosMosURL = conceptSkosMosBase + "data?";
 	@Override


### PR DESCRIPTION
**[VIVO-1655](https://jira.duraspace.org/browse/VIVO-1655)**: 

# What does this pull request do?
Updates broken base URL for AGROVOC REST API concept look-up. 

# How should this be tested?
* To reproduce error:
1) Go to an individual profile and click "Manage list of research areas."
2) Make sure AGROVOC is selected and enter a search term (e.g. wheat). Click Search Service. 
3) Error in UI "An error was encountered in executing this search."
4) Error in vivo.all.log, similar to "ERROR [AgrovocService] Error occurred in getting concept from the URL http://artemide.art.uniroma2.it:8081/skosmos/rest/v1/search?query=animal*&lang=en"
* To test pull request:
1) Go to an individual profile and click "Manage list of research areas."
2) Make sure AGROVOC is selected and enter a search term (e.g. wheat). Click Search Service. 
3) A list of terms should appear. Select a term and verify that it is added. 

# Additional Notes:
There is little/no documentation of the AGROVOC REST API. However, found the following AGROVOC listserv item, posted 6/4/18 by Kristin Kolshus: 

```Important news: AGROVOC SKOSMOS and AGROVOC Web services have moved to a new server. Please update your bookmarks.
There are new addresses for:
* SKOSMOS now at http://agrovoc.uniroma2.it/agrovoc/en/ (to browse AGROVOC)
* Webservices now at http://agrovoc.uniroma2.it:8080/SKOSWS/services/SKOSWS?wsdl
* The web services on the old server (http://artemide.art.uniroma2.it/SKOSWS/services/SKOSWS?wsdl) now are automatically redirected to the ones on the new server (http://agrovoc.uniroma2.it:8080/SKOSWS/services/SKOSWS?wsdl ) for now, but please update your links.
```

# Interested parties
@VIVO-project/vivo-committers, @vivo-project/contributors 
