### PR TITLE
i18n: title tag and headings in capability map are in english in french version

### DIFF
--- a/webapp/src/main/webapp/i18n/vivo_all.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all.properties
@@ -579,6 +579,8 @@ vis_caching_process = What's involved in the caching process?
 vis_tools_note_two = To this end we have devised a caching solution which will retain information about the hierarchy of organizations -- namely, which publications are attributed to which organizations -- by storing the RDF model.
 vis_tools_note_three = We're currently caching these models in memory.  The cache is built (only once) on the first user request after a server restart.  Because of this, the same model will be served until the next restart. This means that the data in these models may become stale depending upon when it was last created. This works well enough for now. In future releases we will improve this solution so that models are stored on disk and periodically updated.
 vis_tools_note_four = The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the "refresh cache" link above to do this without a restart.
+capability_map=Capability Map
+term_capitalized=Term
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)

--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -26,6 +26,13 @@ var demos = [[
 if (!console) var console = {
     log : function() {}
 };
+if (typeof i18nStringsCap == 'undefined')
+{
+    var i18nStringsCap = {
+        term: 'Term',
+        group: 'Group'
+    }
+};
 var schemes = {
     "white" : {
         "backgroundcolor" : "#FFFFFF",
@@ -395,7 +402,7 @@ DetailsPanel.prototype.showDetails = function(mode, id) {
     if (mode != "group") {
         $(this.panel)
             .empty()
-            .append(title = $("<h2>Term: " + decodeURIComponent(id) + "</h2>")
+            .append(title = $("<h2>" + i18nStringsCap.term + ": " + decodeURIComponent(id) + "</h2>")
                 .bind("click", function() {
                     highlight(id);
                     detailsPane.showDetails(mode, id);
@@ -454,7 +461,7 @@ DetailsPanel.prototype.groupInfo = function(i, group, mode, id) {
     });
     return $("<div/>")
         .append(
-            $("<h2>" + "Group: " + group.capabilities.map(function(c) {
+            $("<h2>" + i18nStringsCap.group + ": " + group.capabilities.map(function(c) {
                 return decodeURIComponent(c.term);
             }).join(", ") + "</h2>")
                 .bind("click", function() {

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -15,6 +15,10 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
         var loadedConcepts = $.ajax({

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -16,11 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1847)**

**[Second required PR](https://github.com/vivo-project/VIVO-languages/pull/56)**

# What does this pull request do?
The PR will add multi-language support for a part of the capability map and the title of the site.

# What's new?
This PR will add two variables for the multi-language support in the needed js-file and use them. If they are not provided by the languashould this be tested?
You go to the capability map, search for something (with sample data for example "Rhetoric") and then click the "informations" Button. The Group and the Term should be multi-lingual. Just like the title of the page.

# Additional Notes:
* the multi-language tags come with another PR in the VIVO-languages Repository

**Note:** Ignore the name of the branch, i accidentally used the number of my other ticket. 1847 would be the right onege-templates the previous terms ("Term" and "Group") will be used.

# How should this be tested?
You go to the capability map, search for something (with sample data for example "Rhetoric") and then click the "informations" Button. The Group and the Term should be multi-lingual. Just like the title of the page.

# Additional Notes:
* the multi-language tags come with another PR in the VIVO-languages Repository
