### PR TITLE
Add CollectionProcess and CurationProcess

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -9456,7 +9456,64 @@ This class allows for linking an author to a publication while indicating inform
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents educational training that has been received.</obo:IAO_0000115>
         <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This connects person to their academic degree through this educational training, but can also be used when the training does not result in a degree.</vitro:descriptionAnnot>
     </owl:Class>
+    
+    
+    
+    <!-- http://vivoweb.org/ontology/core#CollectionProcess -->
 
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#CollectionProcess">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+		<obo:IAO_0000112 xml:lang="en">Jane is collector of Collection c. Jane is a person.  Jane bearer_of collectorRole r.  r realized_in CollectionProcess p.  p has_output c.</obo:IAO_0000112><!-- example of usage -->
+		<obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/><!-- curation status = being worked on -->
+		<obo:IAO_0000115 xml:lang="en">A process which has as its output, a collection of material entities and/or information content entities</obo:IAO_0000115><!-- definition -->
+		<obo:IAO_0000116 xml:lang="en">Under development.  The restriction applies to has output assertions.  Collections of material entities are material entities.  Collections of information content entities are information content entities.</obo:IAO_0000116><!-- editor's administrative note -->
+		<obo:IAO_0000117 xml:lang="en">Person: Michael Conlon</obo:IAO_0000117><!-- name of editor -->
+		<obo:IAO_0000119 xml:lang="en"></obo:IAO_0000119><!-- citation -->
+        <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Process resulting in a collection</vitro:descriptionAnnot><!-- Displayed by VIVO/Vitro in ontology editor -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002234"/><!-- has output -->
+                <owl:allValuesFrom>
+                	<owl:Class>
+                		<owl:unionOf rdf:parseType="Collection">
+                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/> <!-- Material Entity -->
+                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/> <!-- Information Content Entity -->
+                		</owl:unionOf>
+            		</owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Collection Process</rdfs:label>
+    </owl:Class>
+  
+    
+    
+    <!-- http://vivoweb.org/ontology/core#CurationProcess -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#CurationProcess">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+		<obo:IAO_0000112 xml:lang="en">Jane is curator of Collection c. Jane is a person.  Jane bearer_of curatorRole r.  r realized_in CurationProcess p.  p has_input c.</obo:IAO_0000112><!-- example of usage -->
+		<obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/><!-- curation status = being worked on -->
+		<obo:IAO_0000115 xml:lang="en">A process which has as its input, a collection of material entities and/or information content entities</obo:IAO_0000115><!-- definition -->
+		<obo:IAO_0000116 xml:lang="en">Under development.  The restriction applies to has input assertions.  Collections of material entities are material entities.  Collection of information content entities are information content entities.</obo:IAO_0000116><!-- editor's administrative note -->
+		<obo:IAO_0000117 xml:lang="en">PERSON: Michael Conlon</obo:IAO_0000117><!-- name of editor -->
+		<obo:IAO_0000119 xml:lang="en"></obo:IAO_0000119><!-- citation -->
+        <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The curation of a collection</vitro:descriptionAnnot><!-- Displayed by VIVO/Vitro in ontology editor -->
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/><!-- has input -->
+                <owl:allValuesFrom>
+                	<owl:Class>
+                		<owl:unionOf rdf:parseType="Collection">
+                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/> <!-- Material Entity -->
+                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/> <!-- Information Content Entity -->
+                		</owl:unionOf>
+            		</owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Curation Process</rdfs:label>
+    </owl:Class>
 
 
     <!-- http://vivoweb.org/ontology/core#EmeritusFaculty -->

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -9470,19 +9470,6 @@ This class allows for linking an author to a publication while indicating inform
 		<obo:IAO_0000117 xml:lang="en">Person: Michael Conlon</obo:IAO_0000117><!-- name of editor -->
 		<obo:IAO_0000119 xml:lang="en"></obo:IAO_0000119><!-- citation -->
         <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Process resulting in a collection</vitro:descriptionAnnot><!-- Displayed by VIVO/Vitro in ontology editor -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002234"/><!-- has output -->
-                <owl:allValuesFrom>
-                	<owl:Class>
-                		<owl:unionOf rdf:parseType="Collection">
-                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/> <!-- Material Entity -->
-                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/> <!-- Information Content Entity -->
-                		</owl:unionOf>
-            		</owl:Class>
-                </owl:allValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Collection Process</rdfs:label>
     </owl:Class>
   
@@ -9499,19 +9486,6 @@ This class allows for linking an author to a publication while indicating inform
 		<obo:IAO_0000117 xml:lang="en">PERSON: Michael Conlon</obo:IAO_0000117><!-- name of editor -->
 		<obo:IAO_0000119 xml:lang="en"></obo:IAO_0000119><!-- citation -->
         <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The curation of a collection</vitro:descriptionAnnot><!-- Displayed by VIVO/Vitro in ontology editor -->
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002233"/><!-- has input -->
-                <owl:allValuesFrom>
-                	<owl:Class>
-                		<owl:unionOf rdf:parseType="Collection">
-                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/> <!-- Material Entity -->
-                    		<rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/> <!-- Information Content Entity -->
-                		</owl:unionOf>
-            		</owl:Class>
-                </owl:allValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:label xml:lang="en">Curation Process</rdfs:label>
     </owl:Class>
 


### PR DESCRIPTION


**[VIVO-1700](https://jira.lyrasis.org/browse/VIVO-1700)**:

Pull request addresses two issues:
* https://jira.lyrasis.org/browse/VIVO-1700 Collection Process
* https://jira.lyrasis.org/browse/VIVO-1699 Curation Process

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

Thessen, AE, Woodburn, M, Koureas, D, Paul, D, Conlon, M, Shorthouse, DP and Ramdeen, S. 2019. Proper Attribution for Curation and Maintenance of Research Collections: Metadata Recommendations of the RDA/TDWG Working Group. Data Science Journal, 18: 54, pp. 1–11. DOI: https://doi.org/10.5334/dsj-2019-054

# What does this pull request do?
Adds two new classes to the VIVO ontology: CurationProcess and CollectionProcess 

# What's new?

To represent that Jane is the Collector of a particular Collection z, we say Jane has a CollectorRole, the role is realized in the CollectionProcess that has the Collection as output.

Usage:

    w a person
    x a CollectionRole
    y a CollectionProcess
    z a Collection

    w bearer of x
    x realized in y
    y has output z

# How should this be tested?

VIVO does not typically display processes in the UI.  SPARQL can be used to see that the class and its attributes have been added to the triple store.

# Additional Notes:
The VIVO software does not refer to CollectionProcess nor to CurationProcess.  These additions are to the ontology only.

# Interested parties
@vivo-project/vivo-ontologists 
