### PR TITLE
[VIVO-1634] Align VIVO exploded war in Tomcat and generated war

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -25,7 +25,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
                     <archiveClasses>false</archiveClasses>
                     <archive>
                         <manifest>

--- a/webapp/src/main/webResources/META-INF/context.xml
+++ b/webapp/src/main/webResources/META-INF/context.xml
@@ -1,0 +1,9 @@
+<Context> <!-- useHttpOnly="false" -->
+   <Environment
+        type="java.lang.String" 
+        name="vitro/home"
+        value="${vivo-dir}" override="true"/>
+
+   <!-- Disable persist sessions on shut down.-->
+   <Manager pathname="" />
+</Context>

--- a/webapp/src/main/webResources/WEB-INF/classes/log4j.properties
+++ b/webapp/src/main/webResources/WEB-INF/classes/log4j.properties
@@ -1,0 +1,49 @@
+#
+# This file sets the log levels for the Vitro webapp.
+#
+# There are 8 principal logging levels, as follows:
+#     <-- more messages ALL TRACE DEBUG INFO WARN ERROR FATAL OFF fewer messages -->
+#
+# The default logging level is specified on the rootLogger. Other levels can be
+# set for individual classes or packages as desired.
+#
+# Examples of setting levels:
+#    log4j.logger.edu.cornell.mannlib.vitro.webapp.ConfigurationProperties=INFO
+#          -- sets INFO level for this one class
+#    log4j.logger.org.apache.catalina=INFO
+#          -- sets INFO level for all classes in "org.apache.catalina" package
+#             and any sub-packages.
+#
+# Documentation for this file can be found here:
+# http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PropertyConfigurator.html#doConfigure(java.lang.String,%20org.apache.log4j.spi.LoggerRepository)
+#
+# More information can be found here:
+# http://logging.apache.org/log4j/1.2/manual.html
+#
+# The "production" version of this file is log4j.properties.
+# debug.log4j.properties exists will be used instead, if it exists, but is not stored in Subversion.
+
+log4j.appender.AllAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.AllAppender.File= ${catalina.base}/logs/${app-name}.all.log
+log4j.appender.AllAppender.MaxFileSize=10MB
+log4j.appender.AllAppender.MaxBackupIndex=10
+log4j.appender.AllAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.AllAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{1}] %m%n
+
+
+log4j.rootLogger=INFO, AllAppender
+
+# These classes are too chatty to display INFO messages.
+log4j.logger.edu.cornell.mannlib.vitro.webapp.startup.StartupStatus=WARN
+log4j.logger.edu.cornell.mannlib.vitro.webapp.servlet.setup.UpdateKnowledgeBase=WARN
+log4j.logger.org.semanticweb.owlapi.rdf.rdfxml.parser=WARN
+
+# Spring as a whole is too chatty to display INFO messages.
+log4j.logger.org.springframework=WARN
+
+# suppress odd warnings from libraries
+log4j.logger.org.apache.jena.sdb.layout2.LoaderTuplesNodes=FATAL
+log4j.logger.org.apache.jena.sdb.sql.SDBConnection=ERROR
+log4j.logger.org.openjena.riot=FATAL
+log4j.logger.org.apache.jena.riot=FATAL
+log4j.logger.org.directwebremoting=WARN

--- a/webapp/src/main/webapp/local/readme
+++ b/webapp/src/main/webapp/local/readme
@@ -1,0 +1,1 @@
+You can override messages and CSS by placing local rules and text in the files here.

--- a/webapp/src/main/webapp/themes/readme
+++ b/webapp/src/main/webapp/themes/readme
@@ -1,0 +1,1 @@
+Add your theme directories here


### PR DESCRIPTION
**[VIVO-1634](https://jira.duraspace.org/browse/VIVO-1643)**:

# What does this pull request do?

Aligns generated VIVO webapp war file to the `installed` exploded webapp in Tomcat.

# What's new?

Additional resource `context.xml`, some webapp readme files, and log4j.properties to be added during the maven build. Also, removal of an exclusion of library jar files.

# How should this be tested?

From vivo-vagrant:

```
cd /work
apt-get -y install tree
cp -r /opt/tomcat/webapps/vivo .
tree vivo > vivo.txt
mkdir vivo-webapp-1.11.0-SNAPSHOT
cd vivo-webapp-1.11.0-SNAPSHOT
cp /home/vagrant/src/VIVO/webapp/target/vivo-webapp-1.11.0-SNAPSHOT.war .
jar xvf vivo-webapp-1.11.0-SNAPSHOT.war
rm -rf vivo-webapp-1.11.0-SNAPSHOT.war
cd ..
tree vivo-webapp-1.11.0-SNAPSHOT > vivo-webapp-1.11.0-SNAPSHOT.txt
diff vivo.txt vivo-webapp-1.11.0-SNAPSHOT.txt
```

# Additional Notes:

Here is the diff between the exploded Tomcat vivo webapp and the generated vivo webapp war file:

```
1c1
< vivo
---
> vivo-webapp-1.11.0-SNAPSHOT
1190,1192d1189
< │           ├── vivo-installer-vivo
< │           │   ├── pom.properties
< │           │   └── pom.xml
2756c2753
< 374 directories, 2379 files
---
> 373 directories, 2377 files
```

# Interested parties

@vivo-project/vivo-committers, @vivo-project/contributors
