### PR TITLE
[VIVO-1687] Set Tenderfoot pub chart height

### DIFF
--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
@@ -9,14 +9,14 @@
 <#assign obo_RO53 = "http://purl.obolibrary.org/obo/RO_0000053">
 
 <#assign isInvestigator = ( p.hasVisualizationStatements(propertyGroups, "${obo_RO53}", "${core}InvestigatorRole") ||
-                            p.hasVisualizationStatements(propertyGroups, "${obo_RO53}", "${core}PrincipalInvestigatorRole") || 
+                            p.hasVisualizationStatements(propertyGroups, "${obo_RO53}", "${core}PrincipalInvestigatorRole") ||
                             p.hasVisualizationStatements(propertyGroups, "${obo_RO53}", "${core}CoPrincipalInvestigatorRole") ) >
 
 <#if (isAuthor || isInvestigator)>
- 
+
     ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/visualization/visualization.css" />')}
     <#assign standardVisualizationURLRoot ="/visualization">
-        
+
         <#if isAuthor>
             ${scripts.add('<script type="text/javascript" src="${urls.base}/js/d3.min.js"></script>')}
 
@@ -24,7 +24,7 @@
             <#assign mapOfScienceIcon = "${urls.images}/visualization/mapofscience/scimap_icon.png">
             <#assign coAuthorVisUrl = individual.coAuthorVisUrl()>
             <#assign mapOfScienceVisUrl = individual.mapOfScienceUrl()>
-            
+
             <span id="publicationsHeading">${i18n().publications_in_vivo}</span>
 
             <svg width="100%" id="publicationsChart" onload="renderPublicationsChart()" onresize="renderPublicationsChart()">
@@ -46,6 +46,8 @@
                             width = (chartWidth - margin.left - margin.right),
                             height = (chartHeight - margin.top - margin.bottom),
                             g = svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+                    svg.attr("width", chartWidth).attr("height",chartHeight)
 
                     var x = d3.scaleBand()
                             .rangeRound([0, width])


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1687)**: https://jira.duraspace.org/browse/VIVO-1687

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://stackoverflow.com/questions/12830897/svg-renders-but-gets-cut-off-in-firefox-only-why

# What does this pull request do?
Resolves an issue where the Tenderfoot publication bar chart is cropped in Firefox 

# What's new?
Sets the SVG width in javascript explicitly for Firefox compatibility

# How should this be tested?
Change theme to Tenderfoot. Look at bar chart in Firefox. It should be cropped in the vertical direction.
<img width="598" alt="Screen Shot 2019-04-18 at 2 43 24 PM" src="https://user-images.githubusercontent.com/10748475/56508692-2e149c80-64e2-11e9-91a1-435b6b0f0464.png">

Redeploy with changes. It should show the whole chart.

# Interested parties
@grahamtriggs 
