### PR TITLE
[VIVO-1737] Update Error Prone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,34 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Profile for Error Prone plugin -->
+            <id>errorprone</id>
+            <activation>
+                <jdk>[1.8,12)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <fork>true</fork>
+                            <compilerArgs combine.children="append">
+                                <arg>-Xplugin:ErrorProne</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>2.3.4</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>
@@ -277,15 +305,7 @@
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
                     </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.3.2</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
**[VIVO-1737](https://jira.lyrasis.org/browse/VIVO-1737)**:

# What does this pull request do?

Updates the Error Prone plugin to for compile time analysis to the latest release, and moves the configuration to a profile that is enabled for JDK 1.8 - 11.

Builds with Error Prone fail when using JDK 12+, so by not enabling on those JDKs enables people to use them for their environment - Vitro/VIVO builds on JDK 13, but it is not tested.

This also allows developers to disable the Error Prone plugin from the command line, however I would not recommend this in general as it quickly and easily catches bad code.

# What's new?
Nothing specific, although the Error Prone plugin is now faster and includes some extra checks

# How should this be tested?
Run mvn clean install - build should complete.
Ideally, test with multiple JDK versions

# Interested parties
@VIVO-project/vivo-committers
