### PR TITLE
[VIVO-1846] i18n: Added i18n support for Capability Map control buttons

### DIFF
--- a/webapp/src/main/webapp/i18n/vivo_all.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all.properties
@@ -581,6 +581,14 @@ vis_tools_note_three = We're currently caching these models in memory.  The cach
 vis_tools_note_four = The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the "refresh cache" link above to do this without a restart.
 capability_map=Capability Map
 term_capitalized=Term
+pause=pause
+resume=resume
+show_group_labels=show group labels
+hide_group_labels=hide group labels
+delete_selected=Delete selected
+remove_capability=Remove capability
+remove_group=Remove group
+expand=Expand
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)

--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -30,7 +30,15 @@ if (typeof i18nStringsCap == 'undefined')
 {
     var i18nStringsCap = {
         term: 'Term',
-        group: 'Group'
+        group: 'Group',
+        pause: 'pause',
+        resume: 'resume',
+        show_group_labels: 'show group labels',
+        hide_group_labels: 'hide group labels',
+        delete_selected: 'delete selected',
+        remove_capability: 'Remove capability',
+        remove_group: 'Remove group',
+        expand: 'Expand'
     }
 };
 var schemes = {
@@ -410,7 +418,7 @@ DetailsPanel.prototype.showDetails = function(mode, id) {
                 .css("cursor", "pointer")
                 .prepend($("<span/>").addClass("orange-square"))
             )
-            .append($("<button>Remove capability</button>")
+            .append($("<button>" + i18nStringsCap.remove_capability + "</button>")
                 .bind("click", function() {
                     g.removeCapability(id);
                     that.clearDetails();
@@ -418,7 +426,7 @@ DetailsPanel.prototype.showDetails = function(mode, id) {
                 })
             )
             .append($("<span> </span>"))
-            .append($("<button>Expand</button>")
+            .append($("<button>" + i18nStringsCap.expand + "</button>")
                 .bind("click", function() {
                     expandLastQuery = 1;
                     addKwd(decodeURIComponent(id));
@@ -471,7 +479,7 @@ DetailsPanel.prototype.groupInfo = function(i, group, mode, id) {
                 .css("cursor", "pointer")
                 .prepend($("<span/>").addClass("blue-circle"))
         )
-        .append($("<button>Remove group</button>")
+        .append($("<button>" + i18nStringsCap.remove_group + "</button>")
             .bind("click", function() {
                 g.removeGroup(group);
                 that.clearDetails();
@@ -814,7 +822,7 @@ var render = function() {
 
     }
     force.on("tick", function() {
-        $("#log button:first-child").html("pause");
+        $("#log button:first-child").html(i18nStringsCap.pause);
     	force2.start();
     	node.call(updateNode);
     	anchorNode.each(function(d, i) {
@@ -839,30 +847,30 @@ var render = function() {
     });
 
     // refresh UI
-    $("#log").empty().append($("<button>pause</button>")
+    $("#log").empty().append($("<button>" + i18nStringsCap.pause + "</button>")
         .bind("click", function() {
-            if ($(this).html() != "resume") {
-                $(this).html("resume");
+            if ($(this).html() != i18nStringsCap.resume) {
+                $(this).html(i18nStringsCap.resume);
                 force.stop();
                 force2.stop();
             } else {
-                $(this).html("pause");
+                $(this).html(i18nStringsCap.pause);
                 force.resume();
                 force2.resume();
             }
         })
-    ).append(" ").append($("<button>hide group labels</button>")
+    ).append(" ").append($("<button>" + i18nStringsCap.hide_group_labels + "</button>")
         .bind("click", function() {
-            if ($(this).html() != "show group labels") {
-                $(this).html("show group labels");
+            if ($(this).html() != i18nStringsCap.show_group_labels) {
+                $(this).html(i18nStringsCap.show_group_labels);
                 $(".label-group").css("visibility", "hidden");
             } else {
-                $(this).html("hide group labels");
+                $(this).html(i18nStringsCap.hide_group_labels);
                 $(".label-group").css("visibility", "visible");
             }
         })
     );
-    $("#log_printout").empty().append($("<button>Delete selected</button>").bind("click", function() {
+    $("#log_printout").empty().append($("<button>" + i18nStringsCap.delete_selected + "</button>").bind("click", function() {
         $("input[type=checkbox]:checked").each(function() {
             g.removeCapability($(this).attr("name"));
             $(this).parent().remove();

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -17,7 +17,15 @@ ${stylesheets.add(
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
         term: '${i18n().term_capitalized}',
-        group: '${i18n().group_capitalized}'
+        group: '${i18n().group_capitalized}',
+        pause: '${i18n().pause}',
+        resume: '${i18n().resume}',
+        show_group_labels: '${i18n().show_group_labels}',
+        hide_group_labels: '${i18n().hide_group_labels}',
+        delete_selected: '${i18n().delete_selected}',
+        remove_capability: '${i18n().remove_capability}',
+        remove_group: '${i18n().remove_group}',
+        expand: '${i18n().expand}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1846)**

**[2nd related PR](https://github.com/vivo-project/VIVO-languages/pull/58)**

# What does this pull request do?
This PR will add i18n support for the Capability Map control buttons

# What's new?
Now the control buttons (and the functionality behind it) use i18n properties and because of that are multilingual.
* added 6 new i18n strings to property-file
* added them to the JS-file and use them for the label and also for the button functionality (for example switch pause <-> resume)

# How should this be tested?
* Go to the Capability Map
* search a existing term (for sample data "Rhetoric" is available)
* all buttons (pause <-> resume, hide group labels <-> show group labels, expand, remove group, remove capability, delete selected) should be in all 6 existing languages in VIVO-Languages  
** to see "resume" and "show group labels" you need to click "pause" and "hide group labels"

# Additional Notes:
The ticket is about french but i added it for all available languages in VIVO-languages

