### PR TITLE
[VIVO-1609] Fix validation on personHasAdvisorRelationship.ftl

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdvisorRelationship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdvisorRelationship.ftl
@@ -114,7 +114,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         </#list>
       <#else>
         <select id="selector" name="advisingRelType"  ${disabledVal} >
-            <option value="${blankSentinel}" selected="selected">${i18n().select_one}</option>                
+            <option value="" selected="selected">${i18n().select_one}</option>
             <#list advisingRelTypeOpts?keys as key>             
                 <option value="${key}"  <#if advisingRelTypeValue = key>selected</#if>>${advisingRelTypeOpts[key]}</option>            
             </#list>


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1609)**: https://jira.duraspace.org/browse/VIVO-1609

# What does this pull request do?
Fixes validation when adding a new advisee to a person.

# What's new?
Fixes a validation error, should restore lost functionality

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
Go to a person's profile. Click the plus sign to add a new advisee. Neglect to select a "Advising Relationship Type" which should be required. Add a name and click 'Create enty.' This should result in the following error: 
```
There was an error in the system.

Error message: java.lang.Exception: Errors processing required N3. The EditConfiguration should be setup so that if a submission passes validation, there will not be errors in the required N3. [line: 1, col: 49] Triples not terminated by DOT N3: <http://vivo.mydomain.edu/individual/n3584> a <>SUBMITTED VALUE WAS BLANK<> .
```
* Test that the pull request does what is intended.
Do the same as above. Do not select an advising relationship type. Click 'Create Enty' and you should get a validation error: `Please select an Advising Relationship Type.`

# Additional Notes:
For what it's worth, removing the blankSentinel value bring it more into line with [personHasAdviseeRelationship.ftl](https://github.com/vivo-project/VIVO/blob/develop/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdviseeRelationship.ftl), which does work.

# Interested parties
@VIVO-project/vivo-committers @mconlon17 
