### PR TITLE
Update example default triple store from SDB to TDB

### DIFF
--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -26,7 +26,7 @@
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
     :hasFileStorage               :ptiFileStorage ;
-    :hasContentTripleSource       :sdbContentTripleSource ;
+    :hasContentTripleSource       :tdbContentTripleSource ;
     :hasConfigurationTripleSource :tdbConfigurationTripleSource ;
     :hasTBoxReasonerModule        :jfactTBoxReasonerModule .
 
@@ -89,15 +89,15 @@
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 
-:sdbContentTripleSource
-    a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
-        vitroWebapp:modules.tripleSource.ContentTripleSource .
+#:sdbContentTripleSource
+#    a   vitroWebapp:triplesource.impl.sdb.ContentTripleSourceSDB ,
+#        vitroWebapp:modules.tripleSource.ContentTripleSource .
 
-#:tdbContentTripleSource
-#    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
-#        vitroWebapp:modules.tripleSource.ContentTripleSource ;
-#    # May be an absolute path, or relative to the Vitro home directory.
-#    :hasTdbDirectory "tdbContentModels" .
+:tdbContentTripleSource
+    a   vitroWebapp:triplesource.impl.tdb.ContentTripleSourceTDB ,
+        vitroWebapp:modules.tripleSource.ContentTripleSource ;
+    # May be an absolute path, or relative to the Vitro home directory.
+    :hasTdbDirectory "tdbContentModels" .
 
 #:sparqlContentTripleSource
 #    a   vitroWebapp:triplesource.impl.sparql.ContentTripleSourceSPARQL ,

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -57,13 +57,16 @@ argon2.memory = 1024
 argon2.time = 1000
 
   #
+  # NOTE: VitroConnection.DataSource.* properties are only used in conjuction with
+  #       an SDB triple store.
+  #
   # The basic parameters for a database connection. Change the end of the
   # URL to reflect your database name (if it is not "vitrodb"). Change the username
   # and password to match the authorized database user you created.
   #
-VitroConnection.DataSource.url = jdbc:mysql://localhost/vitrodb
-VitroConnection.DataSource.username = vitrodbUsername
-VitroConnection.DataSource.password = vitrodbPassword
+# VitroConnection.DataSource.url = jdbc:mysql://localhost/vitrodb
+# VitroConnection.DataSource.username = vitrodbUsername
+# VitroConnection.DataSource.password = vitrodbPassword
 
   #
   # Email parameters which VIVO can use to send mail. If these are left empty,
@@ -118,14 +121,14 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
   # The maximum number of active connections in the database connection pool.
   # Increase this value to support a greater number of concurrent page requests.
   #
-VitroConnection.DataSource.pool.maxActive = 40
+# VitroConnection.DataSource.pool.maxActive = 40
 
   #
   # The maximum number of database connections that will be allowed
   # to remain idle in the connection pool.  Default is 25%
   # of the maximum number of active connections.
   #
-VitroConnection.DataSource.pool.maxIdle = 10
+# VitroConnection.DataSource.pool.maxIdle = 10
 
 
 # -----------------------------------------------------------------------------
@@ -136,9 +139,9 @@ VitroConnection.DataSource.pool.maxIdle = 10
   # Parameters to change in order to use VIVO with a database other than
   # MySQL.
   #
-VitroConnection.DataSource.dbtype = MySQL
-VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
-VitroConnection.DataSource.validationQuery = SELECT 1
+# VitroConnection.DataSource.dbtype = MySQL
+# VitroConnection.DataSource.driver = com.mysql.jdbc.Driver
+# VitroConnection.DataSource.validationQuery = SELECT 1
 
   # Note: the above parameters allow you to change the relational database that
   # is used as the back end for Jena SDB. If you want to use a triple store


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/VIVO-1741

# What does this pull request do?
No functional changes.
This pull-request updates the example.applicationSetup.n3 file to reference a TDB triple store by default (instead of SDB).
Note: Support for SDB still exists.

# How should this be tested?
Use the example.applicationSetup.n3 configuration in a new VIVO installation. 
Verify that VIVO works as expected.
Verify that content is created in the TDB "hasTdbDirectory" location.

# Interested parties
@VIVO-project/vivo-committers
