### PR TITLE
[VIVO-1670] ORCID - Disable Step 2 and Internationalization

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vivo/orcid/OrcidContextSetup.java
+++ b/api/src/main/java/edu/cornell/mannlib/vivo/orcid/OrcidContextSetup.java
@@ -13,6 +13,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import edu.cornell.mannlib.vivo.orcid.controller.OrcidAbstractHandler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -54,6 +55,10 @@ public class OrcidContextSetup implements ServletContextListener {
 	private void initializeOrcidClientContext(ConfigurationProperties props,
 			StartupStatus ss) {
 		try {
+			if (!"member".equalsIgnoreCase(props.getProperty("orcid.apiLevel", "member"))) {
+				OrcidAbstractHandler.setAPiLevelPublic();
+			}
+
 			Map<Setting, String> settings = new EnumMap<>(Setting.class);
 			settings.put(CLIENT_ID, props.getProperty("orcid.clientId"));
 			settings.put(CLIENT_SECRET,

--- a/api/src/main/java/edu/cornell/mannlib/vivo/orcid/controller/OrcidAbstractHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vivo/orcid/controller/OrcidAbstractHandler.java
@@ -45,6 +45,8 @@ public abstract class OrcidAbstractHandler {
 	protected final OrcidConfirmationState state;
 	protected final UserAccount currentUser;
 
+	private static String apiLevel = "member";
+
 	protected OrcidAbstractHandler(VitroRequest vreq) {
 		this.vreq = vreq;
 		this.occ = OrcidClientContext.getInstance();
@@ -121,7 +123,12 @@ public abstract class OrcidAbstractHandler {
 	protected ResponseValues showConfirmationPage() {
 		Map<String, Object> map = new HashMap<>();
 		map.put("orcidInfo", state.toMap());
+		map.put("orcidApiLevel", apiLevel);
 		return new TemplateResponseValues(TEMPLATE_CONFIRM, map);
+	}
+
+	public static void setAPiLevelPublic() {
+		apiLevel = "public";
 	}
 
 }

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -225,6 +225,13 @@ VitroConnection.DataSource.validationQuery = SELECT 1
    # release, sandbox
 # orcid.api = sandbox
 
+   # Specify the type of API access that you have - public or member
+   #   public - only allows you to confirm ORCID IDs
+   #   member - allows VIVO to write a link to the VIVO profile in the ORCID record
+   # If you only have a public API key, ensure that you have entered public here
+#orcid.apiLevel = public
+
+
 # -----------------------------------------------------------------------------
 # OTHER OPTIONS
 # -----------------------------------------------------------------------------

--- a/webapp/src/main/webapp/i18n/vivo_all.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all.properties
@@ -810,3 +810,101 @@ role_in_presentation_capitalized=Role in Presentation
 advisee_capitalized_first_name=First Name
 advisee_capitalized_lastname=Last Name
 
+# Messages for creating and linking resources (publications)
+create_and_link_enter=Enter {0}:
+create_and_link_claim_for=Claiming works for<br />{0}
+create_and_link_confirm_works=Confirm your work(s)
+create_and_link_confirm_works_intro=Please check that these are the work(s) that you wish to claim, and indicate your relationship with them.
+create_and_link_authors=Authors
+create_and_link_authors_desc=If you are an author of a work, please select your name in the author list.<br />Retrieved metadata may be incomplete. If you can not see your name listed, select "Unlisted Author".
+create_and_link_editors=Editors
+create_and_link_editors_desc=If you edited the work, please select "Editor".
+create_and_link_not_mine_desc=If you do not wish to claim a work, select "This is not my work".
+create_and_link_already_claimed=You have already claimed this work.
+create_and_link_unlisted_author=Unlisted Author
+create_and_link_editor=Editor
+create_and_link_not_mine=This is not my work
+create_and_link_remaining=There are {0} ids remaining
+create_and_link_thank_you=Thank you
+create_and_link_finished=There are no more works left to claim.<br />You may enter more IDs below, or view your profile.
+create_and_link_go_profile=Go to profile
+create_and_link_enter_dois_intro=You may enter one or more DOIs to match, and can be entered either as an ID or URL:<br /><br />e.g.
+create_and_link_enter_dois_supported=Currently, DOIs issued by Crossref, DataCite and mEDRA are supported.<br />Each DOI should be separated by a comma or new line.
+create_and_link_enter_pmid_intro=You may enter one or more PubMed IDs to match. Each ID should be separated by a comma or new line.
+create_and_link_enter_pmid_supported=Note that metadata will be retrieved from Crossref, if the PubMed ID can be resolved to a DOI.
+create_and_link_unknown_profile=Unknown Profile
+create_and_link_unknown_resource=Unknown Resource Type
+create_and_link_unauthorized_for_profile=You do not have permissions to claim for this user
+create_and_link_submit_ids=Submit IDs
+create_and_link_submit_confirm=Confirm
+create_and_link_error=Unable to retrieve citation details
+create_and_link_type_article=Article
+create_and_link_type_article_journal=Journal Article
+create_and_link_type_book=Book
+create_and_link_type_chapter=Chapter
+create_and_link_type_dataset=Dataset
+create_and_link_type_figure=Image
+create_and_link_type_graphic=Image
+create_and_link_type_legal_case=Legal Case
+create_and_link_type_legislation=Legislation
+create_and_link_type_manuscript=Manuscript
+create_and_link_type_map=Map
+create_and_link_type_musical_score=Musical Score
+create_and_link_type_paper_conference=Conference Paper
+create_and_link_type_patent=Patent
+create_and_link_type_personal_communication=Letter
+create_and_link_type_post_weblog=Blog
+create_and_link_type_report=Report
+create_and_link_type_review=Review
+create_and_link_type_speech=Speech
+create_and_link_type_thesis=Thesis
+create_and_link_type_webpage=Webpage
+claim_publications_by=Claim publications by
+claim_publications_by_doi=DOI
+claim_publications_by_pmid=PubMed ID
+
+vis_coauthor_vcard=Include unconfirmed co-authors
+
+add_orcid_id=Add an iD
+
+orcid_title_add = Do you want to add an ORCID iD?
+orcid_step1_add = Step 1: Adding your ORCID iD
+orcid_title_confirm = Do you want to add an ORCID iD?
+orcid_step1_confirm = Step 1: Adding your ORCID iD
+
+orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
+<li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
+<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>VIVO reads your ORCID record.</li> \
+<li>VIVO notes that your ORCID iD is confirmed.</li></ul>
+
+orcid_step1_denied = <p>You denied VIVO's request to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_failed = <p>VIVO failed to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
+
+orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
+
+orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>VIVO adds the external ID.</li></ul> 
+
+orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>
+
+orcid_step2_denied = <p>You denied VIVO's request to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_failed = <p>VIVO failed to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_added = <p>Your ORCID record is linked to VIVO</p>
+
+orcid_button_step1 = Continue Step 1
+orcid_button_step2 = Continue Step 2
+
+orcid_step_completed = (step completed)
+orcid_view_orcid_record = View your ORCID record.
+orcid_return_to_vivo = Return to your VIVO profile page

--- a/webapp/src/main/webapp/templates/freemarker/body/orcid/orcidConfirm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/orcid/orcidConfirm.ftl
@@ -65,81 +65,70 @@ span.completed {
 }
 </style>
 
-<#assign orcidTextOne = "add an" />
-<#assign orcidTextTwo = "Adding" />
+<#assign orcidTitle = i18n().orcid_title_add />
+<#assign orcidStepHeading = i18n().orcid_step1_add />
 <#if (orcidInfo.existingOrcids?size > 0) >
-    <#assign orcidTextOne = "confirm your" />
-    <#assign orcidTextTwo = "Confirming" />
+    <#assign orcidTitle = i18n().orcid_title_confirm />
+    <#assign orcidStepHeading = i18n().orcid_step1_confirm />
 </#if>
 <#assign step2dimmed = (["START", "FAILED_AUTHENTICATE", "DENIED_AUTHENTICATE"]?seq_contains(orcidInfo.progress))?string("dimmed", "") />
-<#assign continueAppears = (["START", "GOT_PROFILE"]?seq_contains(orcidInfo.progress))/>
+<#assign continueAppears = (["START"]?seq_contains(orcidInfo.progress))/>
+<#if orcidApiLevel == "member">
+    <#assign continueAppears = (["START", "GOT_PROFILE"]?seq_contains(orcidInfo.progress))/>
+</#if>
 
 <div>
 
 <section id="orcid-offer" role="region">
-    <h2>Do you want to ${orcidTextOne} ORCID iD?</h2>
-   
+    <h2>${orcidTitle}</h2>
+
     <div class="step">
       <#if "START" == orcidInfo.progress>
-        <h2>Step 1: ${orcidTextTwo} your ORCID iD</h2>
-        <ul>
-          <li>VIVO redirects you to ORCID's web site.</li>
-          <li>You log in to your ORCID account.
-            <ul class="inner"><li>If you don't have an account, you can create one.</li></ul>
-            </li>
-          <li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li>
-          <li>VIVO reads your ORCID record.</li>
-          <li>VIVO notes that your ORCID iD is confirmed.</li>
-        </ul>
+          <h2>${orcidStepHeading}</h2>
+          ${i18n().orcid_step1_description}
       <#elseif "DENIED_AUTHENTICATE" == orcidInfo.progress>
-        <h2>Step 1: ${orcidTextTwo} your ORCID iD</h2>
-        <p>You denied VIVO's request to read your ORCID record.</p>
-        <p>Confirmation can't continue.</p>
+          <h2>${orcidStepHeading}</h2>
+          ${i18n().orcid_step1_denied}
       <#elseif "FAILED_AUTHENTICATE" == orcidInfo.progress>
-        <h2>Step 1: ${orcidTextTwo} your ORCID iD</h2>
-        <p>VIVO failed to read your ORCID record.</p>
-        <p>Confirmation can't continue.</p>
+          <h2>${orcidStepHeading}</h2>
+          ${i18n().orcid_step1_failed}
       <#else>
-        <h2>Step 1: ${orcidTextTwo} your ORCID iD <span class="completed">(step completed)</span></h2>
-        <p>Your ORCID iD is confirmed as ${orcidInfo.orcid}</p>
-        <p><a href="${orcidInfo.orcidUri}" target="_blank">View your ORCID record.</a></p>
+          <h2>${orcidStepHeading} <span class="completed">${i18n().orcid_step_completed}</span></h2>
+          ${i18n().orcid_step1_confirmed(orcidInfo.orcid)}
+          <p><a href="${orcidInfo.orcidUri}" target="_blank">${i18n().orcid_view_orcid_record}</a></p>
       </#if>
     </div>
-    
-    <div class="step ${step2dimmed}">
-      <#if "ID_ALREADY_PRESENT" == orcidInfo.progress>
-        <h2>Step 2 (recommended): Linking your ORCID record to VIVO <span class="completed">(step completed)</span></h2>
-        <p>Your ORCID record already includes a link to VIVO.</p>
-      <#elseif "DENIED_ID" == orcidInfo.progress>
-        <h2>Step 2 (recommended): Linking your ORCID record to VIVO</h2>
-        <p>You denied VIVO's request to add an External ID to your ORCID record.</p>
-        <p>Linking can't continue.</p>
-      <#elseif "FAILED_ID" == orcidInfo.progress>
-        <h2>Step 2 (recommended): Linking your ORCID record to VIVO</h2>
-        <p>VIVO failed to add an External ID to your ORCID record.</p>
-        <p>Linking can't continue.</p>
-      <#elseif "ADDED_ID" == orcidInfo.progress>
-        <h2>Step 2 (recommended): Linking your ORCID record to VIVO <span class="completed">(step completed)</span></h2>
-        <p>Your ORCID record is linked to VIVO</p>
-        <p><a href="${orcidInfo.orcidUri}" target="_blank">View your ORCID record.</a></p>
-      <#else>
-        <h2>Step 2 (recommended): Linking your ORCID record to VIVO</h2>
-        <ul>
-          <li>VIVO redirects you to ORCID's web site</li>
-          <li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li>
-          <li>VIVO adds the external ID.</li>
-        </ul>
-      </#if>
-    </div>
-    
+
+    <#if orcidApiLevel == "member">
+        <div class="step ${step2dimmed}">
+        <#if "ID_ALREADY_PRESENT" == orcidInfo.progress>
+            <h2>${i18n().orcid_step2_heading} <span class="completed">${i18n().orcid_step_completed}</span></h2>
+            ${i18n().orcid_step2_already_present}
+        <#elseif "DENIED_ID" == orcidInfo.progress>
+            <h2>${i18n().orcid_step2_heading}</h2>
+            ${i18n().orcid_step2_denied}
+        <#elseif "FAILED_ID" == orcidInfo.progress>
+            <h2>${i18n().orcid_step2_heading}</h2>
+            ${i18n().orcid_step2_failed}
+        <#elseif "ADDED_ID" == orcidInfo.progress>
+            <h2>${i18n().orcid_step2_heading} <span class="completed">${i18n().orcid_step_completed}</span></h2>
+            ${i18n().orcid_step2_added}
+            <p><a href="${orcidInfo.orcidUri}" target="_blank">${i18n().orcid_view_orcid_record}</a></p>
+        <#else>
+            <h2>${i18n().orcid_step2_heading}</h2>
+            ${i18n().orcid_step2_description}
+        </#if>
+        </div>
+    </#if>
+
     <div class=links>
       <form method="GET" action="${orcidInfo.progressUrl}">
         <p>
           <#if continueAppears>
-            <input type="submit" name="submit" value="Continue <#if "START" == orcidInfo.progress>Step 1<#else>Step 2</#if>" class="submit"/>
+            <input type="submit" name="submit" value="<#if "START" == orcidInfo.progress>${i18n().orcid_button_step1}<#else>${i18n().orcid_button_step1}</#if>" class="submit"/>
             or 
           </#if>
-          <a class="cancel" href="${orcidInfo.profilePage}">Return to your VIVO profile page</a>
+          <a class="cancel" href="${orcidInfo.profilePage}">${i18n().orcid_return_to_vivo}</a>
         </p>
       </form>
     </div>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-orcidInterface.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-orcidInterface.ftl
@@ -26,7 +26,7 @@
     <#if orcidInfo.authorizedToConfirm>
         <script>
             $(document).ready(function(){
-                $('#orcidId a.add-orcidId').replaceWith("<a class='add-orcidId' style='padding-left:20px' href='${orcidInfo.orcidUrl}'><#if orcidInfo.orcids?size == 0>Add an iD<#else>${confirmThis}</#if></a> ");
+                $('#orcidId a.add-orcidId').replaceWith("<a class='add-orcidId' style='padding-left:20px' href='${orcidInfo.orcidUrl}'><#if orcidInfo.orcids?size == 0>${i18n().add_orcid_id}<#else>${confirmThis}</#if></a> ");
             });
         </script>
     </#if>


### PR DESCRIPTION
**[VIVO-1670](https://jira.duraspace.org/browse/VIVO-1670)**: 

# What does this pull request do?
Internationalization and ability to disable step 2 of ORCID interface in configuration.

# What's new?
Adds an option to example.runtime.properties for setting whether it is the "public" or "member" API that you have access to.

Setting this to "public" disables the Step 2 of integration, which uses the member's API to add a link to a person's ORCID profile.

Also, strings have been pulled out of the interface for internationalization.

# How should this be tested?
Set up a VIVO with ORCID integration.

Use without the new setting in runtime.properties, or with the setting orcid.apiLevel = member, the ORCID integration should appear and behave exactly as before.

Setting runtime.properties to orcid.apiLevel = public (and restarting) will result in only Step 1 being visible, and it does not attempt to add a link to your ORCID profile.

# Interested parties
@VIVO-project/vivo-committers
