### PR TITLE
i18n: Widget control buttons for capability map are in english in french version

### DIFF
--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -26,6 +26,13 @@ var demos = [[
 if (!console) var console = {
     log : function() {}
 };
+if (typeof i18nStringsCap == 'undefined')
+{
+    var i18nStringsCap = {
+        term: 'Term',
+        group: 'Group'
+    }
+};
 var schemes = {
     "white" : {
         "backgroundcolor" : "#FFFFFF",
@@ -395,7 +402,7 @@ DetailsPanel.prototype.showDetails = function(mode, id) {
     if (mode != "group") {
         $(this.panel)
             .empty()
-            .append(title = $("<h2>Term: " + decodeURIComponent(id) + "</h2>")
+            .append(title = $("<h2>" + i18nStringsCap.term + ": " + decodeURIComponent(id) + "</h2>")
                 .bind("click", function() {
                     highlight(id);
                     detailsPane.showDetails(mode, id);
@@ -454,7 +461,7 @@ DetailsPanel.prototype.groupInfo = function(i, group, mode, id) {
     });
     return $("<div/>")
         .append(
-            $("<h2>" + "Group: " + group.capabilities.map(function(c) {
+            $("<h2>" + i18nStringsCap.group + ": " + group.capabilities.map(function(c) {
                 return decodeURIComponent(c.term);
             }).join(", ") + "</h2>")
                 .bind("click", function() {

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -15,6 +15,10 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
         var loadedConcepts = $.ajax({


### PR DESCRIPTION
**Thank you for submitting a pull request! Title this pull request with a brief description of what the pull request fixes/improves/changes. Please describe the pull request in detail using the template below.**


**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1847)**

**[Second required PR](https://github.com/vivo-project/VIVO-languages/pull/55)**

# What does this pull request do?
The PR will add multi-language support for a part of the capability map and the title of the site.

# What's new?
This PR will add two variables for the multi-language support in the needed js-file and use them. If they are not provided by the language-templates the previous terms ("Term" and "Group") will be used.

# How should this be tested?
You go to the capability map, search for something (with sample data for example "Rhetoric") and then click the "informations" Button. The Group and the Term should be multi-lingual. Just like the title of the page.

# Additional Notes:
* the multi-language tags come with another PR in the VIVO-languages Repository

**Note:** Ignore the name of the branch, i accidentally used the number of my other ticket. 1847 would be the right one