### PR TITLE
Fix typo in AddReviewerRoleToPersonGenerator

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddReviewerRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddReviewerRoleToPersonGenerator.java
@@ -97,7 +97,7 @@ public class AddReviewerRoleToPersonGenerator extends AddRoleToPersonTwoStageGen
 			"<http://vivoweb.org/ontology/core#Video> " +
 			"<http://purl.org/ontology/bibo/Webpage> " +
 			"<http://purl.org/ontology/bibo/Website> " +
-			"<http://vivoweb.org/ontology/core#WorkingPaper";
+			"<http://vivoweb.org/ontology/core#WorkingPaper>";
 
 	/**
 	 *  Each subclass generator will return its own type of option here:
@@ -106,8 +106,7 @@ public class AddReviewerRoleToPersonGenerator extends AddRoleToPersonTwoStageGen
 	@Override
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
 		// UQAM-Linguistic-Management Replacing the above hard coding assignment by a dynamic assignment that takes into account the linguistic context
-		ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-		return filedOptions;
+		return GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
 
 		//    	return new ConstantFieldOptions(
 		//		        "",  "Select type",

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
@@ -34,16 +34,16 @@ public class GeneratorUtil {
 	/*
 	 * UQAM-Linguistic-Management Help to generate the labels of scrollDowm list in proper language
 	 */
-	static public ConstantFieldOptions buildConstantFieldOptions(VitroRequest vreq, String DESCRIBE_QUERY) throws Exception {
+	static public ConstantFieldOptions buildConstantFieldOptions(VitroRequest vreq, String describeQuery) throws Exception {
 
-		List<List<String>> options = builFieldOptionsList(vreq, DESCRIBE_QUERY);
+		List<List<String>> options = builFieldOptionsList(vreq, describeQuery);
 		ConstantFieldOptions filedOptions = new  ConstantFieldOptions("" , options);
 		return filedOptions;
 	}
 	/*
 	 * UQAM-Linguistic-Management Help to generate the labels of scrollDowm list in proper language
 	 */
-	static public List<List<String>> builFieldOptionsList(VitroRequest vreq, String DESCRIBE_QUERY) throws Exception {
+	static public List<List<String>> builFieldOptionsList(VitroRequest vreq, String describeQuery) throws Exception {
 
 		I18nBundle i18n = I18n.bundle(vreq);
 		String i18nSelectType = i18n.text("select_type");
@@ -57,7 +57,7 @@ public class GeneratorUtil {
 		RDFService rdfService = vreq.getRDFService();
 
 		Model constructedModel = RDFServiceUtils.parseModel(
-				rdfService.sparqlDescribeQuery(DESCRIBE_QUERY, RDFService.ModelSerializationFormat.N3),
+				rdfService.sparqlDescribeQuery(describeQuery, RDFService.ModelSerializationFormat.N3),
 				RDFService.ModelSerializationFormat.N3);
 
 		Query query = QueryFactory.create(GET_LABEL_QUERY.replaceAll("LANGUAGE", lang.toString())) ;


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/VIVO-1774

# What does this pull request do?
- Fixes a type in the constant "describe-query" of AddReviewerRoleToPersonGenerator
- Updates related variable names to use standard Java syntax

# How should this be tested?
Test steps detailed in description of: https://jira.lyrasis.org/browse/VIVO-1774

# Interested parties
@MichelHeon / @VIVO-project/vivo-committers
