### PR TITLE
[VIVO-1733] - Fix visualization tool css selector

### DIFF
--- a/webapp/src/main/webapp/css/visualization/visualization.css
+++ b/webapp/src/main/webapp/css/visualization/visualization.css
@@ -106,9 +106,6 @@ span.incomplete-data-holder,
 /* ---------------------------*/
 /* Visualization Tools -------*/
 /* ---------------------------*/
-section.visualizationTools h3, p {
-    margin-left:20px;
-}
-section.visualizationTools p {
+section.visualizationTools h3, section.visualizationTools p {
     margin-left:20px;
 }


### PR DESCRIPTION
**[JIRA Issue](https://jira.duraspace.org/browse/VIVO-1733)**: VIVO-1733 

# What does this pull request do?
Changes a css selector so it only affects `<p>` tags within the intended visualization tools, rather than potentially all `<p>` tags on the page.

The margin is usually overwritten by wilma.css, but here is an example where it did not for a project I am working on and the visualization css was applied outside its intended scope:
<img width="1083" alt="Screen Shot 2019-11-01 at 3 45 56 PM" src="https://user-images.githubusercontent.com/10748475/68058501-e35cb400-fcbe-11e9-80cd-a54b65a23c4d.png">


# How should this be tested?
Visit http://localhost:8080/vivo/vis/tools. Note 20px indent of text.
<img width="1066" alt="Screen Shot 2019-11-01 at 3 35 23 PM" src="https://user-images.githubusercontent.com/10748475/68058106-af34c380-fcbd-11e9-9095-d1f73a1beab9.png">

Apply change.
Visit same page. Display should be unchanged for visualization tools text.

# Interested parties
@VIVO-project/vivo-committers
