### PR TITLE
Replace antrun-plugin <tasks> with <target> in pom.xml files

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -58,9 +58,9 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <delete dir="${vivo-dir}/rdf" />
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>

--- a/installer/solr/pom.xml
+++ b/installer/solr/pom.xml
@@ -72,9 +72,9 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <delete dir="${tomcat-dir}/webapps/${project.build.finalName}" />
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -84,9 +84,9 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <delete dir="${tomcat-dir}/webapps/${project.build.finalName}" />
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1610)**: https://jira.duraspace.org/browse/VIVO-1610

# What does this pull request do?
Changes antrun-plugin to use the target tag instead of the deprecated task tag.

# What's new?
No functional change, just a change in tag name in the antrun-plugin from the deprecated tag to the new.

# How should this be tested?
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
Build VIVO. Observe warnings from antrun plugin 
`[INFO] --- maven-antrun-plugin:1.8:run (remove-webapp) @ vivo-installer-vivo ---
[WARNING] Parameter tasks is deprecated, use target instead
`
* Test that the pull request does what is intended.
Build VIVO with changes to pom.xml files, ensure VIVO/Vitro still builds but warnings no longer appear.

# Interested parties
@VIVO-project/vivo-committers
