### PR TITLE
[VIVO-1675] Fix publication counts in histogram

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/CumulativeCountRequestHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/CumulativeCountRequestHandler.java
@@ -3,6 +3,7 @@
 package edu.cornell.mannlib.vitro.webapp.visualization.personpubcount;
 
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
 import edu.cornell.mannlib.vitro.webapp.visualization.exceptions.MalformedQueryParametersException;
@@ -11,17 +12,49 @@ import edu.cornell.mannlib.vitro.webapp.visualization.visutils.QueryRunner;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.VisualizationRequestHandler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.Dataset;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CumulativeCountRequestHandler implements VisualizationRequestHandler {
+    private static final Log log = LogFactory.getLog(CumulativeCountRequestHandler.class);
+
+    // Flag to say whether we have attempted to load column definitions from the runtime.properties
+    private static boolean loadedColumnDefinitions = false;
+
+    // Default configuration for pub lication groups and the types they contain
+    private static String[] pubsGroups = { "Articles", "Books" };
+
+    // Default types for each publications group
+    private static Map<String, String[]> groupTypeMap = Stream.of(
+        new SimpleEntry<String, String[]>(
+                    "Articles", new String[] {
+                            "http://purl.org/ontology/bibo/AcademicArticle",
+                            "http://purl.org/ontology/bibo/Article"
+                        }
+                ),
+        new SimpleEntry<String, String[]>(
+                    "Books", new String[] {
+                            "http://purl.org/ontology/bibo/Book",
+                            "http://purl.org/ontology/bibo/BookSection",
+                            "http://purl.org/ontology/bibo/Chapter",
+                            "http://purl.org/ontology/bibo/EditedBook"
+                        }
+                )
+    ).collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
+
     @Override
     public AuthorizationRequest getRequiredPrivileges() {
         return null;
@@ -39,16 +72,19 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
 
     @Override
     public Object generateAjaxVisualization(VitroRequest vitroRequest, Log log, Dataset dataSource) throws MalformedQueryParametersException {
+        // Ensure that we have loaded any configured definitions
+        loadColumnDefintions(vitroRequest);
+
         String personURI = vitroRequest.getParameter("uri");
 
-        QueryRunner<Set<Activity>> queryManager = new PersonPublicationCountQueryRunner(
+        QueryRunner<Collection<Activity>> queryManager = new PersonPublicationCountQueryRunner(
                 personURI,
                 vitroRequest.getRDFService(),
                 log);
 
-        Set<Activity> authorDocuments = queryManager.getQueryResult();
+        Collection<Activity> authorDocuments = queryManager.getQueryResult();
 
-        Map<Integer, Map<String, Integer>> yearToTypeCount = new TreeMap<Integer, Map<String, Integer>>();
+        Map<Integer, int[]> yearToTypeCount = new TreeMap<Integer, int[]>();
         for (Activity currentActivity : authorDocuments) {
             String activityYearStr = currentActivity.getParsedActivityYear();
             Integer activityYear;
@@ -58,30 +94,36 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
                 activityYear = 0;
             }
 
-            Map<String, Integer> typeCounts;
+            // Get an array for the type counts
+            int[] typeCounts;
             if (yearToTypeCount.containsKey(activityYear)) {
                 typeCounts = yearToTypeCount.get(activityYear);
             } else {
-                typeCounts = new TreeMap<String, Integer>();
+                // Note that we want an array that is one bigger than the number of groups defined (for "other")
+                typeCounts = new int[pubsGroups.length + 1];
                 yearToTypeCount.put(activityYear, typeCounts);
             }
 
-            String activityType = currentActivity.getActivityType();
-            if (StringUtils.isEmpty(activityType)) {
-                activityType = "http://purl.org/ontology/bibo/Document";
-            }
+            // Match the activity types to one of the configured groups
+            int groupIndex = getGroupIndex(currentActivity.getActivityTypes());
 
-            if (typeCounts.containsKey(activityType)) {
-                typeCounts.put(activityType, typeCounts.get(activityType) + 1);
-
+            if (groupIndex < 0) {
+                // Use the first element to count "other"
+                typeCounts[0]++;
             } else {
-                typeCounts.put(activityType, 1);
+                // Add one to the group index (reserve '0' as the "other" count), and increment the relevant count
+                typeCounts[groupIndex + 1]++;
             }
         }
 
         StringBuilder csv = new StringBuilder();
 
-        csv.append("Year,Previous,Other,Books,Articles\n");
+        csv.append("Year,Previous,Other");
+        // Add the configured groups to CSV headings
+        for (String groupName : pubsGroups) {
+            csv.append(",").append(groupName);
+        }
+        csv.append("\n");
 
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
 
@@ -97,40 +139,31 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
         for (Integer year : years) {
             if (year < currentYear - 9) {
                 if (yearToTypeCount.containsKey(year)) {
-                    Map<String, Integer> typeCounts = yearToTypeCount.get(year);
-                    for (Map.Entry<String, Integer> entry : typeCounts.entrySet()) {
-                        publicationCount += entry.getValue();
-                    }
-                }
-            } else {
-                int articleCount = 0;
-                int bookCount = 0;
-                int otherCount = 0;
-
-                if (yearToTypeCount.containsKey(year)) {
-                    Map<String, Integer> typeCounts = yearToTypeCount.get(year);
-                    for (Map.Entry<String, Integer> entry : typeCounts.entrySet()) {
-                        if ("http://purl.org/ontology/bibo/AcademicArticle".equalsIgnoreCase(entry.getKey()) ||
-                                "http://purl.org/ontology/bibo/Article".equalsIgnoreCase(entry.getKey()) ) {
-                            articleCount += entry.getValue();
-                        } else if ("http://purl.org/ontology/bibo/Book".equalsIgnoreCase(entry.getKey()) ||
-                                "http://purl.org/ontology/bibo/BookSection".equalsIgnoreCase(entry.getKey()) ||
-                                "http://purl.org/ontology/bibo/Chapter".equalsIgnoreCase(entry.getKey()) ||
-                                "http://purl.org/ontology/bibo/EditedBook".equalsIgnoreCase(entry.getKey()) ) {
-                            bookCount += entry.getValue();
-                        } else {
-                            otherCount += entry.getValue();
+                    // Too early a year - just get the type counts and add everything to the overall total
+                    int[] typeCounts = yearToTypeCount.get(year);
+                    if (typeCounts != null) {
+                        for (int count : typeCounts) {
+                            publicationCount += count;
                         }
                     }
                 }
+            } else {
+                // Get the type counts for the given year
+                int[] typeCounts = yearToTypeCount.get(year);
+                if (typeCounts == null) {
+                    // No type counts, so create an empty array (must contain one element more than configured groups)
+                    typeCounts = new int[pubsGroups.length + 1];
+                }
 
-                csv.append(year).append(",")
-                        .append(publicationCount).append(",")
-                        .append(otherCount).append(",")
-                        .append(bookCount).append(",")
-                        .append(articleCount).append("\n");
+                // Add the year and overall previous total to the CSV
+                csv.append(year).append(",").append(publicationCount);
 
-                publicationCount += articleCount + bookCount + otherCount;
+                // Add all of the type counts to the CSV, and the overall count
+                for (int count : typeCounts) {
+                    csv.append(",").append(count);
+                    publicationCount += count;
+                }
+                csv.append("\n");
             }
         }
 
@@ -140,5 +173,84 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
     @Override
     public Map<String, String> generateDataVisualization(VitroRequest vitroRequest, Log log, Dataset dataset) throws MalformedQueryParametersException {
         return null;
+    }
+
+    /**
+     * Find an appropriate group index for the type URIs passed.
+     * It treats the configured group order as the priority, so it will return the group
+     * where a type first matches, if there is more than one type passed.
+     *
+     * @param types
+     * @return
+     */
+    private int getGroupIndex(Set<String> types) {
+        int index = 0;
+
+        if (types != null) {
+            for (String column : pubsGroups) {
+                if (groupTypeMap.containsKey(column)) {
+                    for (String mappedType : groupTypeMap.get(column)) {
+                        if (types.contains(mappedType)) {
+                            return index;
+                        }
+                    }
+                }
+
+                index++;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Load column definition from the runtime.properties
+     *
+     * @param vitroRequest
+     */
+    private synchronized void loadColumnDefintions(VitroRequest vitroRequest) {
+        // Only do this if we haven't already loaded a configuration
+        if (!loadedColumnDefinitions) {
+            // Flag that we don't need to do this again
+            loadedColumnDefinitions = true;
+
+            ConfigurationProperties properties = ConfigurationProperties.getBean(vitroRequest);
+
+            if (properties != null) {
+                // Get the configurated group names (e.g. Articles, Books, etc.)
+                String groupsDefsStr = properties.getProperty("histogram.groups");
+                if (!StringUtils.isEmpty(groupsDefsStr)) {
+                    // Create a temporary map for the loaded group configuration
+                    Map<String, String[]> loadedGroupsTypeMap = new HashMap<>();
+
+                    String[] loadedGroups = groupsDefsStr.split("\\s*,\\s*");
+
+                    // For each group
+                    for (String group : loadedGroups) {
+                        // Validate that there is a name
+                        if (StringUtils.isEmpty(group)) {
+                            log.error("Error in groups definition for publications count: " + groupsDefsStr);
+                            return;
+                        }
+
+                        // Get the comma separated list of URIs for this group
+                        String typeStr = properties.getProperty("histogram.types.for." + group);
+                        String[] types = null;
+                        if (StringUtils.isEmpty(typeStr)) {
+                            log.error("Error in type definition for publication count: histogram.types.for." + group);
+                            return;
+                        }
+
+                        // Split the type URIs into an array
+                        // And add it to the group-types map
+                        loadedGroupsTypeMap.put(group, typeStr.split("\\s*,\\s*"));
+                    }
+
+                    // Finished parsing the config, replace the static fields
+                    pubsGroups = loadedGroups;
+                    groupTypeMap = loadedGroupsTypeMap;
+                }
+            }
+        }
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/CumulativeCountRequestHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/CumulativeCountRequestHandler.java
@@ -6,6 +6,7 @@ import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationReques
 import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.visualization.exceptions.MalformedQueryParametersException;
 import edu.cornell.mannlib.vitro.webapp.visualization.valueobjects.Activity;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.QueryRunner;
@@ -121,7 +122,14 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
         csv.append("Year,Previous,Other");
         // Add the configured groups to CSV headings
         for (String groupName : pubsGroups) {
-            csv.append(",").append(groupName);
+            // Retrieve a label from the i18n file
+            String label = I18n.text(vitroRequest, "histogram_label_for_" + groupName);
+            if (!StringUtils.isEmpty(label)) {
+                csv.append(",").append(label);
+            } else {
+                // No label, so use the group name
+                csv.append(",").append(groupName);
+            }
         }
         csv.append("\n");
 
@@ -235,7 +243,6 @@ public class CumulativeCountRequestHandler implements VisualizationRequestHandle
 
                         // Get the comma separated list of URIs for this group
                         String typeStr = properties.getProperty("histogram.types.for." + group);
-                        String[] types = null;
                         if (StringUtils.isEmpty(typeStr)) {
                             log.error("Error in type definition for publication count: histogram.types.for." + group);
                             return;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountQueryRunner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountQueryRunner.java
@@ -167,9 +167,7 @@ public class PersonPublicationCountQueryRunner implements QueryRunner<Collection
 		@Override
 		protected void processQuerySolution(QuerySolution qs) {
 			String documentUri = qs.get("document").asResource().getURI();
-			if (authorDocuments.containsKey(documentUri)) {
-
-			} else {
+			if (!authorDocuments.containsKey(documentUri)) {
 				Activity biboDocument = new Activity(documentUri);
 
 				RDFNode publicationDateNode = qs.get("publicationDate");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountQueryRunner.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountQueryRunner.java
@@ -2,7 +2,10 @@
 
 package edu.cornell.mannlib.vitro.webapp.visualization.personpubcount;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.jena.rdf.model.Model;
@@ -40,7 +43,7 @@ import edu.cornell.mannlib.vitro.webapp.visualization.visutils.QueryRunner;
  * 
  * @author cdtank
  */
-public class PersonPublicationCountQueryRunner implements QueryRunner<Set<Activity>> {
+public class PersonPublicationCountQueryRunner implements QueryRunner<Collection<Activity>> {
 
 	protected static final Syntax SYNTAX = Syntax.syntaxARQ;
 
@@ -115,7 +118,7 @@ public class PersonPublicationCountQueryRunner implements QueryRunner<Set<Activi
 		return sparqlQuery;
 	}
 
-	public Set<Activity> getQueryResult()
+	public Collection<Activity> getQueryResult()
 		throws MalformedQueryParametersException {
 
         if (StringUtils.isNotBlank(this.personURI)) {
@@ -159,27 +162,32 @@ public class PersonPublicationCountQueryRunner implements QueryRunner<Set<Activi
 	}
 
 	private static class PersonPublicationConsumer extends ResultSetConsumer {
-		Set<Activity> authorDocuments = new HashSet<Activity>();
+		Map<String, Activity> authorDocuments = new HashMap<>();
 
 		@Override
 		protected void processQuerySolution(QuerySolution qs) {
-			Activity biboDocument = new Activity(qs.get("document").asResource().getURI());
+			String documentUri = qs.get("document").asResource().getURI();
+			if (authorDocuments.containsKey(documentUri)) {
 
-			RDFNode publicationDateNode = qs.get("publicationDate");
-			if (publicationDateNode != null) {
-				biboDocument.setActivityDate(publicationDateNode.asLiteral().getString());
+			} else {
+				Activity biboDocument = new Activity(documentUri);
+
+				RDFNode publicationDateNode = qs.get("publicationDate");
+				if (publicationDateNode != null) {
+					biboDocument.setActivityDate(publicationDateNode.asLiteral().getString());
+				}
+
+				RDFNode publicationType = qs.get("publicationType");
+				if (publicationType != null) {
+					biboDocument.addActivityType(publicationType.asResource().getURI());
+				}
+
+				authorDocuments.put(documentUri, biboDocument);
 			}
-
-			RDFNode publicationType = qs.get("publicationType");
-			if (publicationType != null) {
-				biboDocument.setActivityType(publicationType.asResource().getURI());
-			}
-
-			authorDocuments.add(biboDocument);
 		}
 
-		public Set<Activity> getAuthorDocuments() {
-			return authorDocuments;
+		public Collection<Activity> getAuthorDocuments() {
+			return authorDocuments.values();
 		}
 	}
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountRequestHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountRequestHandler.java
@@ -2,6 +2,7 @@
 
 package edu.cornell.mannlib.vitro.webapp.visualization.personpubcount;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -65,12 +66,12 @@ VisualizationRequestHandler {
             					.getParameter(
 										VisualizationFrameworkConstants.REQUESTING_TEMPLATE_KEY);  
 
-		QueryRunner<Set<Activity>> queryManager = new PersonPublicationCountQueryRunner(
+		QueryRunner<Collection<Activity>> queryManager = new PersonPublicationCountQueryRunner(
 															personURI,
 															vitroRequest.getRDFService(),
 															log);
 
-		Set<Activity> authorDocuments = queryManager.getQueryResult();
+		Collection<Activity> authorDocuments = queryManager.getQueryResult();
 
 		/*
 		 * Create a map from the year to number of publications. Use the
@@ -125,12 +126,12 @@ VisualizationRequestHandler {
 		String personURI = vitroRequest
 		.getParameter(VisualizationFrameworkConstants.INDIVIDUAL_URI_KEY);
 
-		QueryRunner<Set<Activity>> queryManager = new PersonPublicationCountQueryRunner(
+		QueryRunner<Collection<Activity>> queryManager = new PersonPublicationCountQueryRunner(
 																personURI,
 																vitroRequest.getRDFService(),
 																log);
 
-		Set<Activity> authorDocuments = queryManager.getQueryResult();
+		Collection<Activity> authorDocuments = queryManager.getQueryResult();
 
 		/*
 		 * Create a map from the year to number of publications. Use the
@@ -161,12 +162,12 @@ VisualizationRequestHandler {
 		String visContainer = vitroRequest.getParameter(
 									VisualizationFrameworkConstants.VIS_CONTAINER_KEY);
 
-		QueryRunner<Set<Activity>> queryManager = new PersonPublicationCountQueryRunner(
+		QueryRunner<Collection<Activity>> queryManager = new PersonPublicationCountQueryRunner(
 																personURI,
 																vitroRequest.getRDFService(),
 																log);
 
-		Set<Activity> authorDocuments = queryManager.getQueryResult();
+		Collection<Activity> authorDocuments = queryManager.getQueryResult();
 
 		/*
 		 * Create a map from the year to number of publications. Use the

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountRequestHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/personpubcount/PersonPublicationCountRequestHandler.java
@@ -28,7 +28,7 @@ import edu.cornell.mannlib.vitro.webapp.visualization.visutils.UtilityFunctions;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.VisualizationRequestHandler;
 
 /**
- * 
+ *
  * This request handler is used to serve the content related to an individual's
  * publications over the years like, 1. Sprakline representing this 2. An entire
  * page dedicated to the sparkline vis which will also have links to download
@@ -37,7 +37,7 @@ import edu.cornell.mannlib.vitro.webapp.visualization.visutils.VisualizationRequ
  * years. 4. Downloadable PDf file containing the publications content, among
  * other things. Currently this is disabled because the feature is half-baked.
  * We plan to activate this in the next major release.
- * 
+ *
  * @author cdtank
  */
 public class PersonPublicationCountRequestHandler implements
@@ -64,7 +64,7 @@ VisualizationRequestHandler {
         /* personPublicationCountDynamicActivator.ftl template needs to know which is the requesting template. */
         String requestingTemplate = vitroRequest
             					.getParameter(
-										VisualizationFrameworkConstants.REQUESTING_TEMPLATE_KEY);  
+										VisualizationFrameworkConstants.REQUESTING_TEMPLATE_KEY);
 
 		QueryRunner<Collection<Activity>> queryManager = new PersonPublicationCountQueryRunner(
 															personURI,
@@ -77,7 +77,7 @@ VisualizationRequestHandler {
 		 * Create a map from the year to number of publications. Use the
 		 * BiboDocument's parsedPublicationYear to populate the data.
 		 */
-		Map<String, Integer> yearToPublicationCount = 
+		Map<String, Integer> yearToPublicationCount =
 				UtilityFunctions.getYearToActivityCount(authorDocuments);
 
 		boolean shouldVIVOrenderVis = false;
@@ -96,11 +96,11 @@ VisualizationRequestHandler {
 		 * Computations required to generate HTML for the sparkline & related
 		 * context.
 		 */
-		PersonPublicationCountVisCodeGenerator visualizationCodeGenerator = 
+		PersonPublicationCountVisCodeGenerator visualizationCodeGenerator =
 				new PersonPublicationCountVisCodeGenerator(
-						personURI, 
-						visMode, 
-						visContainer, 
+						personURI,
+						visMode,
+						visContainer,
 						yearToPublicationCount,
 						log);
 
@@ -110,12 +110,12 @@ VisualizationRequestHandler {
 				shouldVIVOrenderVis, requestingTemplate);
 
 	}
-	
+
 	@Override
 	public ResponseValues generateVisualizationForShortURLRequests(
 			Map<String, String> parameters, VitroRequest vitroRequest, Log log,
 			Dataset dataSource) throws MalformedQueryParametersException {
-		throw new UnsupportedOperationException("Person Publication Count Visualization does not provide " 
+		throw new UnsupportedOperationException("Person Publication Count Visualization does not provide "
 					+ "Short URL Response.");
 	}
 
@@ -137,7 +137,7 @@ VisualizationRequestHandler {
 		 * Create a map from the year to number of publications. Use the
 		 * BiboDocument's parsedPublicationYear to populate the data.
 		 */
-		Map<String, Integer> yearToPublicationCount = 
+		Map<String, Integer> yearToPublicationCount =
 				UtilityFunctions.getYearToActivityCount(authorDocuments);
 
 		String authorName = ((PersonPublicationCountQueryRunner) queryManager).getAuthorName();
@@ -173,22 +173,22 @@ VisualizationRequestHandler {
 		 * Create a map from the year to number of publications. Use the
 		 * BiboDocument's parsedPublicationYear to populate the data.
 		 */
-		Map<String, Integer> yearToPublicationCount = 
+		Map<String, Integer> yearToPublicationCount =
 				UtilityFunctions.getYearToActivityCount(authorDocuments);
 
 		/*
 		 * Computations required to generate HTML for the sparkline & related
 		 * context.
 		 */
-		PersonPublicationCountVisCodeGenerator visualizationCodeGenerator = 
+		PersonPublicationCountVisCodeGenerator visualizationCodeGenerator =
 				new PersonPublicationCountVisCodeGenerator(
-						personURI, 
-						visMode, 
-						visContainer, 
+						personURI,
+						visMode,
+						visContainer,
 						yearToPublicationCount,
 						log);
 
-		SparklineData sparklineData = 
+		SparklineData sparklineData =
 				visualizationCodeGenerator.getValueObjectContainer();
 
 		return prepareStandaloneResponse(vitroRequest, sparklineData);
@@ -216,7 +216,7 @@ VisualizationRequestHandler {
 	/**
 	 * Provides response when csv file containing the publication count over the
 	 * years is requested.
-	 * 
+	 *
 	 * @param authorName Name of author
 	 * @param yearToPublicationCount Year / publication counts
 	 */
@@ -235,11 +235,11 @@ VisualizationRequestHandler {
 									+ "_publications-per-year" + ".csv";
 
 		Map<String, String> fileData = new HashMap<String, String>();
-		fileData.put(DataVisualizationController.FILE_NAME_KEY, 
+		fileData.put(DataVisualizationController.FILE_NAME_KEY,
 					 outputFileName);
-		fileData.put(DataVisualizationController.FILE_CONTENT_TYPE_KEY, 
+		fileData.put(DataVisualizationController.FILE_CONTENT_TYPE_KEY,
 					 "application/octet-stream");
-		fileData.put(DataVisualizationController.FILE_CONTENT_KEY, 
+		fileData.put(DataVisualizationController.FILE_CONTENT_KEY,
 					 getPublicationsOverTimeCSVContent(yearToPublicationCount));
 
 		return fileData;
@@ -248,7 +248,7 @@ VisualizationRequestHandler {
 	/**
 	 * Provides response when an entire page dedicated to publication sparkline
 	 * is requested.
-	 * 
+	 *
 	 * @param vreq Vitro Request
 	 * @param valueObjectContainer Sparkline Data
 	 */
@@ -268,7 +268,7 @@ VisualizationRequestHandler {
 	/**
 	 * Provides response when the publication sparkline has to be rendered in
 	 * already existing page, e.g. profile page.
-	 * 
+	 *
 	 * @param vreq Vitro Request
 	 * @param valueObjectContainer Sparkline data
 	 * @param shouldVIVOrenderVis Flag to render visualization

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/valueobjects/Activity.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/valueobjects/Activity.java
@@ -4,6 +4,9 @@ package edu.cornell.mannlib.vitro.webapp.visualization.valueobjects;
 import edu.cornell.mannlib.vitro.webapp.visualization.constants.VOConstants;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.UtilityFunctions;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * This interface will make sure that VOs conveying any person's academic output like publications,
  * grants etc implement certain methods which will be used to generalize methods which are just 
@@ -14,7 +17,7 @@ import edu.cornell.mannlib.vitro.webapp.visualization.visutils.UtilityFunctions;
 public class Activity extends Individual {
 	
 	private String activityDate;
-	private String activityType;
+	private Set<String> activityTypes = new HashSet<String>();
 
 	public Activity(String activityURI) {
 		super(activityURI);
@@ -32,9 +35,9 @@ public class Activity extends Individual {
 		this.setIndividualLabel(activityLabel);
 	}
 
-	public String getActivityType() { return this.activityType; }
+	public Set<String> getActivityTypes() { return this.activityTypes; }
 
-	public void setActivityType(String activityType) { this.activityType = activityType; }
+	public void addActivityType(String activityType) { this.activityTypes.add(activityType); }
 	
 	/**
 	 * This method will be called to get the final/inferred year for the publication. 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/valueobjects/Activity.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/valueobjects/Activity.java
@@ -9,28 +9,28 @@ import java.util.Set;
 
 /**
  * This interface will make sure that VOs conveying any person's academic output like publications,
- * grants etc implement certain methods which will be used to generalize methods which are just 
- * interested in certain common properties like what was the year in which the activity was 
- * published (or started). 
+ * grants etc implement certain methods which will be used to generalize methods which are just
+ * interested in certain common properties like what was the year in which the activity was
+ * published (or started).
  * @author cdtank
  */
 public class Activity extends Individual {
-	
+
 	private String activityDate;
 	private Set<String> activityTypes = new HashSet<String>();
 
 	public Activity(String activityURI) {
 		super(activityURI);
 	}
-	
+
 	public String getActivityURI() {
 		return this.getIndividualURI();
 	}
-	
+
 	public String getActivityLabel() {
 		return this.getIndividualLabel();
 	}
-	
+
 	public void setActivityLabel(String activityLabel) {
 		this.setIndividualLabel(activityLabel);
 	}
@@ -38,21 +38,21 @@ public class Activity extends Individual {
 	public Set<String> getActivityTypes() { return this.activityTypes; }
 
 	public void addActivityType(String activityType) { this.activityTypes.add(activityType); }
-	
+
 	/**
-	 * This method will be called to get the final/inferred year for the publication. 
+	 * This method will be called to get the final/inferred year for the publication.
 	 * The 2 choices, in order, are,
-	 * 		1. parsed year from xs:DateTime object saved in core:dateTimeValue 
-	 * 		2. Default Publication Year 
+	 * 		1. parsed year from xs:DateTime object saved in core:dateTimeValue
+	 * 		2. Default Publication Year
 	 */
 	public String getParsedActivityYear() {
-		
+
 		return UtilityFunctions.getValidYearFromCoreDateTimeString(activityDate,
 				VOConstants.DEFAULT_ACTIVITY_YEAR);
 	}
-	
+
 	/**
-	 * This method should be used to get the raw date & not the parsed publication year. 
+	 * This method should be used to get the raw date & not the parsed publication year.
 	 * For the later use getParsedPublicationYear.
 	 */
 	public String getActivityDate() {

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
@@ -56,7 +56,7 @@
                             .rangeRound([height, 0]);
 
                     var z = d3.scaleOrdinal()
-                            .range(["#777777", "#1f77b4", "#aec7e8", "#ff7f0e"]);
+                        .range(["#777777", "#1f77b4", "#aec7e8", "#ff7f0e", "#ff0000"]);
 
                     d3.csv(dataUrl, function (d, i, columns) {
                         for (i = 1, t = 0; i < columns.length; ++i) t += d[columns[i]] = +d[columns[i]];
@@ -112,15 +112,19 @@
                                 .attr("dy", "0.32em")
                                 .attr("fill", "#000");
 
+                        var keyOffset = 200;
+                        if (keys.length > 4)
+                            keyOffset = 240;
+
                         var legend = g.append("g")
                                 .attr("font-family", "sans-serif")
                                 .attr("font-size", 10)
                                 .attr("text-anchor", "end")
                                 .selectAll("g")
-                                .data(keys.slice(1,4).reverse())
+                                .data(keys.slice(1,5).reverse())
                                 .enter().append("g")
                                 .attr("transform", function (d, i) {
-                                    return "translate(-" + (200 - i * 80) +",-25)";
+                                    return "translate(-" + (keyOffset - i * 80) +",-25)";
                                 });
 
                         legend.append("rect")


### PR DESCRIPTION
**[VIVO-1675](https://jira.duraspace.org/browse/VIVO-1675)**:

# What does this pull request do?
Corrects problem where a publication that has been assigned multiple types gets counted more than once.

# What's new?
Assigns all publication types to a single publication activity, rather than creating an additional activity for each publication type.

Uses the configuration of "groups" (Articles, Books) and their associated types as a priority list so that the activity is counted in the first matching group, or "other" if none.

There is a hardcoded default configuration for "Articles" and "Books", however there are optional runtime.properties entries that allow you to change the configuration:

e.g.

histogram.groups = Articles, Books

histogram.types.for.Articles = http://purl.org/ontology/bibo/AcademicArticle, http://purl.org/ontology/bibo/Article

histogram.types.for.Books = http://purl.org/ontology/bibo/Book, http://purl.org/ontology/bibo/BookSection, http://purl.org/ontology/bibo/Chapter, http://purl.org/ontology/bibo/EditedBook

Note, these are all comma separated lists - the groups key provides the names of each group, and the associated types.for key contains the URIs of publication classes to be counted in that group.

Priority is given to the first group in the list.

# How should this be tested?
Using Tenderfoot, create a profile with one publication, published in the last 10 years (so it appears on the chart).
Add two publication types to the same publication - e.g. Academic Article and Book Chapter.

In the existing code, you should see the one publication counted as both an article and a book.

Applying this fix will show the publication counted only once in the chart.

# Interested parties
@VIVO-project/vivo-committers
