### PR TITLE
Ensure 'other' in Individual->Teaching->advisees->type is translated

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddRoleToPersonTwoStageGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddRoleToPersonTwoStageGenerator.java
@@ -415,7 +415,7 @@ public abstract class AddRoleToPersonTwoStageGenerator extends BaseEditConfigura
 
         //make list of type URIs from options, this can be called with null since
 	    //ConstantFieldOptions doesn't use any of the arguments.
-	    Map<String,String> options = fieldOptions.getOptions(null, null, null) ;
+	    Map<String,String> options = fieldOptions.getOptions(null, null, null, null) ;
 
         if (options != null && options.size() > 0) {
             List<String> typeUris = new ArrayList<String>();


### PR DESCRIPTION
Partial resolution to: https://jira.lyrasis.org/browse/VIVO-1881

# What does this pull request do?
Adds an I18NBundle parameter to `FieldOptions` so that drop-down lists may be translated.

# How should this be tested?
1. Go to person/individual
1. Select the "Teaching" tab
1. Select "advisees"
1. View "Advising Relationship Type" dropdown list
   - Verify the term "Other" is translated

# Related pull-request(s)
- https://github.com/vivo-project/Vitro/pull/171

# Interested parties
@VIVO-project/vivo-committers