### PR TITLE
[VIVO-1607] corrected pom in order to template child module build number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,18 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
@@ -166,18 +178,6 @@
                             <quiet>true</quiet>
                             <additionalparam>${javadoc.opts}</additionalparam>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -200,24 +200,6 @@
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>buildnumber-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>create</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <doCheck>false</doCheck>
-                            <doUpdate>false</doUpdate>
-                            <shortRevisionLength>7</shortRevisionLength>
-                            <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -304,6 +286,24 @@
                             <version>2.3.2</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doCheck>false</doCheck>
+                    <doUpdate>false</doUpdate>
+                    <shortRevisionLength>7</shortRevisionLength>
+                    <revisionOnScmFailure>Detached</revisionOnScmFailure>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**[VIVO-1607](https://jira.duraspace.org/browse/VIVO-1607)**:

# What does this pull request do?

This pull requests enables child modules to correctly template revision info build number.

# What's new?

The pom plugin, buildnumber-maven-plugin, was moved from release-sign-artifacts profile to the root build section. Also, the release-sign-artifacts profile was reorganized to match Vitro pom.

# How should this be tested?

Deploy each strategy and ensure http://localhost:8080/vivo/revisionInfo displays correct build number. This can also be confirmed by checking under Tomcat `webapps/vivo/WEB-INF/resources/revisionInfo.txt` if deployed or under VIVO source `webapp/target/vivo-webapp-1.11.0-SNAPSHOT/WEB-INF/resources/revisionInfo.txt` if just built. The `revisionInfo.txt` file should have the correct 7 digit commit hash in replace of `${buildNumber}`.

# Additional Notes:
 N/A

# Interested parties

@vivo-project/vivo-committers, @vivo-project/contributors 
