### PR TITLE
[VIVO-1704] - Fix unbound research area query

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-researchAreaOf.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-researchAreaOf.xml
@@ -56,6 +56,8 @@
              }
              OPTIONAL {
                 <precise-subquery>?subject ?property ?person .</precise-subquery>
+                ?person core:relatedBy ?position .
+                ?position a core:Position .
                 ?position core:dateTimeInterval ?dateTimeInterval .
                 ?dateTimeInterval core:end ?dateTimeEndValue .
                 ?dateTimeEndValue core:dateTime ?dateTimeEnd .


### PR DESCRIPTION
Jira Issue: **[Research area display slow to load, or never loads](https://jira.duraspace.org/browse/VIVO-1704)**

# What does this pull request do?
Improves performance of concept pages that include 'research area of' relationship.

# What's new?
Nothing, this is a performance improvement 

# How should this be tested?
Create a 'has research area of' relationship between a concept and a person without a position. The ?position variable is unbound, meaning you get results such as this...

![Screen Shot 2019-10-02 at 9 48 16 AM](https://user-images.githubusercontent.com/10748475/66059777-d4d18000-e4f9-11e9-9ea1-0f28f4f47224.png)

Apply the fix, concepts should load much faster.

# Interested parties
@vivo-project/vivo-committers 
