### PR TITLE
[VIVO-1726] - Co-author visualization: Change cursor type when hovering over link

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coAuthorPersonLevelD3.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coAuthorPersonLevelD3.ftl
@@ -201,12 +201,14 @@ $(document).ready(function(){
             if (opacity > .5) {
                 var chordInfoDiv = d3.select('#chord-info-div');
                 chordInfoDiv.style('display', 'none');
+                $('#chord').css('cursor', 'default');
             } else {
                 var hoverEvent = d3.event;
                 var topPos = hoverEvent.pageY - 60;
                 var leftPos = hoverEvent.pageX + 10;
 
                 var chord = d3.select('#chord').node();
+                $('#chord').css('cursor', 'pointer');
                 var chordInfoDiv = d3.select('#chord-info-div');
                 var hoverMsg = labels[i] + "<br/>";
                 if (i > 0) {
@@ -241,7 +243,7 @@ $(document).ready(function(){
 
     function chord_click() {
         return function (g, i) {
-            if (i > 0) {
+            if (i >= 0) {
                 window.location.href = getWellFormedURLs(uris[i], "profile");
             }
         };

--- a/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
@@ -205,12 +205,14 @@ $(document).ready(function(){
             if (opacity > .5) {
                 var chordInfoDiv = d3.select('#chord-info-div');
                 chordInfoDiv.style('display', 'none');
+                $('#chord').css('cursor', 'default');
             } else {
                 var hoverEvent = d3.event;
                 var topPos = hoverEvent.pageY - 60;
                 var leftPos = hoverEvent.pageX + 10;
 
                 var chord = d3.select('#chord').node();
+                $('#chord').css('cursor', 'pointer');
                 var chordInfoDiv = d3.select('#chord-info-div');
                 var hoverMsg = labels[i] + "<br/>";
                 if (i > 0) {
@@ -245,7 +247,7 @@ $(document).ready(function(){
 
     function chord_click() {
         return function (g, i) {
-            if (i > 0) {
+            if (i >= 0) {
                 window.location.href = getWellFormedURLs(uris[i], "profile");
             }
         };


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1726)**: Co-author visualization: Change cursor type when hovering over link

# What does this pull request do?
Makes two small changes to the co-author and co-pi chord visualizations.

# What's new?
Change the mouse icon if a user hovers over a link in the chord diagram visualization. Additionally, link the primary author's profile page in the diagram to match the other co-authors.

# How should this be tested?
View a co-author diagram. Confirm the mouse pointer icon does not change when hovering over the links on the edges of the chord diagram.

<img width="308" alt="Screen Shot 2019-10-21 at 4 02 47 PM" src="https://user-images.githubusercontent.com/10748475/67247013-5cd1e800-f41d-11e9-9b98-0d5f7758f357.png">

Apply change to templates. Confirm the mouse pointer changes to the 'hand' icon when hovering over links. 

<img width="250" alt="Screen Shot 2019-10-21 at 4 03 24 PM" src="https://user-images.githubusercontent.com/10748475/67247055-8d198680-f41d-11e9-9930-f5676ed67d4b.png">

Additionally, confirm that the primary person (who the visualization is created for) is now linked within the chord diagram.

# Interested parties
@VIVO-project/vivo-committers
