### PR TITLE
Include language dependencies in build all of the time

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -108,11 +108,11 @@
             <type>tar.gz</type>
         </dependency>
         <!-- Dependency for multilingual support -->
-        <!-- dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vivo-languages-home</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vivo-languages-home-core</artifactId>
+            <version>${project.version}</version>
             <type>tar.gz</type>
-        </dependency -->
+        </dependency>
     </dependencies>
 </project>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -45,16 +45,16 @@
                                     <type>war</type>
                                 </overlay>
                                 <!-- Overlays for multilingual support -->
-                                <!-- overlay>
+                                <overlay>
                                     <groupId>org.vivoweb</groupId>
-                                    <artifactId>vitro-languages-webapp</artifactId>
+                                    <artifactId>vitro-languages-webapp-core</artifactId>
                                     <type>war</type>
                                 </overlay>
                                 <overlay>
                                     <groupId>org.vivoweb</groupId>
-                                    <artifactId>vivo-languages-webapp</artifactId>
+                                    <artifactId>vivo-languages-webapp-core</artifactId>
                                     <type>war</type>
-                                </overlay -->
+                                </overlay>
                             </overlays>
                             <webResources>
                                 <resource>
@@ -153,18 +153,18 @@
             <type>war</type>
         </dependency>
         <!-- Dependencies for multilingual support -->
-        <!-- dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vitro-languages-webapp</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vitro-languages-webapp-core</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vivo-languages-webapp</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vivo-languages-webapp-core</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
-        </dependency -->
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -21,6 +21,9 @@ edu.cornell.mannlib.vitro.webapp.config.RevisionInfoSetup
 
 edu.cornell.mannlib.vitro.webapp.email.FreemarkerEmailFactory$Setup
 
+# For multiple language support
+edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup
+
 edu.cornell.mannlib.vitro.webapp.servlet.setup.ConfigurationModelsSetup
 edu.cornell.mannlib.vitro.webapp.servlet.setup.ContentModelSetup
 
@@ -66,9 +69,6 @@ org.vivoweb.webapp.startup.TemplateModelSetup
 org.vivoweb.webapp.startup.SearchResultTemplateModelSetup
 
 edu.ucsf.vitro.opensocial.OpenSocialSmokeTests
-
-# For multiple language support
-edu.cornell.mannlib.vitro.webapp.i18n.selection.LocaleSelectionSetup
 
 # The search indexer uses a "public" permission, so the PropertyRestrictionPolicyHelper
 #   and the PermissionRegistry must already be set up.


### PR DESCRIPTION
Move "LocaleSelectionSetup" higher in the startup list so that the Vitro:RDFFilesLoader has the locale info available on its startup

See https://github.com/vivo-project/Vitro/pull/160 for full details

## Related pull-requests
* https://github.com/vivo-project/Vitro-languages/pull/18
* https://github.com/vivo-project/VIVO-languages/pull/41
* https://github.com/vivo-project/Vitro/pull/160

Part of resolution to: https://jira.lyrasis.org/browse/VIVO-1836
