### PR TITLE
[VIVO-1671] Restrict context node labels added to search index to relationships

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
@@ -1,10 +1,10 @@
 @prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> . 
 @prefix searchIndex: <java:edu.cornell.mannlib.vitro.webapp.searchindex#> .
 
 
 #
-# Specify the SearchIndexExcluders, DocumentModifiers and IndexingUriFinders for VIVO.
+# Specify the SearchIndexExcluders, DocumentModifiers and IndexingUriFinders for VIVO. 
 # These are in addition to the ones specified for VIVO.
 #
 
@@ -28,7 +28,7 @@
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#relates" .
 
 # Some roles look like this:  bearerOf ==> role ==> roleContributesTo
-#                            inheresIn <== role <== contributingRole
+#                            inheresIn <== role <== contributingRole        
 :extension_forContextNodes_role_contributes_1
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -36,7 +36,7 @@
     rdfs:label "Labels across bearerOf/contributesTo" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#roleContributesTo" .
-
+        
 :extension_forContextNodes_role_contributes_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -44,9 +44,9 @@
     rdfs:label "Labels across contributor/inheresIn" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#contributingRole" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-
+        
 # Other roles look like this:  bearerOf ==> role ==> realizedIn
-#                             inheresIn <== role <== realizes
+#                             inheresIn <== role <== realizes        
 :extension_forContextNodes_role_realizedIn_1
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -54,7 +54,7 @@
     rdfs:label "Labels across bearerOf/realizedIn" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/BFO_0000054" .
-
+        
 :extension_forContextNodes_role_realizedIn_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -62,7 +62,7 @@
     rdfs:label "Labels across realizes/inheresIn" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/BFO_0000055" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-
+        
 # Roles on grants look like this:  bearerOf ==> role ==> relatedBy
 #                                 inheresIn <== role <== relates
 :extension_forContextNodes_roles_on_grants_1
@@ -72,7 +72,7 @@
     rdfs:label "Labels across bearerOf/relates" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#relatedBy" .
-
+        
 :extension_forContextNodes_roles_on_grants_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -80,7 +80,7 @@
     rdfs:label "Labels across contributor/relatedBy" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#relates" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-
+        
 
 # ------------------------------------
 
@@ -127,7 +127,7 @@
     :hasSelectQuery """
         PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-		SELECT ?title
+		SELECT ?title 
 		WHERE {
 			?uri obo:ARG_2000028 ?card .
 			?card a vcard:Individual .
@@ -135,7 +135,7 @@
 			?titleHolder vcard:title ?title .
 		}
         """ .
-
+    
 :vivodocumentModifier_EmailAddress
     a   searchIndex:documentBuilding.SelectQueryDocumentModifier ,
         searchIndex:documentBuilding.DocumentModifier ;
@@ -143,7 +143,7 @@
     :hasSelectQuery """
         PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-		SELECT ?email
+		SELECT ?email 
 		WHERE {
 			?uri obo:ARG_2000028 ?card .
 			?card a vcard:Individual .

--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
@@ -1,10 +1,10 @@
 @prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationSetup#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix searchIndex: <java:edu.cornell.mannlib.vitro.webapp.searchindex#> .
 
 
 #
-# Specify the SearchIndexExcluders, DocumentModifiers and IndexingUriFinders for VIVO. 
+# Specify the SearchIndexExcluders, DocumentModifiers and IndexingUriFinders for VIVO.
 # These are in addition to the ones specified for VIVO.
 #
 
@@ -23,11 +23,12 @@
         searchIndex:documentBuilding.DocumentModifier ,
         searchIndex:extensions.LabelsAcrossContextNodes ;
     rdfs:label "Labels across relatedBy/relates" ;
+    :hasTypeRestriction "http://vivoweb.org/ontology/core#Relationship" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#relatedBy" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#relates" .
 
 # Some roles look like this:  bearerOf ==> role ==> roleContributesTo
-#                            inheresIn <== role <== contributingRole        
+#                            inheresIn <== role <== contributingRole
 :extension_forContextNodes_role_contributes_1
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -35,7 +36,7 @@
     rdfs:label "Labels across bearerOf/contributesTo" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#roleContributesTo" .
-        
+
 :extension_forContextNodes_role_contributes_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -43,9 +44,9 @@
     rdfs:label "Labels across contributor/inheresIn" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#contributingRole" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-        
+
 # Other roles look like this:  bearerOf ==> role ==> realizedIn
-#                             inheresIn <== role <== realizes        
+#                             inheresIn <== role <== realizes
 :extension_forContextNodes_role_realizedIn_1
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -53,7 +54,7 @@
     rdfs:label "Labels across bearerOf/realizedIn" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/BFO_0000054" .
-        
+
 :extension_forContextNodes_role_realizedIn_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -61,7 +62,7 @@
     rdfs:label "Labels across realizes/inheresIn" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/BFO_0000055" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-        
+
 # Roles on grants look like this:  bearerOf ==> role ==> relatedBy
 #                                 inheresIn <== role <== relates
 :extension_forContextNodes_roles_on_grants_1
@@ -71,7 +72,7 @@
     rdfs:label "Labels across bearerOf/relates" ;
     :hasIncomingProperty "http://purl.obolibrary.org/obo/RO_0000053" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#relatedBy" .
-        
+
 :extension_forContextNodes_roles_on_grants_2
     a   searchIndex:indexing.IndexingUriFinder ,
         searchIndex:documentBuilding.DocumentModifier ,
@@ -79,7 +80,7 @@
     rdfs:label "Labels across contributor/relatedBy" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#relates" ;
     :hasOutgoingProperty "http://purl.obolibrary.org/obo/RO_0000052" .
-        
+
 
 # ------------------------------------
 
@@ -126,7 +127,7 @@
     :hasSelectQuery """
         PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-		SELECT ?title 
+		SELECT ?title
 		WHERE {
 			?uri obo:ARG_2000028 ?card .
 			?card a vcard:Individual .
@@ -134,7 +135,7 @@
 			?titleHolder vcard:title ?title .
 		}
         """ .
-    
+
 :vivodocumentModifier_EmailAddress
     a   searchIndex:documentBuilding.SelectQueryDocumentModifier ,
         searchIndex:documentBuilding.DocumentModifier ;
@@ -142,7 +143,7 @@
     :hasSelectQuery """
         PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-		SELECT ?email 
+		SELECT ?email
 		WHERE {
 			?uri obo:ARG_2000028 ?card .
 			?card a vcard:Individual .
@@ -150,4 +151,3 @@
 			?emailHolder vcard:email ?email .
 		}
         """ .
-


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1671)**: https://jira.duraspace.org/browse/VIVO-1671

# What does this pull request do?
Restricts addition of labels to the search index for context nodes (aka faux properties).

# What's new?
Labels will be added to a search document for objects connected via a faux property if the property is one of the following:

 Advising Relationship (vivo)
 Authorship (vivo)
 Awarded Degree (vivo)
 Award or Honor Receipt (vivo)
 Contract (vivo)
 Editorship (vivo)
 Grant (vivo)
 Issued Credential (vivo)
 Position (vivo)

which roll up to vivo:Relationship.

e.g. take this relationship:
person vivo:relatedBy authorship
authorship a vivo:Authorship
authorship vivo:relates publication

In this case, ALLTEXT in the search document for person will include the label for the publication.
vs. this relationship:
publication1 vivo:relatedBy organization
instrument a vivo:Instrument
instrument vivo:relates (many, many publications)

the label of the many, many publications will NOT be added to the search document for original publication because the class type of is vivo:Instrument, not one of the relationships listed above.

# How should this be tested?
Before the changes, add triples like above using vivo:relates or vivo:relatedBy that does not connect two objects via a vivo:Relationship. The label for the many, many publications (and the instrument) will be added to the search document for the original publication1. Apply the changes, and now only the label for instrument will be added. 

# Additional Notes:
In summary, VIVO tries to be smart about adding labels for faux properties, but without this restriction it gets overzealous if a site is using vivo:relates/vivo:relatedBy for anything besides faux properties.

# Interested parties
@Stefan-Wolff 
