### PR TITLE
[VIVO-1676] Fix for Plum Analytics badge on wrong publications

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
@@ -137,8 +137,10 @@
                 <#assign plumIdParam = "isbn=${statement.isbn13}">
             <#elseif statement.oclc??>
                 <#assign plumIdParam = "oclc=${statement.oclc}">
+            <#else>
+                <#assign plumIdParam = "">
             </#if>
-            <#if plumIdParam??>
+            <#if plumIdParam?has_content>
                 <div class="plum-print-wrapper" style="display: inline-block; vertical-align: top">
                     <a class="plumx-plum-print-popup"
                        href="https://plu.mx/plum/a/?${plumIdParam}"


### PR DESCRIPTION
**[VIVO-1676](https://jira.duraspace.org/browse/VIVO-1676)**:

# What does this pull request do?
Fixes problem where Plum Analytics badges incorrectly appear on publications without a recognised ID.

# How should this be tested?
Create a profile with two publications:

a) An Academic Article with a DOI that shows a Plum Analytics badge
b) A DataSet, without any identifier properties set.

In the existing code, the Plum Analytics badge will be shown on both the academic article and the dataset.

With the fix applied, only the academic article will display a plum analytics badge.

# Interested parties
@VIVO-project/vivo-committers
