### PR TITLE
[VIVO-1677] Change legacy Google Maps link to use https

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceSetup.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceSetup.ftl
@@ -110,7 +110,7 @@ var i18nStrings = {
 <#if googleMapsKey??>
     ${scripts.add('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=${googleMapsKey}"></script>')}
 <#else>
-    ${scripts.add('<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>')}
+    ${scripts.add('<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>')}
 </#if>
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/jquery-ui/js/jquery-ui-1.12.1.min.js"></script>',
 			  '<script type="text/javascript" src="${urls.base}/js/jquery_plugins/jquery.blockUI.js"></script>',


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1677)**:  Chrome blocks Google Maps js include if site uses https

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content
Note, I changed the link to https rather than making it protocol independent. From https://www.paulirish.com/2010/the-protocol-relative-url/ ...

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset.

# What does this pull request do?
Change the protocol of one javascript link from http to https.

# What's new?
Nothing

# How should this be tested?
Try loading the Map of Science over https without setting the Google Maps API key in runtime.properties. It will not work. It will say the visualization is being refreshed but it will never load.
Do the same with the change to https. The page will load.

# Additional Notes:
Using the API without the API key will cause Google maps to throw an error and overlay a 'for development' text string, but hey, at least it works at all.

# Interested parties
@roflinn 
