### PR TITLE
[VIVO-1656] Extension mechansim for passing properties to templates

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/VIVOIndividualResponseBuilderExtension.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/individual/VIVOIndividualResponseBuilderExtension.java
@@ -1,0 +1,74 @@
+package edu.cornell.mannlib.vitro.webapp.controller.individual;
+
+import edu.cornell.mannlib.vitro.webapp.config.ConfigurationProperties;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.Map;
+
+public class VIVOIndividualResponseBuilderExtension implements IndividualResponseBuilder.ExtendedResponse {
+    public static class Setup implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent sce) {
+            IndividualResponseBuilder.registerExtendedResponse(new VIVOIndividualResponseBuilderExtension());
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent sce) {
+
+        }
+    }
+
+    @Override
+    public void addOptions(VitroRequest vreq, Map<String, Object> body) {
+        addAltMetricOptions(vreq, body);
+        addPlumPrintOptions(vreq, body);
+    }
+
+    private void addAltMetricOptions(VitroRequest vreq, Map<String, Object> body) {
+        ConfigurationProperties properties = ConfigurationProperties.getBean(vreq);
+
+        if (properties != null) {
+            String enabled        = properties.getProperty("resource.altmetric", "enabled");
+            String displayTo      = properties.getProperty("resource.altmetric.displayto", "right");
+            String badgeType      = properties.getProperty("resource.altmetric.badge-type", "donut");
+            String badgeHideEmpty = properties.getProperty("resource.altmetric.hide-no-mentions", "true");
+            String badgePopover   = properties.getProperty("resource.altmetric.badge-popover", "right");
+            String badgeDetails   = properties.getProperty("resource.altmetric.badge-details");
+
+            if (!"disabled".equalsIgnoreCase(enabled)) {
+                body.put("altmetricEnabled", true);
+
+                body.put("altmetricDisplayTo", displayTo);
+                body.put("altmetricBadgeType", badgeType);
+                if ("true".equalsIgnoreCase(badgeHideEmpty)) {
+                    body.put("altmetricHideEmpty", true);
+                }
+                body.put("altmetricPopover", badgePopover);
+                body.put("altmetricDetails", badgeDetails);
+            }
+        }
+    }
+
+    private void addPlumPrintOptions(VitroRequest vreq, Map<String, Object> body) {
+        ConfigurationProperties properties = ConfigurationProperties.getBean(vreq);
+
+        if (properties != null) {
+            String enabled = properties.getProperty("resource.plum-print", "enabled");
+            String displayTo = properties.getProperty("resource.plum-print.displayto", "right");
+            String printHideEmpty = properties.getProperty("resource.plum-print.hide-when-empty", "true");
+            String printPopover = properties.getProperty("resource.plum-print.popover", "right");
+            String printSize = properties.getProperty("resource.plum-print.size", "medium");
+
+            if (!"disabled".equalsIgnoreCase(enabled)) {
+                body.put("plumPrintEnabled", true);
+
+                body.put("plumPrintDisplayTo", displayTo);
+                body.put("plumPrintHideEmpty", "true".equalsIgnoreCase(printHideEmpty) ? "true" : "false");
+                body.put("plumPrintPopover", printPopover);
+                body.put("plumPrintSize", printSize);
+            }
+        }
+    }
+}

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -86,6 +86,9 @@ edu.cornell.mannlib.vitro.webapp.dao.jena.VClassGroupCache$Setup
 
 edu.cornell.mannlib.vivo.orcid.OrcidContextSetup
 
+# Register the extensions to the IndividualResponseBuilder (e.g. alt metric, plum analytics)
+edu.cornell.mannlib.vitro.webapp.controller.individual.VIVOIndividualResponseBuilderExtension$Setup
+
 # This should be near the end, because it will issue a warning if the connection to Solr times out.
 edu.cornell.mannlib.vitro.webapp.servlet.setup.SolrSmokeTest
 


### PR DESCRIPTION
**[VIVO-1656](https://jira.duraspace.org/browse/VIVO-1656)**:

# What does this pull request do?
Uses the extension mechanism to pass the Plum Analytics and AltMetric options to the individual templates.

Requires the corresponding pull request from Vitro.

# What's new?
No change in functionality, this is an architectural improvement.

# How should this be tested?
Visit the page of any "individual" in VIVO. Should work exactly as it did before.

In particular, check publications that previously display Plum Analytics / AltMetric badges - these badges should still appear as before.

# Interested parties
@VIVO-project/vivo-committers
