### PR TITLE
Issue/vivo 1908

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAttendeeRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAttendeeRoleToPersonGenerator.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddAttendeeRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -21,49 +22,28 @@ public class AddAttendeeRoleToPersonGenerator extends AddRoleToPersonTwoStageGen
     /** Editor role involves hard-coded options for the "right side" of the role or activity. */
     @Override
     FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-        //        return new ConstantFieldOptions(
-        //        "", "Select type",
-        //        "http://purl.org/NET/c4dm/event.owl#Event", "Event",
-        //        "http://vivoweb.org/ontology/core#Competition", "Competition",
-        //        "http://purl.org/ontology/bibo/Conference", "Conference",
-        //        "http://vivoweb.org/ontology/core#Course", "Course",
-        //        "http://vivoweb.org/ontology/core#Exhibit", "Exhibit",
-        //        "http://purl.org/ontology/bibo/Hearing", "Hearing",
-        //        "http://purl.org/ontology/bibo/Interview", "Interview",
-        //        "http://vivoweb.org/ontology/core#Meeting", "Meeting",
-        //        "http://purl.org/ontology/bibo/Performance", "Performance",
-        //        "http://vivoweb.org/ontology/core#Presentation", "Presentation",
-        //        "http://vivoweb.org/ontology/core#InvitedTalk", "Invited Talk",
-        //        "http://purl.org/ontology/bibo/Workshop", "Workshop",
-        //        "http://vivoweb.org/ontology/core#EventSeries", "Event Series",
-        //        "http://vivoweb.org/ontology/core#ConferenceSeries", "Conference Series",
-        //        "http://vivoweb.org/ontology/core#SeminarSeries", "Seminar Series",
-        //        "http://vivoweb.org/ontology/core#WorkshopSeries", "Workshop Series"
-        //        );
-        // UQAM-Linguistic-Management Replacing the above hard coding assignment by a dynamic assignment that takes into account the linguistic context
-        ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-        return filedOptions;
+        return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"), 
+                "http://purl.org/NET/c4dm/event.owl#Event",
+                "http://vivoweb.org/ontology/core#Competition",
+                "http://purl.org/ontology/bibo/Conference",
+                "http://vivoweb.org/ontology/core#Course",
+                "http://vivoweb.org/ontology/core#Exhibit",
+                "http://purl.org/ontology/bibo/Hearing",
+                "http://purl.org/ontology/bibo/Interview",
+                "http://vivoweb.org/ontology/core#Meeting",
+                "http://purl.org/ontology/bibo/Performance",
+                "http://vivoweb.org/ontology/core#Presentation",
+                "http://vivoweb.org/ontology/core#InvitedTalk",
+                "http://purl.org/ontology/bibo/Workshop",
+                "http://vivoweb.org/ontology/core#EventSeries",
+                "http://vivoweb.org/ontology/core#ConferenceSeries",
+                "http://vivoweb.org/ontology/core#SeminarSeries",
+                "http://vivoweb.org/ontology/core#WorkshopSeries"
+                );
     }
-    /*
-     * UQAM-Linguistic-Management get attributes for this specific subject
-     */
-    private static String DESCRIBE_QUERY = " describe "+
-            "<http://purl.org/NET/c4dm/event.owl#Event> "+
-            "<http://vivoweb.org/ontology/core#Competition> "+
-            "<http://purl.org/ontology/bibo/Conference> "+
-            "<http://vivoweb.org/ontology/core#Course> "+
-            "<http://vivoweb.org/ontology/core#Exhibit> "+
-            "<http://purl.org/ontology/bibo/Hearing> "+
-            "<http://purl.org/ontology/bibo/Interview> "+
-            "<http://vivoweb.org/ontology/core#Meeting> "+
-            "<http://purl.org/ontology/bibo/Performance> "+
-            "<http://vivoweb.org/ontology/core#Presentation> "+
-            "<http://vivoweb.org/ontology/core#InvitedTalk> "+
-            "<http://purl.org/ontology/bibo/Workshop> "+
-            "<http://vivoweb.org/ontology/core#EventSeries> "+
-            "<http://vivoweb.org/ontology/core#ConferenceSeries> "+
-            "<http://vivoweb.org/ontology/core#SeminarSeries> "+
-            "<http://vivoweb.org/ontology/core#WorkshopSeries> ";
+
     boolean isShowRoleLabelField() {
         return false;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddClinicalRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddClinicalRoleToPersonGenerator.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddClinicalRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -22,30 +23,20 @@ public class AddClinicalRoleToPersonGenerator extends AddRoleToPersonTwoStageGen
 	}
 
 	/** Clinical role involves hard-coded options for the "right side" of the role or activity. */
-    @Override
-    FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-		//		return new ConstantFieldOptions(
-		//		        "",  "Select one",
-		//		        "http://vivoweb.org/ontology/core#Project", "Project",
-		//		        "http://purl.obolibrary.org/obo/ERO_0000005", "Service"
-		//		);
-
-		//UQAM-Linguistic-Management Replacing the above hard coding assigment by a dynamic assigment that takes into account the linguistic context
-		ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-		return filedOptions;
-	}
-	/*
-	 * UQAM-Linguistic-Management get attributes for this specific subject
-	 */
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://vivoweb.org/ontology/core#Project> "+
-			"<http://purl.obolibrary.org/obo/ERO_0000005>";
-	//isShowRoleLabelField remains true for this so doesn't need to be overwritten
 	@Override
-	boolean isShowRoleLabelField(){
+	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+	            vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+	            I18n.bundle(vreq).text("select_type"),
+	            "http://vivoweb.org/ontology/core#Project",
+	            "http://purl.obolibrary.org/obo/ERO_0000005" /* Service */
+	            );
+	}
+
+	@Override
+    boolean isShowRoleLabelField(){
 	    return true;
 	}
-
 
        /*
         * Use the methods below to change the date/time precision in the

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorshipToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorshipToPersonGenerator.java
@@ -23,9 +23,10 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
 import edu.cornell.mannlib.vitro.webapp.dao.VitroVocabulary;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUtils;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
-import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
@@ -109,8 +110,7 @@ public class AddEditorshipToPersonGenerator extends VivoBaseGenerator implements
                 setName("documentType").
                 setValidators( list("nonempty") ).
                 // UQAM-Linguistic-Management vreq for linguistic context
-                setOptions( new ConstantFieldOptions("documentType", getDocumentTypeLiteralOptions(vreq) ))
-                );
+                setOptions( getDocumentTypeLiteralOptions(vreq) ) );
 
         conf.addField( new FieldVTwo().
                 setName("documentLabel").
@@ -204,42 +204,22 @@ public class AddEditorshipToPersonGenerator extends VivoBaseGenerator implements
         return null;
     }
 
-    private List<List<String>> getDocumentTypeLiteralOptions(VitroRequest vreq) throws Exception {
-		//UQAM-Linguistic-Management Replacing hard coding assigment by a dynamic assigment that takes into account the linguistic context
-		List<List<String>> value =  GeneratorUtil.builFieldOptionsList(vreq, DESCRIBE_QUERY);
-		return value;
-
-//        List<List<String>> literalOptions = new ArrayList<List<String>>();
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Book", "Book"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Chapter", "Chapter"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/EditedBook", "Edited Book"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Film", "Film"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Magazine", "Magazine"));
-//        literalOptions.add(list("http://vivoweb.org/ontology/core#Newsletter", "Newsletter"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Newspaper", "Newspaper"));
-//        literalOptions.add(list("http://vivoweb.org/ontology/core#NewsRelease", "News Release"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Report", "Report"));
-//        literalOptions.add(list("http://vivoweb.org/ontology/core#Video", "Video"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Webpage", "Webpage"));
-//        literalOptions.add(list("http://purl.org/ontology/bibo/Website", "Website"));
-//        return literalOptions;
+    private FieldOptions getDocumentTypeLiteralOptions(VitroRequest vreq) throws Exception {
+        return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"),
+                "http://purl.org/ontology/bibo/Book",
+                "http://purl.org/ontology/bibo/Chapter",
+                "http://purl.org/ontology/bibo/EditedBook",
+                "http://purl.org/ontology/bibo/Film",
+                "http://purl.org/ontology/bibo/Magazine",
+                "http://vivoweb.org/ontology/core#Newsletter",
+                "http://purl.org/ontology/bibo/Newspaper",
+                "http://vivoweb.org/ontology/core#NewsRelease",
+                "http://purl.org/ontology/bibo/Report",
+                "http://vivoweb.org/ontology/core#Video",
+                "http://purl.org/ontology/bibo/Webpage",
+                "http://purl.org/ontology/bibo/Website");
     }
-	/*
-	 * UQAM-Linguistic-Management get attributes for this specific subject
-	 */
-	private static String DESCRIBE_QUERY = " describe "+
-	        "<http://purl.org/ontology/bibo/Book> " +
-	        "<http://purl.org/ontology/bibo/Chapter> " +
-	        "<http://purl.org/ontology/bibo/EditedBook> " +
-	        "<http://purl.org/ontology/bibo/Film> " +
-	        "<http://purl.org/ontology/bibo/Magazine> " +
-	        "<http://vivoweb.org/ontology/core#Newsletter> " +
-	        "<http://purl.org/ontology/bibo/Newspaper> " +
-	        "<http://vivoweb.org/ontology/core#NewsRelease> " +
-	        "<http://purl.org/ontology/bibo/Report> " +
-	        "<http://vivoweb.org/ontology/core#Video> " +
-	        "<http://purl.org/ontology/bibo/Webpage> " +
-	        "<http://purl.org/ontology/bibo/Website> ";
-
 
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddMemberRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddMemberRoleToPersonGenerator.java
@@ -41,87 +41,44 @@ public class AddMemberRoleToPersonGenerator extends AddRoleToPersonTwoStageGener
 
 
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-
-
-/*
-
-		return new ConstantFieldOptions(
-				"",selectType,
-				"http://vivoweb.org/ontology/core#AcademicDepartment","Academic Department",
-				"http://vivoweb.org/ontology/core#Association","Association",
-				"http://vivoweb.org/ontology/core#Center","Center",
-				"http://vivoweb.org/ontology/core#ClinicalOrganization","Clinical Organization",
-				"http://vivoweb.org/ontology/core#College","College",
-				"http://vivoweb.org/ontology/core#Committee","Committee",
-				"http://vivoweb.org/ontology/core#Company","Company",
-				"http://vivoweb.org/ontology/core#Consortium","Consortium",
-				"http://vivoweb.org/ontology/core#CoreLaboratory","Core Laboratory",
-				"http://vivoweb.org/ontology/core#Department","Department",
-				"http://vivoweb.org/ontology/core#Division","Division",
-				"http://vivoweb.org/ontology/core#ExtensionUnit","Extension Unit",
-				"http://vivoweb.org/ontology/core#Foundation","Foundation",
-				"http://vivoweb.org/ontology/core#FundingOrganization","Funding Organization",
-				"http://vivoweb.org/ontology/core#GovernmentAgency","Government Agency",
-				"http://xmlns.com/foaf/0.1/Group","Group",
-				"http://vivoweb.org/ontology/core#Hospital","Hospital",
-				"http://vivoweb.org/ontology/core#Institute","Institute",
-				"http://vivoweb.org/ontology/core#Laboratory","Laboratory",
-				"http://vivoweb.org/ontology/core#Library","Library",
-				"http://purl.obolibrary.org/obo/OBI_0000835","Manufacturer",
-				"http://vivoweb.org/ontology/core#Museum","Museum",
-				"http://xmlns.com/foaf/0.1/Organization","Organization",
-				"http://vivoweb.org/ontology/core#PrivateCompany","Private Company",
-				"http://vivoweb.org/ontology/core#Program","Program",
-				"http://vivoweb.org/ontology/core#Publisher","Publisher",
-				"http://vivoweb.org/ontology/core#ResearchOrganization","Research Organization",
-				"http://vivoweb.org/ontology/core#School","School",
-				"http://vivoweb.org/ontology/core#Team","Team",
-				"http://vivoweb.org/ontology/core#ServiceProvidingLaboratory","Service Providing Lab",
-				"http://vivoweb.org/ontology/core#StudentOrganization","Student Organization",
-				"http://purl.obolibrary.org/obo/ERO_0000565","Technology Transfer Office",
-				"http://vivoweb.org/ontology/core#University","University");
-				*/
-			//UQAM-Linguistic-Management Replacing the above hard coding assigment by a dynamic assigment that takes into account the linguistic context
-	       ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-	       return filedOptions;
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+	            vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+	            I18n.bundle(vreq).text("select_type"),
+	            "http://vivoweb.org/ontology/core#AcademicDepartment",
+	            "http://vivoweb.org/ontology/core#Association",
+	            "http://vivoweb.org/ontology/core#Center",
+	            "http://vivoweb.org/ontology/core#ClinicalOrganization",
+	            "http://vivoweb.org/ontology/core#College",
+	            "http://vivoweb.org/ontology/core#Committee",
+	            "http://vivoweb.org/ontology/core#Company",
+	            "http://vivoweb.org/ontology/core#Consortium",
+	            "http://vivoweb.org/ontology/core#CoreLaboratory",
+	            "http://vivoweb.org/ontology/core#Department",
+	            "http://vivoweb.org/ontology/core#Division",
+	            "http://vivoweb.org/ontology/core#ExtensionUnit",
+	            "http://vivoweb.org/ontology/core#Foundation",
+	            "http://vivoweb.org/ontology/core#FundingOrganization",
+	            "http://vivoweb.org/ontology/core#GovernmentAgency",
+	            "http://xmlns.com/foaf/0.1/Group",
+	            "http://vivoweb.org/ontology/core#Hospital",
+	            "http://vivoweb.org/ontology/core#Institute",
+	            "http://vivoweb.org/ontology/core#Laboratory",
+	            "http://vivoweb.org/ontology/core#Library",
+	            "http://purl.obolibrary.org/obo/OBI_0000835" /* Manufacturer */,
+	            "http://vivoweb.org/ontology/core#Museum",
+	            "http://xmlns.com/foaf/0.1/Organization",
+	            "http://vivoweb.org/ontology/core#PrivateCompany",
+	            "http://vivoweb.org/ontology/core#Program",
+	            "http://vivoweb.org/ontology/core#Publisher",
+	            "http://vivoweb.org/ontology/core#ResearchOrganization",
+	            "http://vivoweb.org/ontology/core#School",
+	            "http://vivoweb.org/ontology/core#Team",
+	            "http://vivoweb.org/ontology/core#ServiceProvidingLaboratory",
+	            "http://vivoweb.org/ontology/core#StudentOrganization",
+	            "http://purl.obolibrary.org/obo/ERO_0000565" /* Technology Transfer Office */,
+	            "http://vivoweb.org/ontology/core#University");
 	}
-	/*
-	 * UQAM-Linguistic-Management get attributes for this specific subject
-	 */
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://vivoweb.org/ontology/core#AcademicDepartment> " +
-			"<http://vivoweb.org/ontology/core#Association> "+
-			"<http://vivoweb.org/ontology/core#Center> "+
-			"<http://vivoweb.org/ontology/core#ClinicalOrganization> "+
-			"<http://vivoweb.org/ontology/core#College> "+
-			"<http://vivoweb.org/ontology/core#Committee> "+
-			"<http://vivoweb.org/ontology/core#Company> "+
-			"<http://vivoweb.org/ontology/core#Consortium> "+
-			"<http://vivoweb.org/ontology/core#CoreLaboratory> "+
-			"<http://vivoweb.org/ontology/core#Department> "+
-			"<http://vivoweb.org/ontology/core#Division> "+
-			"<http://vivoweb.org/ontology/core#ExtensionUnit> "+
-			"<http://vivoweb.org/ontology/core#Foundation> "+
-			"<http://vivoweb.org/ontology/core#FundingOrganization> "+
-			"<http://vivoweb.org/ontology/core#GovernmentAgency> "+
-			"<http://xmlns.com/foaf/0.1/Group> "+
-			"<http://vivoweb.org/ontology/core#Hospital> "+
-			"<http://vivoweb.org/ontology/core#Institute> "+
-			"<http://vivoweb.org/ontology/core#Laboratory> "+
-			"<http://vivoweb.org/ontology/core#Library> "+
-			"<http://purl.obolibrary.org/obo/OBI_0000835> "+
-			"<http://vivoweb.org/ontology/core#Museum> "+
-			"<http://xmlns.com/foaf/0.1/Organization> "+
-			"<http://vivoweb.org/ontology/core#PrivateCompany> "+
-			"<http://vivoweb.org/ontology/core#Program> "+
-			"<http://vivoweb.org/ontology/core#Publisher> "+
-			"<http://vivoweb.org/ontology/core#ResearchOrganization> "+
-			"<http://vivoweb.org/ontology/core#School> "+
-			"<http://vivoweb.org/ontology/core#Team> "+
-			"<http://vivoweb.org/ontology/core#ServiceProvidingLaboratory> "+
-			"<http://vivoweb.org/ontology/core#StudentOrganization> "+
-			"<http://purl.obolibrary.org/obo/ERO_0000565> "+
-			"<http://vivoweb.org/ontology/core#University> ";
+
 	@Override
 	boolean isShowRoleLabelField(){return true;}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
@@ -2,9 +2,6 @@
 
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
@@ -2,12 +2,16 @@
 
 package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
-import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddOrganizerRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
+    private static final Log log = LogFactory.getLog(AddOrganizerRoleToPersonGenerator.class);
 	private static String template = "addOrganizerRoleToPerson.ftl";
 
 
@@ -20,50 +24,29 @@ public class AddOrganizerRoleToPersonGenerator extends AddRoleToPersonTwoStageGe
 	String getRoleType() {
 		return "http://vivoweb.org/ontology/core#OrganizerRole";
 	}
-	// UQAM-Linguistic-Management Added for buildConstantFieldOptions() call
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://vivoweb.org/ontology/core#Competition> "+
-			"<http://purl.org/ontology/bibo/Conference> "+
-			"<http://vivoweb.org/ontology/core#Course> "+
-			"<http://purl.org/NET/c4dm/event.owl#Event> "+
-			"<http://vivoweb.org/ontology/core#Exhibit> "+
-			"<http://purl.org/ontology/bibo/Hearing> "+
-			"<http://purl.org/ontology/bibo/Interview> "+
-			"<http://vivoweb.org/ontology/core#InvitedTalk> "+
-			"<http://vivoweb.org/ontology/core#Meeting> "+
-			"<http://purl.org/ontology/bibo/Performance> "+
-			"<http://vivoweb.org/ontology/core#Presentation> "+
-			"<http://purl.org/ontology/bibo/Workshop> "+
-			"<http://vivoweb.org/ontology/core#ConferenceSeries> "+
-			"<http://vivoweb.org/ontology/core#EventSeries> "+
-			"<http://vivoweb.org/ontology/core#SeminarSeries> "+
-			"<http://vivoweb.org/ontology/core#WorkshopSeries> ";
 
 	//Organizer role involves hard-coded options for the "right side" of the role or activity
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
 
-		// UQAM-Linguistic-Management Replacing the above hard coding assignment by a dynamic assignment that takes into account the linguistic context
-		ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-		return filedOptions;
-
-		//		return new ConstantFieldOptions(
-		//        "","Select type",
-		//        "http://vivoweb.org/ontology/core#Competition", "Competition",
-		//        "http://purl.org/ontology/bibo/Conference", "Conference",
-		//        "http://vivoweb.org/ontology/core#Course", "Course",
-		//        "http://purl.org/NET/c4dm/event.owl#Event", "Event",
-		//        "http://vivoweb.org/ontology/core#Exhibit", "Exhibit",
-		//        "http://purl.org/ontology/bibo/Hearing", "Hearing",
-		//        "http://purl.org/ontology/bibo/Interview", "Interview",
-		//        "http://vivoweb.org/ontology/core#InvitedTalk", "Invited Talk",
-		//        "http://vivoweb.org/ontology/core#Meeting", "Meeting",
-		//        "http://purl.org/ontology/bibo/Performance", "Performance",
-		//        "http://vivoweb.org/ontology/core#Presentation", "Presentation",
-		//        "http://purl.org/ontology/bibo/Workshop", "Workshop",
-		//        "http://vivoweb.org/ontology/core#ConferenceSeries", "Conference Series",
-		//        "http://vivoweb.org/ontology/core#EventSeries", "Event Series",
-		//        "http://vivoweb.org/ontology/core#SeminarSeries", "Seminar Series",
-		//        "http://vivoweb.org/ontology/core#WorkshopSeries", "Workshop Series");
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+	            vreq.getRDFService(), vreq.getWebappDaoFactory(),
+	            "", I18n.bundle(vreq).text("select_type"),
+	            "http://vivoweb.org/ontology/core#Competition",
+	            "http://purl.org/ontology/bibo/Conference",
+	            "http://vivoweb.org/ontology/core#Course",
+	            "http://purl.org/NET/c4dm/event.owl#Event",
+	            "http://vivoweb.org/ontology/core#Exhibit",
+	            "http://purl.org/ontology/bibo/Hearing",
+	            "http://purl.org/ontology/bibo/Interview",
+	            "http://vivoweb.org/ontology/core#InvitedTalk",
+	            "http://vivoweb.org/ontology/core#Meeting",
+	            "http://purl.org/ontology/bibo/Performance",
+	            "http://vivoweb.org/ontology/core#Presentation",
+	            "http://purl.org/ontology/bibo/Workshop",
+	            "http://vivoweb.org/ontology/core#ConferenceSeries",
+	            "http://vivoweb.org/ontology/core#EventSeries",
+	            "http://vivoweb.org/ontology/core#SeminarSeries",
+	            "http://vivoweb.org/ontology/core#WorkshopSeries");
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOrganizerRoleToPersonGenerator.java
@@ -11,7 +11,6 @@ import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddOrganizerRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
-    private static final Log log = LogFactory.getLog(AddOrganizerRoleToPersonGenerator.class);
 	private static String template = "addOrganizerRoleToPerson.ftl";
 
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOutreachProviderRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddOutreachProviderRoleToPersonGenerator.java
@@ -4,6 +4,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddOutreachProviderRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -19,114 +20,62 @@ public class AddOutreachProviderRoleToPersonGenerator extends AddRoleToPersonTwo
 	String getRoleType() {
 		return "http://vivoweb.org/ontology/core#OutreachProviderRole";
 	}
-	private static String describeQuery = " describe "+
-			"<http://vivoweb.org/ontology/core#AcademicDepartment> " +
-			"<http://vivoweb.org/ontology/core#Association> " +
-			"<http://vivoweb.org/ontology/core#Center> " +
-			"<http://vivoweb.org/ontology/core#ClinicalOrganization> " +
-			"<http://vivoweb.org/ontology/core#College> " +
-			"<http://vivoweb.org/ontology/core#Committee> " +
-			"<http://vivoweb.org/ontology/core#Company> " +
-			"<http://vivoweb.org/ontology/core#Competition> " +
-			"<http://purl.org/ontology/bibo/Conference> " +
-			"<http://vivoweb.org/ontology/core#ConferenceSeries> " +
-			"<http://vivoweb.org/ontology/core#Consortium> " +
-			"<http://vivoweb.org/ontology/core#CoreLaboratory> " +
-			"<http://vivoweb.org/ontology/core#Course> " +
-			"<http://vivoweb.org/ontology/core#Department> " +
-			"<http://vivoweb.org/ontology/core#Division> " +
-			"<http://purl.org/NET/c4dm/event.owl#Event> " +
-			"<http://vivoweb.org/ontology/core#EventSeries> " +
-			"<http://vivoweb.org/ontology/core#Exhibit> " +
-			"<http://vivoweb.org/ontology/core#ExtensionUnit> " +
-			"<http://vivoweb.org/ontology/core#Foundation> " +
-			"<http://vivoweb.org/ontology/core#FundingOrganization> " +
-			"<http://vivoweb.org/ontology/core#GovernmentAgency> " +
-			"<http://xmlns.com/foaf/0.1/Group> " +
-			"<http://purl.org/ontology/bibo/Hearing> " +
-			"<http://vivoweb.org/ontology/core#Hospital> " +
-			"<http://vivoweb.org/ontology/core#Institute> " +
-			"<http://purl.org/ontology/bibo/Interview> " +
-			"<http://vivoweb.org/ontology/core#InvitedTalk> " +
-			"<http://vivoweb.org/ontology/core#Laboratory> " +
-			"<http://vivoweb.org/ontology/core#Library> " +
-			"<http://purl.obolibrary.org/obo/OBI_0000835> " +
-			"<http://vivoweb.org/ontology/core#Meeting> " +
-			"<http://vivoweb.org/ontology/core#Museum> " +
-			"<http://xmlns.com/foaf/0.1/Organization> " +
-			"<http://purl.org/ontology/bibo/Performance> " +
-			"<http://vivoweb.org/ontology/core#Presentation> " +
-			"<http://vivoweb.org/ontology/core#PrivateCompany> " +
-			"<http://vivoweb.org/ontology/core#Program> " +
-			"<http://vivoweb.org/ontology/core#Publisher> " +
-			"<http://vivoweb.org/ontology/core#ResearchOrganization> " +
-			"<http://vivoweb.org/ontology/core#School> " +
-			"<http://vivoweb.org/ontology/core#SeminarSeries> " +
-			"<http://vivoweb.org/ontology/core#Team> " +
-			"<http://vivoweb.org/ontology/core#ServiceProvidingLaboratory> " +
-			"<http://vivoweb.org/ontology/core#StudentOrganization> " +
-			"<http://purl.obolibrary.org/obo/ERO_0000565> " +
-			"<http://vivoweb.org/ontology/core#University> " +
-			"<http://purl.org/ontology/bibo/Workshop> " +
-			"<http://vivoweb.org/ontology/core#WorkshopSeries>";
-
 
 	//Outreach Provider role involves hard-coded options for the "right side" of the role or activity
 	@Override
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-		return GeneratorUtil.buildConstantFieldOptions(vreq, describeQuery);
-
-		//                    return new ConstantFieldOptions(
-		//            "","Select type",
-		//            "http://vivoweb.org/ontology/core#AcademicDepartment","Academic Department",
-		//            "http://vivoweb.org/ontology/core#Association","Association",
-		//            "http://vivoweb.org/ontology/core#Center","Center",
-		//            "http://vivoweb.org/ontology/core#ClinicalOrganization","Clinical Organization",
-		//            "http://vivoweb.org/ontology/core#College","College",
-		//            "http://vivoweb.org/ontology/core#Committee","Committee",
-		//            "http://vivoweb.org/ontology/core#Company","Company",
-		//            "http://vivoweb.org/ontology/core#Competition", "Competition",
-		//            "http://purl.org/ontology/bibo/Conference", "Conference",
-		//            "http://vivoweb.org/ontology/core#ConferenceSeries", "Conference Series",
-		//            "http://vivoweb.org/ontology/core#Consortium","Consortium",
-		//            "http://vivoweb.org/ontology/core#CoreLaboratory","Core Laboratory",
-		//            "http://vivoweb.org/ontology/core#Course", "Course",
-		//            "http://vivoweb.org/ontology/core#Department","Department",
-		//            "http://vivoweb.org/ontology/core#Division","Division",
-		//            "http://purl.org/NET/c4dm/event.owl#Event","Event",
-		//            "http://vivoweb.org/ontology/core#EventSeries", "Event Series",
-		//            "http://vivoweb.org/ontology/core#Exhibit", "Exhibit",
-		//            "http://vivoweb.org/ontology/core#ExtensionUnit","Extension Unit",
-		//            "http://vivoweb.org/ontology/core#Foundation","Foundation",
-		//            "http://vivoweb.org/ontology/core#FundingOrganization","Funding Organization",
-		//            "http://vivoweb.org/ontology/core#GovernmentAgency","Government Agency",
-		//            "http://xmlns.com/foaf/0.1/Group","Group",
-		//            "http://purl.org/ontology/bibo/Hearing", "Hearing",
-		//            "http://vivoweb.org/ontology/core#Hospital","Hospital",
-		//            "http://vivoweb.org/ontology/core#Institute","Institute",
-		//            "http://purl.org/ontology/bibo/Interview", "Interview",
-		//            "http://vivoweb.org/ontology/core#InvitedTalk", "Invited Talk",
-		//            "http://vivoweb.org/ontology/core#Laboratory","Laboratory",
-		//            "http://vivoweb.org/ontology/core#Library","Library",
-		//            "http://purl.obolibrary.org/obo/OBI_0000835","Manufacturer",
-		//            "http://vivoweb.org/ontology/core#Meeting", "Meeting",
-		//            "http://vivoweb.org/ontology/core#Museum","Museum",
-		//            "http://xmlns.com/foaf/0.1/Organization","Organization",
-		//            "http://purl.org/ontology/bibo/Performance", "Performance",
-		//            "http://vivoweb.org/ontology/core#Presentation", "Presentation",
-		//            "http://vivoweb.org/ontology/core#PrivateCompany","Private Company",
-		//            "http://vivoweb.org/ontology/core#Program","Program",
-		//            "http://vivoweb.org/ontology/core#Publisher","Publisher",
-		//            "http://vivoweb.org/ontology/core#ResearchOrganization","Research Organization",
-		//            "http://vivoweb.org/ontology/core#School","School",
-		//            "http://vivoweb.org/ontology/core#SeminarSeries", "Seminar Series",
-		//            "http://vivoweb.org/ontology/core#Team","Team",
-		//            "http://vivoweb.org/ontology/core#ServiceProvidingLaboratory","Service Providing Lab",
-		//            "http://vivoweb.org/ontology/core#StudentOrganization","Student Organization",
-		//            "http://purl.obolibrary.org/obo/ERO_0000565","Technology Transfer Office",
-		//            "http://vivoweb.org/ontology/core#University","University",
-		//            "http://purl.org/ontology/bibo/Workshop", "Workshop",
-		//            "http://vivoweb.org/ontology/core#WorkshopSeries", "Workshop Series");
+		return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"),		
+                "http://vivoweb.org/ontology/core#AcademicDepartment",
+                "http://vivoweb.org/ontology/core#Association",
+                "http://vivoweb.org/ontology/core#Center",
+                "http://vivoweb.org/ontology/core#ClinicalOrganization",
+                "http://vivoweb.org/ontology/core#College",
+                "http://vivoweb.org/ontology/core#Committee",
+                "http://vivoweb.org/ontology/core#Company",
+                "http://vivoweb.org/ontology/core#Competition",
+                "http://purl.org/ontology/bibo/Conference",
+                "http://vivoweb.org/ontology/core#ConferenceSeries",
+                "http://vivoweb.org/ontology/core#Consortium",
+                "http://vivoweb.org/ontology/core#CoreLaboratory",
+                "http://vivoweb.org/ontology/core#Course",
+                "http://vivoweb.org/ontology/core#Department",
+                "http://vivoweb.org/ontology/core#Division",
+                "http://purl.org/NET/c4dm/event.owl#Event",
+                "http://vivoweb.org/ontology/core#EventSeries",
+                "http://vivoweb.org/ontology/core#Exhibit",
+                "http://vivoweb.org/ontology/core#ExtensionUnit",
+                "http://vivoweb.org/ontology/core#Foundation",
+                "http://vivoweb.org/ontology/core#FundingOrganization",
+                "http://vivoweb.org/ontology/core#GovernmentAgency",
+                "http://xmlns.com/foaf/0.1/Group",
+                "http://purl.org/ontology/bibo/Hearing",
+                "http://vivoweb.org/ontology/core#Hospital",
+                "http://vivoweb.org/ontology/core#Institute",
+                "http://purl.org/ontology/bibo/Interview",
+                "http://vivoweb.org/ontology/core#InvitedTalk",
+                "http://vivoweb.org/ontology/core#Laboratory",
+                "http://vivoweb.org/ontology/core#Library",
+                "http://purl.obolibrary.org/obo/OBI_0000835" /* Manufacturer */,
+                "http://vivoweb.org/ontology/core#Meeting",
+                "http://vivoweb.org/ontology/core#Museum",
+                "http://xmlns.com/foaf/0.1/Organization",
+                "http://purl.org/ontology/bibo/Performance",
+                "http://vivoweb.org/ontology/core#Presentation",
+                "http://vivoweb.org/ontology/core#PrivateCompany",
+                "http://vivoweb.org/ontology/core#Program",
+                "http://vivoweb.org/ontology/core#Publisher",
+                "http://vivoweb.org/ontology/core#ResearchOrganization",
+                "http://vivoweb.org/ontology/core#School",
+                "http://vivoweb.org/ontology/core#SeminarSeries",
+                "http://vivoweb.org/ontology/core#Team",
+                "http://vivoweb.org/ontology/core#ServiceProvidingLaboratory",
+                "http://vivoweb.org/ontology/core#StudentOrganization",
+                "http://purl.obolibrary.org/obo/ERO_0000565" /*Technology Transfer Office*/,
+                "http://vivoweb.org/ontology/core#University",
+                "http://purl.org/ontology/bibo/Workshop",
+                "http://vivoweb.org/ontology/core#WorkshopSeries");
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
@@ -29,8 +29,10 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.DateTimeWithPrecisio
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUtils;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelAccess;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
@@ -670,7 +672,7 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
 		editConfiguration.addField(new FieldVTwo().
 				setName("pubType").
 				setValidators( list("nonempty") ).
-				setOptions( new ConstantFieldOptions("pubType", getPublicationTypeLiteralOptions(vreq) ))
+				setOptions( getPublicationTypeLiteralOptions(vreq) )
 				);
 	}
 
@@ -888,80 +890,41 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
                 );
     }
 
-	private List<List<String>> getPublicationTypeLiteralOptions(VitroRequest vreq) throws Exception {
-		//UQAM-Linguistic-Management Replacing hard coding assigment by a dynamic assigment that takes into account the linguistic context
-		List<List<String>> value =  GeneratorUtil.builFieldOptionsList(vreq, DESCRIBE_QUERY);
-		return value;
-		//UQAM in replacement of this
-		//        List<List<String>> literalOptions = new ArrayList<List<String>>();
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Abstract", "Abstract"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/AcademicArticle", "Academic Article"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Article", "Article"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/AudioDocument", "Audio Document"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#BlogPosting", "Blog Posting"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Book", "Book"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#CaseStudy", "Case Study"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Catalog", "Catalog"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Chapter", "Chapter"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#ConferencePaper", "Conference Paper"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#ConferencePoster", "Conference Poster"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Database", "Database"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Dataset", "Dataset"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/EditedBook", "Edited Book"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#EditorialArticle", "Editorial Article"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Film", "Film"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Newsletter", "Newsletter"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#NewsRelease", "News Release"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Patent", "Patent"));
-		//        literalOptions.add(list("http://purl.obolibrary.org/obo/OBI_0000272", "Protocol"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Report", "Report"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#ResearchProposal", "Research Proposal"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Review", "Review"));
-		//        literalOptions.add(list("http://purl.obolibrary.org/obo/ERO_0000071 ", "Software"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Speech", "Speech"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Thesis", "Thesis"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#Video", "Video"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Webpage", "Webpage"));
-		//        literalOptions.add(list("http://purl.org/ontology/bibo/Website", "Website"));
-		//        literalOptions.add(list("http://vivoweb.org/ontology/core#WorkingPaper", "Working Paper"));
-		//        return literalOptions;
-	}
-
-
-	/*
-	 * UQAM-Linguistic-Management get attributes for this specific subject
-	 */
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://vivoweb.org/ontology/core#Abstract> "+
-			"<http://purl.org/ontology/bibo/AcademicArticle> "+
-			"<http://purl.org/ontology/bibo/Article> "+
-			"<http://purl.org/ontology/bibo/AudioDocument> "+
-			"<http://vivoweb.org/ontology/core#BlogPosting> "+
-			"<http://purl.org/ontology/bibo/Book> "+
-			"<http://vivoweb.org/ontology/core#CaseStudy> "+
-			"<http://vivoweb.org/ontology/core#Catalog> "+
-			"<http://purl.org/ontology/bibo/Chapter> "+
-			"<http://vivoweb.org/ontology/core#ConferencePaper> "+
-			"<http://vivoweb.org/ontology/core#ConferencePoster> "+
-			"<http://vivoweb.org/ontology/core#Database> "+
-			"<http://vivoweb.org/ontology/core#Dataset> "+
-			"<http://purl.org/ontology/bibo/EditedBook> "+
-			"<http://vivoweb.org/ontology/core#EditorialArticle> "+
-			"<http://purl.org/ontology/bibo/Film> "+
-			"<http://vivoweb.org/ontology/core#Newsletter> "+
-			"<http://vivoweb.org/ontology/core#NewsRelease> "+
-			"<http://purl.org/ontology/bibo/Patent> "+
-			"<http://purl.obolibrary.org/obo/OBI_0000272> "+
-			"<http://purl.org/ontology/bibo/Report> "+
-			"<http://vivoweb.org/ontology/core#ResearchProposal> "+
-			"<http://vivoweb.org/ontology/core#Review> "+
-			"<http://purl.obolibrary.org/obo/ERO_0000071> "+
-			"<http://vivoweb.org/ontology/core#Speech> "+
-			"<http://purl.org/ontology/bibo/Thesis> "+
-			"<http://vivoweb.org/ontology/core#Video> "+
-			"<http://purl.org/ontology/bibo/Webpage> "+
-			"<http://purl.org/ontology/bibo/Website> "+
-			"<http://vivoweb.org/ontology/core#WorkingPaper> ";
+    private FieldOptions getPublicationTypeLiteralOptions(VitroRequest vreq) throws Exception {
+        return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"),		
+                "http://vivoweb.org/ontology/core#Abstract",
+                "http://purl.org/ontology/bibo/AcademicArticle",
+                "http://purl.org/ontology/bibo/Article",
+                "http://purl.org/ontology/bibo/AudioDocument",
+                "http://vivoweb.org/ontology/core#BlogPosting",
+                "http://purl.org/ontology/bibo/Book",
+                "http://vivoweb.org/ontology/core#CaseStudy",
+                "http://vivoweb.org/ontology/core#Catalog",
+                "http://purl.org/ontology/bibo/Chapter",
+                "http://vivoweb.org/ontology/core#ConferencePaper",
+                "http://vivoweb.org/ontology/core#ConferencePoster",
+                "http://vivoweb.org/ontology/core#Database",
+                "http://vivoweb.org/ontology/core#Dataset",
+                "http://purl.org/ontology/bibo/EditedBook",
+                "http://vivoweb.org/ontology/core#EditorialArticle",
+                "http://purl.org/ontology/bibo/Film",
+                "http://vivoweb.org/ontology/core#Newsletter",
+                "http://vivoweb.org/ontology/core#NewsRelease",
+                "http://purl.org/ontology/bibo/Patent",
+                "http://purl.obolibrary.org/obo/OBI_0000272",
+                "http://purl.org/ontology/bibo/Report",
+                "http://vivoweb.org/ontology/core#ResearchProposal",
+                "http://vivoweb.org/ontology/core#Review",
+                "http://purl.obolibrary.org/obo/ERO_0000071 ",
+                "http://vivoweb.org/ontology/core#Speech",
+                "http://purl.org/ontology/bibo/Thesis",
+                "http://vivoweb.org/ontology/core#Video",
+                "http://purl.org/ontology/bibo/Webpage",
+                "http://purl.org/ontology/bibo/Website",
+                "http://vivoweb.org/ontology/core#WorkingPaper");
+    }
 
     //Form specific data
     public void addFormSpecificData(EditConfigurationVTwo editConfiguration, VitroRequest vreq) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddResearcherRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddResearcherRoleToPersonGenerator.java
@@ -29,7 +29,7 @@ public class AddResearcherRoleToPersonGenerator extends AddRoleToPersonTwoStageG
                 I18n.bundle(vreq).text("select_type"),
                 "http://vivoweb.org/ontology/core#Grant",
                 "http://purl.obolibrary.org/obo/ERO_0000015" /* Human Study" */,
-                "http://vivoweb.org/ontology/core#Project", "Project",
+                "http://vivoweb.org/ontology/core#Project",
 	            "http://purl.obolibrary.org/obo/ERO_0000014" /* Research Project */);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddResearcherRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddResearcherRoleToPersonGenerator.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddResearcherRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -23,24 +24,15 @@ public class AddResearcherRoleToPersonGenerator extends AddRoleToPersonTwoStageG
 	/** Researcher role involves hard-coded options for the "right side" of the role or activity. */
 	@Override
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-		//UQAM-Linguistic-Management Replacing the above hard coding assigment by a dynamic assigment that takes into account the linguistic context
-		ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-		return filedOptions;
-//		return new ConstantFieldOptions(
-//		        "", "Select one",
-//		        "http://vivoweb.org/ontology/core#Grant", "Grant",
-//	        "http://purl.obolibrary.org/obo/ERO_0000015", "Human Study",
-//	        "http://vivoweb.org/ontology/core#Project", "Project",
-//	        "http://purl.obolibrary.org/obo/ERO_0000014", "Research Project");
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"),
+                "http://vivoweb.org/ontology/core#Grant",
+                "http://purl.obolibrary.org/obo/ERO_0000015" /* Human Study" */,
+                "http://vivoweb.org/ontology/core#Project", "Project",
+	            "http://purl.obolibrary.org/obo/ERO_0000014" /* Research Project */);
 	}
-	/*
-	 * UQAM-Linguistic-Management get attributes for this specific subject
-	 */
-	private static String DESCRIBE_QUERY = " describe "+
-	    "<http://vivoweb.org/ontology/core#Grant> " +
-        "<http://purl.obolibrary.org/obo/ERO_0000015> " +
-        "<http://vivoweb.org/ontology/core#Project> " +
-        "<http://purl.obolibrary.org/obo/ERO_0000014> ";
+
 	@Override
     boolean isShowRoleLabelField() { return true;  }
    /*

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddReviewerRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddReviewerRoleToPersonGenerator.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddReviewerRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -28,157 +29,83 @@ public class AddReviewerRoleToPersonGenerator extends AddRoleToPersonTwoStageGen
 		return "http://vivoweb.org/ontology/core#ReviewerRole";
 	}
 
-	// UQAM-Linguistic-Management Added for buildConstantFieldOptions() call
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://purl.org/ontology/bibo/AcademicArticle> " +
-			"<http://purl.org/ontology/bibo/Article> " +
-			"<http://purl.org/ontology/bibo/AudioDocument> " +
-			"<http://purl.org/ontology/bibo/AudioVisualDocument> " +
-			"<http://purl.org/ontology/bibo/Bill> " +
-			"<http://vivoweb.org/ontology/core#Blog> " +
-			"<http://vivoweb.org/ontology/core#BlogPosting> " +
-			"<http://purl.org/ontology/bibo/Book> " +
-			"<http://purl.org/ontology/bibo/BookSection> " +
-			"<http://purl.org/ontology/bibo/Brief> " +
-			"<http://vivoweb.org/ontology/core#CaseStudy> " +
-			"<http://vivoweb.org/ontology/core#Catalog> " +
-			"<http://purl.org/ontology/bibo/Chapter> " +
-			"<http://purl.org/spar/fabio/ClinicalGuideline> " +
-			"<http://purl.org/ontology/bibo/Code> " +
-			"<http://purl.org/ontology/bibo/CollectedDocument> " +
-			"<http://purl.org/spar/fabio/Comment> " +
-			"<http://vivoweb.org/ontology/core#ConferencePaper> " +
-			"<http://vivoweb.org/ontology/core#ConferencePoster> " +
-			"<http://purl.org/ontology/bibo/CourtReporter> " +
-			"<http://vivoweb.org/ontology/core#Database> " +
-			"<http://purl.org/ontology/bibo/LegalDecision> " +
-			"<http://purl.org/ontology/bibo/DocumentPart> " +
-			"<http://purl.org/ontology/bibo/EditedBook> " +
-			"<http://vivoweb.org/ontology/core#EditorialArticle> " +
-			"<http://purl.org/spar/fabio/Erratum> " +
-			"<http://purl.org/ontology/bibo/Excerpt> " +
-			"<http://purl.org/ontology/bibo/Film> " +
-			"<http://purl.org/ontology/bibo/Image> " +
-			"<http://purl.org/ontology/bibo/Issue> " +
-			"<http://purl.org/ontology/bibo/Journal> " +
-			"<http://purl.obolibrary.org/obo/IAO_0000013> " +
-			"<http://purl.org/ontology/bibo/LegalCaseDocument> " +
-			"<http://purl.org/ontology/bibo/LegalDocument> " +
-			"<http://purl.org/ontology/bibo/Legislation> " +
-			"<http://purl.org/ontology/bibo/Letter> " +
-			"<http://purl.org/ontology/bibo/Magazine> " +
-			"<http://purl.org/ontology/bibo/Manual> " +
-			"<http://purl.org/ontology/bibo/Manuscript> " +
-			"<http://purl.org/ontology/bibo/Map> " +
-			"<http://vivoweb.org/ontology/core#Newsletter> " +
-			"<http://purl.org/ontology/bibo/Newspaper> " +
-			"<http://vivoweb.org/ontology/core#NewsRelease> " +
-			"<http://purl.org/ontology/bibo/Note> " +
-			"<http://purl.org/ontology/bibo/Patent> " +
-			"<http://purl.org/ontology/bibo/Periodical> " +
-			"<http://purl.org/ontology/bibo/PersonalCommunicationDocument> " +
-			"<http://purl.org/ontology/bibo/Proceedings> " +
-			"<http://purl.obolibrary.org/obo/OBI_0000272> " +
-			"<http://purl.org/ontology/bibo/Quote> " +
-			"<http://purl.org/ontology/bibo/ReferenceSource> " +
-			"<http://purl.org/ontology/bibo/Report> " +
-			"<http://vivoweb.org/ontology/core#ResearchProposal> " +
-			"<http://vivoweb.org/ontology/core#Review> " +
-			"<http://vivoweb.org/ontology/core#Score> " +
-			"<http://vivoweb.org/ontology/core#Screenplay> " +
-			"<http://purl.org/ontology/bibo/Series> " +
-			"<http://purl.org/ontology/bibo/Slide> " +
-			"<http://purl.org/ontology/bibo/Slideshow> " +
-			"<http://vivoweb.org/ontology/core#Speech> " +
-			"<http://purl.org/ontology/bibo/Standard> " +
-			"<http://purl.org/ontology/bibo/Statute> " +
-			"<http://purl.org/ontology/bibo/Thesis> " +
-			"<http://vivoweb.org/ontology/core#Translation> " +
-			"<http://vivoweb.org/ontology/core#Video> " +
-			"<http://purl.org/ontology/bibo/Webpage> " +
-			"<http://purl.org/ontology/bibo/Website> " +
-			"<http://vivoweb.org/ontology/core#WorkingPaper>";
-
 	/**
 	 *  Each subclass generator will return its own type of option here:
 	 *   whether literal hardcoded, based on class group, or subclasses of a specific class
 	 */
 	@Override
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-		// UQAM-Linguistic-Management Replacing the above hard coding assignment by a dynamic assignment that takes into account the linguistic context
-		return GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-
-		//    	return new ConstantFieldOptions(
-		//		        "",  "Select type",
-		//		        "http://purl.org/ontology/bibo/AcademicArticle", "Academic Article",
-		//                "http://purl.org/ontology/bibo/Article", "Article",
-		//                "http://purl.org/ontology/bibo/AudioDocument", "Audio Document",
-		//                "http://purl.org/ontology/bibo/AudioVisualDocument", "Audio-Visual Document",
-		//                "http://purl.org/ontology/bibo/Bill", "Bill",
-		//                "http://vivoweb.org/ontology/core#Blog", "Blog",
-		//                "http://vivoweb.org/ontology/core#BlogPosting", "Blog Posting",
-		//                "http://purl.org/ontology/bibo/Book", "Book",
-		//                "http://purl.org/ontology/bibo/BookSection", "Book Section",
-		//                "http://purl.org/ontology/bibo/Brief", "Brief",
-		//                "http://vivoweb.org/ontology/core#CaseStudy", "Case Study",
-		//                "http://vivoweb.org/ontology/core#Catalog", "Catalog",
-		//                "http://purl.org/ontology/bibo/Chapter", "Chapter",
-		//                "http://purl.org/spar/fabio/ClinicalGuideline", "Clinical Guideline",
-		//                "http://purl.org/ontology/bibo/Code", "Code",
-		//                "http://purl.org/ontology/bibo/CollectedDocument", "Collected Document",
-		//                "http://purl.org/spar/fabio/Comment", "Comment",
-		//                "http://vivoweb.org/ontology/core#ConferencePaper", "Conference Paper",
-		//                "http://vivoweb.org/ontology/core#ConferencePoster", "Conference Poster",
-		//                "http://purl.org/ontology/bibo/CourtReporter", "Court Reporter",
-		//                "http://vivoweb.org/ontology/core#Database", "Database",
-		//                "http://purl.org/ontology/bibo/LegalDecision", "Decision",
-		//                "http://purl.org/ontology/bibo/DocumentPart", "Document Part",
-		//                "http://purl.org/ontology/bibo/EditedBook", "Edited Book",
-		//                "http://vivoweb.org/ontology/core#EditorialArticle", "Editorial Article",
-		//                "http://purl.org/spar/fabio/Erratum", "Erratum",
-		//                "http://purl.org/ontology/bibo/Excerpt", "Excerpt",
-		//                "http://purl.org/ontology/bibo/Film", "Film",
-		//                "http://purl.org/ontology/bibo/Image", "Image",
-		//                "http://purl.org/ontology/bibo/Issue", "Issue",
-		//                "http://purl.org/ontology/bibo/Journal", "Journal",
-		//                "http://purl.obolibrary.org/obo/IAO_0000013", "Journal Article",
-		//                "http://purl.org/ontology/bibo/LegalCaseDocument", "Legal Case Document",
-		//                "http://purl.org/ontology/bibo/LegalDocument", "Legal Document",
-		//                "http://purl.org/ontology/bibo/Legislation", "Legislation",
-		//                "http://purl.org/ontology/bibo/Letter", "Letter",
-		//                "http://purl.org/ontology/bibo/Magazine", "Magazine",
-		//                "http://purl.org/ontology/bibo/Manual", "Manual",
-		//                "http://purl.org/ontology/bibo/Manuscript", "Manuscript",
-		//                "http://purl.org/ontology/bibo/Map", "Map",
-		//                "http://vivoweb.org/ontology/core#Newsletter", "Newsletter",
-		//                "http://purl.org/ontology/bibo/Newspaper", "Newspaper",
-		//                "http://vivoweb.org/ontology/core#NewsRelease", "News Release",
-		//                "http://purl.org/ontology/bibo/Note", "Note",
-		//                "http://purl.org/ontology/bibo/Patent", "Patent",
-		//                "http://purl.org/ontology/bibo/Periodical", "Periodical",
-		//                "http://purl.org/ontology/bibo/PersonalCommunicationDocument", "Personal Communication Document",
-		//                "http://purl.org/ontology/bibo/Proceedings", "Proceedings",
-		//                "http://purl.obolibrary.org/obo/OBI_0000272", "protocol",
-		//                "http://purl.org/ontology/bibo/Quote", "Quote",
-		//                "http://purl.org/ontology/bibo/ReferenceSource", "Reference Source",
-		//                "http://purl.org/ontology/bibo/Report", "Report",
-		//                "http://vivoweb.org/ontology/core#ResearchProposal", "Research Proposal",
-		//                "http://vivoweb.org/ontology/core#Review", "Review",
-		//                "http://vivoweb.org/ontology/core#Score", "Score",
-		//                "http://vivoweb.org/ontology/core#Screenplay", "Screenplay",
-		//                "http://purl.org/ontology/bibo/Series", "Series",
-		//                "http://purl.org/ontology/bibo/Slide", "Slide",
-		//                "http://purl.org/ontology/bibo/Slideshow", "Slideshow",
-		//                "http://vivoweb.org/ontology/core#Speech", "Speech",
-		//                "http://purl.org/ontology/bibo/Standard", "Standard",
-		//                "http://purl.org/ontology/bibo/Statute", "Statute",
-		//                "http://purl.org/ontology/bibo/Thesis", "Thesis",
-		//                "http://vivoweb.org/ontology/core#Translation", "Translation",
-		//                "http://vivoweb.org/ontology/core#Video", "Video",
-		//                "http://purl.org/ontology/bibo/Webpage", "Webpage",
-		//                "http://purl.org/ontology/bibo/Website", "Website",
-		//                "http://vivoweb.org/ontology/core#WorkingPaper", "Working Paper"
-		//        );
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+	            vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+	            I18n.bundle(vreq).text("select_type"),
+	            "http://purl.org/ontology/bibo/AcademicArticle",
+	            "http://purl.org/ontology/bibo/Article",
+	            "http://purl.org/ontology/bibo/AudioDocument",
+	            "http://purl.org/ontology/bibo/AudioVisualDocument",
+	            "http://purl.org/ontology/bibo/Bill",
+	            "http://vivoweb.org/ontology/core#Blog",
+	            "http://vivoweb.org/ontology/core#BlogPosting",
+	            "http://purl.org/ontology/bibo/Book",
+	            "http://purl.org/ontology/bibo/BookSection",
+	            "http://purl.org/ontology/bibo/Brief",
+	            "http://vivoweb.org/ontology/core#CaseStudy",
+	            "http://vivoweb.org/ontology/core#Catalog",
+	            "http://purl.org/ontology/bibo/Chapter",
+	            "http://purl.org/spar/fabio/ClinicalGuideline",
+	            "http://purl.org/ontology/bibo/Code",
+	            "http://purl.org/ontology/bibo/CollectedDocument",
+	            "http://purl.org/spar/fabio/Comment",
+	            "http://vivoweb.org/ontology/core#ConferencePaper",
+	            "http://vivoweb.org/ontology/core#ConferencePoster",
+	            "http://purl.org/ontology/bibo/CourtReporter",
+	            "http://vivoweb.org/ontology/core#Database",
+	            "http://purl.org/ontology/bibo/LegalDecision",
+	            "http://purl.org/ontology/bibo/DocumentPart",
+	            "http://purl.org/ontology/bibo/EditedBook",
+	            "http://vivoweb.org/ontology/core#EditorialArticle",
+	            "http://purl.org/spar/fabio/Erratum",
+	            "http://purl.org/ontology/bibo/Excerpt",
+	            "http://purl.org/ontology/bibo/Film",
+	            "http://purl.org/ontology/bibo/Image",
+	            "http://purl.org/ontology/bibo/Issue",
+	            "http://purl.org/ontology/bibo/Journal",
+	            "http://purl.obolibrary.org/obo/IAO_0000013" /* "Journal Article" */,
+	            "http://purl.org/ontology/bibo/LegalCaseDocument",
+	            "http://purl.org/ontology/bibo/LegalDocument",
+	            "http://purl.org/ontology/bibo/Legislation",
+	            "http://purl.org/ontology/bibo/Letter",
+	            "http://purl.org/ontology/bibo/Magazine",
+	            "http://purl.org/ontology/bibo/Manual",
+	            "http://purl.org/ontology/bibo/Manuscript",
+	            "http://purl.org/ontology/bibo/Map",
+	            "http://vivoweb.org/ontology/core#Newsletter",
+	            "http://purl.org/ontology/bibo/Newspaper",
+	            "http://vivoweb.org/ontology/core#NewsRelease",
+	            "http://purl.org/ontology/bibo/Note",
+	            "http://purl.org/ontology/bibo/Patent",
+	            "http://purl.org/ontology/bibo/Periodical",
+	            "http://purl.org/ontology/bibo/PersonalCommunicationDocument",
+	            "http://purl.org/ontology/bibo/Proceedings",
+	            "http://purl.obolibrary.org/obo/OBI_0000272" /* Protocol" */,
+	            "http://purl.org/ontology/bibo/Quote",
+	            "http://purl.org/ontology/bibo/ReferenceSource",
+	            "http://purl.org/ontology/bibo/Report",
+	            "http://vivoweb.org/ontology/core#ResearchProposal",
+	            "http://vivoweb.org/ontology/core#Review",
+	            "http://vivoweb.org/ontology/core#Score",
+	            "http://vivoweb.org/ontology/core#Screenplay",
+	            "http://purl.org/ontology/bibo/Series",
+	            "http://purl.org/ontology/bibo/Slide",
+	            "http://purl.org/ontology/bibo/Slideshow",
+	            "http://vivoweb.org/ontology/core#Speech",
+	            "http://purl.org/ontology/bibo/Standard",
+	            "http://purl.org/ontology/bibo/Statute",
+	            "http://purl.org/ontology/bibo/Thesis",
+	            "http://vivoweb.org/ontology/core#Translation",
+	            "http://vivoweb.org/ontology/core#Video",
+	            "http://purl.org/ontology/bibo/Webpage",
+	            "http://purl.org/ontology/bibo/Website",
+	            "http://vivoweb.org/ontology/core#WorkingPaper");
 	}
 
 	//isShowRoleLabelField remains true for this so doesn't need to be overwritten

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddServiceProviderRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddServiceProviderRoleToPersonGenerator.java
@@ -5,6 +5,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class AddServiceProviderRoleToPersonGenerator extends AddRoleToPersonTwoStageGenerator {
 
@@ -17,117 +18,62 @@ public class AddServiceProviderRoleToPersonGenerator extends AddRoleToPersonTwoS
 	String getRoleType() {
 		return "http://purl.obolibrary.org/obo/ERO_0000012";
 	}
-	private static String DESCRIBE_QUERY = " describe "+
-			"<http://vivoweb.org/ontology/core#AcademicDepartment> " +
-			"<http://vivoweb.org/ontology/core#Association> " +
-			"<http://vivoweb.org/ontology/core#Center> " +
-			"<http://vivoweb.org/ontology/core#ClinicalOrganization> " +
-			"<http://vivoweb.org/ontology/core#College> " +
-			"<http://vivoweb.org/ontology/core#Committee> " +
-			"<http://vivoweb.org/ontology/core#Company> " +
-			"<http://vivoweb.org/ontology/core#Competition> " +
-			"<http://purl.org/ontology/bibo/Conference> " +
-			"<http://vivoweb.org/ontology/core#ConferenceSeries> " +
-			"<http://vivoweb.org/ontology/core#Consortium> " +
-			"<http://vivoweb.org/ontology/core#CoreLaboratory> " +
-			"<http://vivoweb.org/ontology/core#Course> " +
-			"<http://vivoweb.org/ontology/core#Department> " +
-			"<http://vivoweb.org/ontology/core#Division> " +
-			"<http://purl.org/NET/c4dm/event.owl#Event> " +
-			"<http://vivoweb.org/ontology/core#EventSeries> " +
-			"<http://vivoweb.org/ontology/core#Exhibit> " +
-			"<http://vivoweb.org/ontology/core#ExtensionUnit> " +
-			"<http://vivoweb.org/ontology/core#Foundation> " +
-			"<http://vivoweb.org/ontology/core#FundingOrganization> " +
-			"<http://vivoweb.org/ontology/core#GovernmentAgency> " +
-			"<http://xmlns.com/foaf/0.1/Group> " +
-			"<http://purl.org/ontology/bibo/Hearing>" +
-			"<http://vivoweb.org/ontology/core#Hospital> " +
-			"<http://vivoweb.org/ontology/core#Institute> " +
-			"<http://purl.org/ontology/bibo/Interview> " +
-			"<http://vivoweb.org/ontology/core#InvitedTalk> " +
-			"<http://vivoweb.org/ontology/core#Laboratory> " +
-			"<http://vivoweb.org/ontology/core#Library> " +
-			"<http://purl.obolibrary.org/obo/OBI_0000835> " +
-			"<http://vivoweb.org/ontology/core#Meeting> " +
-			"<http://vivoweb.org/ontology/core#Museum> " +
-			"<http://xmlns.com/foaf/0.1/Organization> " +
-			"<http://purl.org/ontology/bibo/Performance> " +
-			"<http://vivoweb.org/ontology/core#Presentation> " +
-			"<http://vivoweb.org/ontology/core#PrivateCompany> " +
-			"<http://vivoweb.org/ontology/core#Program> " +
-			"<http://vivoweb.org/ontology/core#Publisher> " +
-			"<http://vivoweb.org/ontology/core#ResearchOrganization> " +
-			"<http://vivoweb.org/ontology/core#School> " +
-			"<http://vivoweb.org/ontology/core#SeminarSeries> " +
-			"<http://vivoweb.org/ontology/core#Team> " +
-			"<http://vivoweb.org/ontology/core#ServiceProvidingLaboratory> " +
-			"<http://vivoweb.org/ontology/core#StudentOrganization> " +
-			"<http://purl.obolibrary.org/obo/ERO_0000565> " +
-			"<http://vivoweb.org/ontology/core#University> " +
-			"<http://purl.org/ontology/bibo/Workshop> " +
-			"<http://vivoweb.org/ontology/core#WorkshopSeries> ";
-	/** Service Provider role involves hard-coded options for the
-	 * "right side" of the role or activity.	 */
+	
 	@Override
 	FieldOptions getRoleActivityFieldOptions(VitroRequest vreq) throws Exception {
-
-		// UQAM-Linguistic-Management Replacing the above hard coding assignment by a dynamic assignment that takes into account the linguistic context
-		ConstantFieldOptions filedOptions = GeneratorUtil.buildConstantFieldOptions(vreq, DESCRIBE_QUERY);
-		return filedOptions;
-
-
-		//                return new ConstantFieldOptions(
-		//        "","Select type",
-		//        "http://vivoweb.org/ontology/core#AcademicDepartment","Academic Department",
-		//        "http://vivoweb.org/ontology/core#Association","Association",
-		//        "http://vivoweb.org/ontology/core#Center","Center",
-		//        "http://vivoweb.org/ontology/core#ClinicalOrganization","Clinical Organization",
-		//        "http://vivoweb.org/ontology/core#College","College",
-		//        "http://vivoweb.org/ontology/core#Committee","Committee",
-		//        "http://vivoweb.org/ontology/core#Company","Company",
-		//        "http://vivoweb.org/ontology/core#Competition", "Competition",
-		//        "http://purl.org/ontology/bibo/Conference", "Conference",
-		//        "http://vivoweb.org/ontology/core#ConferenceSeries", "Conference Series",
-		//        "http://vivoweb.org/ontology/core#Consortium","Consortium",
-		//        "http://vivoweb.org/ontology/core#CoreLaboratory","Core Laboratory",
-		//        "http://vivoweb.org/ontology/core#Course", "Course",
-		//        "http://vivoweb.org/ontology/core#Department","Department",
-		//        "http://vivoweb.org/ontology/core#Division","Division",
-		//        "http://purl.org/NET/c4dm/event.owl#Event","Event",
-		//        "http://vivoweb.org/ontology/core#EventSeries", "Event Series",
-		//        "http://vivoweb.org/ontology/core#Exhibit", "Exhibit",
-		//        "http://vivoweb.org/ontology/core#ExtensionUnit","Extension Unit",
-		//        "http://vivoweb.org/ontology/core#Foundation","Foundation",
-		//        "http://vivoweb.org/ontology/core#FundingOrganization","Funding Organization",
-		//        "http://vivoweb.org/ontology/core#GovernmentAgency","Government Agency",
-		//        "http://xmlns.com/foaf/0.1/Group","Group",
-		//        "http://purl.org/ontology/bibo/Hearing", "Hearing",
-		//        "http://vivoweb.org/ontology/core#Hospital","Hospital",
-		//        "http://vivoweb.org/ontology/core#Institute","Institute",
-		//        "http://purl.org/ontology/bibo/Interview", "Interview",
-		//        "http://vivoweb.org/ontology/core#InvitedTalk", "Invited Talk",
-		//        "http://vivoweb.org/ontology/core#Laboratory","Laboratory",
-		//        "http://vivoweb.org/ontology/core#Library","Library",
-		//        "http://purl.obolibrary.org/obo/OBI_0000835","Manufacturer",
-		//        "http://vivoweb.org/ontology/core#Meeting", "Meeting",
-		//        "http://vivoweb.org/ontology/core#Museum","Museum",
-		//        "http://xmlns.com/foaf/0.1/Organization","Organization",
-		//        "http://purl.org/ontology/bibo/Performance", "Performance",
-		//        "http://vivoweb.org/ontology/core#Presentation", "Presentation",
-		//        "http://vivoweb.org/ontology/core#PrivateCompany","Private Company",
-		//        "http://vivoweb.org/ontology/core#Program","Program",
-		//        "http://vivoweb.org/ontology/core#Publisher","Publisher",
-		//        "http://vivoweb.org/ontology/core#ResearchOrganization","Research Organization",
-		//        "http://vivoweb.org/ontology/core#School","School",
-		//        "http://vivoweb.org/ontology/core#SeminarSeries", "Seminar Series",
-		//        "http://vivoweb.org/ontology/core#Team","Team",
-		//        "http://vivoweb.org/ontology/core#ServiceProvidingLaboratory","Service Providing Lab",
-		//        "http://vivoweb.org/ontology/core#StudentOrganization","Student Organization",
-		//        "http://purl.obolibrary.org/obo/ERO_0000565","Technology Transfer Office",
-		//        "http://vivoweb.org/ontology/core#University","University",
-		//        "http://purl.org/ontology/bibo/Workshop", "Workshop",
-		//        "http://vivoweb.org/ontology/core#WorkshopSeries", "Workshop Series");
+	    return GeneratorUtil.buildResourceAndLabelFieldOptions(
+                vreq.getRDFService(), vreq.getWebappDaoFactory(), "", 
+                I18n.bundle(vreq).text("select_type"),
+                "","Select type",
+                "http://vivoweb.org/ontology/core#AcademicDepartment",
+                "http://vivoweb.org/ontology/core#Association",
+                "http://vivoweb.org/ontology/core#Center",
+                "http://vivoweb.org/ontology/core#ClinicalOrganization",
+                "http://vivoweb.org/ontology/core#College",
+                "http://vivoweb.org/ontology/core#Committee",
+                "http://vivoweb.org/ontology/core#Company",
+                "http://vivoweb.org/ontology/core#Competition",
+                "http://purl.org/ontology/bibo/Conference",
+                "http://vivoweb.org/ontology/core#ConferenceSeries",
+                "http://vivoweb.org/ontology/core#Consortium",
+                "http://vivoweb.org/ontology/core#CoreLaboratory",
+                "http://vivoweb.org/ontology/core#Course",
+                "http://vivoweb.org/ontology/core#Department",
+                "http://vivoweb.org/ontology/core#Division",
+                "http://purl.org/NET/c4dm/event.owl#Event",
+                "http://vivoweb.org/ontology/core#EventSeries",
+                "http://vivoweb.org/ontology/core#Exhibit",
+                "http://vivoweb.org/ontology/core#ExtensionUnit",
+                "http://vivoweb.org/ontology/core#Foundation",
+                "http://vivoweb.org/ontology/core#FundingOrganization",
+                "http://vivoweb.org/ontology/core#GovernmentAgency",
+                "http://xmlns.com/foaf/0.1/Group",
+                "http://purl.org/ontology/bibo/Hearing",
+                "http://vivoweb.org/ontology/core#Hospital",
+                "http://vivoweb.org/ontology/core#Institute",
+                "http://purl.org/ontology/bibo/Interview",
+                "http://vivoweb.org/ontology/core#InvitedTalk",
+                "http://vivoweb.org/ontology/core#Laboratory",
+                "http://vivoweb.org/ontology/core#Library",
+                "http://purl.obolibrary.org/obo/OBI_0000835" /* Manufacturer */,
+                "http://vivoweb.org/ontology/core#Meeting",
+                "http://vivoweb.org/ontology/core#Museum",
+                "http://xmlns.com/foaf/0.1/Organization",
+                "http://purl.org/ontology/bibo/Performance",
+                "http://vivoweb.org/ontology/core#Presentation",
+                "http://vivoweb.org/ontology/core#PrivateCompany",
+                "http://vivoweb.org/ontology/core#Program",
+                "http://vivoweb.org/ontology/core#Publisher",
+                "http://vivoweb.org/ontology/core#ResearchOrganization",
+                "http://vivoweb.org/ontology/core#School",
+                "http://vivoweb.org/ontology/core#SeminarSeries",
+                "http://vivoweb.org/ontology/core#Team",
+                "http://vivoweb.org/ontology/core#ServiceProvidingLaboratory",
+                "http://vivoweb.org/ontology/core#StudentOrganization",
+                "http://purl.obolibrary.org/obo/ERO_0000565" /* Technology Transfer Office" */,
+                "http://vivoweb.org/ontology/core#University",
+                "http://purl.org/ontology/bibo/Workshop",
+                "http://vivoweb.org/ontology/core#WorkshopSeries");
 	}
 
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
@@ -63,7 +63,7 @@ public class GeneratorUtil {
 	   for(String resourceURI : resourceURIs) {	       
 	       IRI iri = iriFactory.create(resourceURI);
 	       if(iri.hasViolation(false)) {
-	           log.debug("Not adding invalid URI " + resourceURI 
+	           log.warn("Not adding invalid URI " + resourceURI 
 	                   + " to field options list");
 	       } else {
 	           String label = getLabel(iri, rdfService, webappDaoFactory);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
@@ -2,81 +2,122 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.iri.IRIFactory;
 import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.Model;
+import org.apache.jena.vocabulary.RDFS;
 
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.dao.WebappDaoFactory;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
-import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
-import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
-import edu.cornell.mannlib.vitro.webapp.i18n.selection.SelectedLocale;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.impl.RDFServiceUtils;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
 
 public class GeneratorUtil {
-	private static String GET_LABEL_QUERY = " "
-			+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
-			+ "SELECT DISTINCT ?uri ?label  \n"
-			+ "WHERE {  \n"
-			+ "    ?uri <http://www.w3.org/2000/01/rdf-schema#label> ?label  \n"
-			//			+ "    FILTER (lang(?label) = 'LANGUAGE' ) "
-			+ "} \n"
-			+ "        ORDER BY ?label \n"
-			;
-	/*
-	 * UQAM-Linguistic-Management Help to generate the labels of scrollDowm list in proper language
+    
+    private static final Log log = LogFactory.getLog(GeneratorUtil.class);
+	
+	/**
+	 * Build a field options list of resource URIs paired with their labels
+	 * as retrieved from the supplied RDFService.
+	 * 
+	 * @param rdfService from which to retrieve labels: this should typically
+	 * be a LanguageFilteringRDFService.
+	 *  
+	 * @param webappDaoFactory may be null.  If non-null, labels for classes
+	 * will be returned from here first before consulting rdfService.
+	 * 
+	 * @param headerValue optional value for first value/label pair
+	 * in the options list before appending the URIs with their labels. 
+	 * May be null.
+	 * 
+	 * @param headerLabel optional label for first value/label pair
+     * in the options list before appending the URIs with their labels. 
+     * May be null.
+	 * 
+	 * @param resourceURIs variable list of resource URI strings
+	 * 
+	 * @return empty ConstantFieldOptions list if resourceURIs is null or empty 
+	 * or if rdfService is null
+	 * @throws RDFServiceException from the supplied rdfService
+	 * @throws Exception from ConstantFieldOptions constructor
 	 */
-	static public ConstantFieldOptions buildConstantFieldOptions(VitroRequest vreq, String describeQuery) throws Exception {
-
-		List<List<String>> options = builFieldOptionsList(vreq, describeQuery);
-		ConstantFieldOptions filedOptions = new  ConstantFieldOptions("" , options);
-		return filedOptions;
+	public static ConstantFieldOptions buildResourceAndLabelFieldOptions(
+	        RDFService rdfService, WebappDaoFactory wadf, String headerValue, 
+	        String headerLabel, String ... resourceURIs) throws Exception {	   
+	   if(resourceURIs == null || resourceURIs.length == 0 || rdfService == null) {
+	       return new ConstantFieldOptions();
+	   }
+	   List<String> options = new ArrayList<String>();
+	   if(headerValue != null && headerLabel != null) {
+	       options.add(headerValue);
+	       options.add(headerLabel);
+	   }
+	   IRIFactory iriFactory = IRIFactory.iriImplementation();	   
+	   for(String resourceURI : resourceURIs) {	       
+	       IRI iri = iriFactory.create(resourceURI);
+	       if(iri.hasViolation(false)) {
+	           log.debug("Not adding invalid URI " + resourceURI 
+	                   + " to field options list");
+	       } else {
+	           String label = getLabel(iri, rdfService, wadf);
+	           if(!StringUtils.isEmpty(label)) {
+	               options.add(iri.toString());
+	               options.add(label);
+	           }
+	       }
+	   }
+	   return new ConstantFieldOptions(options.toArray(
+	           new String[options.size()]));
 	}
-	/*
-	 * UQAM-Linguistic-Management Help to generate the labels of scrollDowm list in proper language
+	
+	/**
+	 * Retrieve lowest-sorting rdfs:label for iri from rdfService  
+	 * @param iri may not be null
+	 * @param rdfService may not be null
 	 */
-	static public List<List<String>> builFieldOptionsList(VitroRequest vreq, String describeQuery) throws Exception {
-
-		I18nBundle i18n = I18n.bundle(vreq);
-		String i18nSelectType = i18n.text("select_type");
-		String selectType = (i18nSelectType == null || i18nSelectType.isEmpty()) ? "Select type" : i18nSelectType ;
-		Locale lang = SelectedLocale.getCurrentLocale(vreq);
-		List<List<String>> options = new ArrayList<List<String>>();
-		List<String> pair = new ArrayList<String>(2);
-		pair.add("");
-		pair.add(selectType);
-		options.add(pair);
-		RDFService rdfService = vreq.getRDFService();
-
-		Model constructedModel = RDFServiceUtils.parseModel(
-				rdfService.sparqlDescribeQuery(describeQuery, RDFService.ModelSerializationFormat.N3),
-				RDFService.ModelSerializationFormat.N3);
-
-		Query query = QueryFactory.create(GET_LABEL_QUERY.replaceAll("LANGUAGE", lang.toString())) ;
-		QueryExecution qe = QueryExecutionFactory.create(query, constructedModel);
-		try {
-			ResultSet results = qe.execSelect();
-
-			while (results.hasNext()) {
-				QuerySolution soln = results.nextSolution();
-				String uriId = soln.getResource("uri").getURI();
-				String label = soln.getLiteral("label").getLexicalForm();
-				pair = new ArrayList<String>(2);
-				pair.add(uriId);
-				pair.add(label);
-				options.add(pair);
-			}
-		} finally {
-			qe.close();
-		}
-		return options;
+	private static String getLabel(IRI iri, RDFService rdfService, WebappDaoFactory wadf) 
+	        throws RDFServiceException {
+	    // Try the WebappDaoFactory for class labels that exist only in
+	    // "everytime" and do not show up in the RDFService.
+	    if(wadf != null) {
+	        VClass vclass = wadf.getVClassDao().getVClassByURI(iri.toString());
+	        if(vclass != null) {
+	            return vclass.getLabel();
+	        }
+	    }
+	    StringBuilder select = new StringBuilder("SELECT ?label WHERE { \n");
+	    select.append("  <" + iri + "> <" + RDFS.label.getURI() + "> ?label \n");
+	    select.append("} ORDER BY ?label");
+	    LabelConsumer labelConsumer = new LabelConsumer();
+        rdfService.sparqlSelectQuery(select.toString(), labelConsumer); 
+	    return labelConsumer.getLabel();
 	}
+	
+	private static class LabelConsumer extends ResultSetConsumer {
+
+	    private String label;
+	    
+        @Override
+        protected void processQuerySolution(QuerySolution qsoln) {
+            if(label != null) {
+                return;
+                // keep only the first value returned in the result set
+            }
+            if(qsoln.contains("label") && qsoln.get("label").isLiteral()) {
+                label = qsoln.getLiteral("label").getLexicalForm();
+            }
+        }
+	    
+        public String getLabel() {
+            return label;
+        }
+        
+	}
+	
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java
@@ -35,11 +35,11 @@ public class GeneratorUtil {
      * 
      * @param headerValue      optional value for first value/label pair in the
      *                         options list before appending the URIs with their
-     *                         labels. May be null.
+     *                         labels. May be null. Example: empty string
      * 
      * @param headerLabel      optional label for first value/label pair in the
      *                         options list before appending the URIs with their
-     *                         labels. May be null.
+     *                         labels. May be null. Example: "Select type"
      * 
      * @param resourceURIs     variable list of resource URI strings
      * 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
@@ -236,8 +236,8 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
         Locale locale = SelectedLocale.getCurrentLocale(vreq);
         ParameterizedSparqlString queryPstr = new ParameterizedSparqlString(
                 WEBPAGE_QUERY);
-        queryPstr.setLiteral("locale", locale.toString().replace("_", "-"));
-        queryPstr.setLiteral("language", locale.getLanguage().toString());
+        queryPstr.setLiteral("locale", locale.replace("_", "-"));
+        queryPstr.setLiteral("language", locale.getLanguage());
     	return queryPstr.toString();
     }
 


### PR DESCRIPTION
**[VIVO-1908](https://jira.lyrasis.org/browse/VIVO-1908)**:

* Also addresses subtask https://jira.lyrasis.org/browse/VIVO-1906

# What does this pull request do?
Uses the existing language-filtering mechanism for generating dropdown select lists with language-appropriate labels on editing forms (such as "organizer of event") where the URIs are in the select lists are harcoded in the form.  Also adds a fallback mechanism to the manage webpages for individual form where language filtering is injected into a SPARQL query.

# What's new?
See GeneratorUtil.java and ManageWebapagesForIndividualGenerator.java for the most substantive changes.  
GeneratorUtil now has a method buildResourceAndLabelFieldOptions() that is very similar to the original method for building a list of constant field options.  This new method uses a WebappDaoFactory, if available, to retrieve in-memory class labels, and an RDFService to retrieve labels for all other URIs.  The individual editing forms supply the existing WebappDaoFactory and RDFService from the request, which already perform language filtering.  The editing forms no longer build DESCRIBE queries where language filtering is injected.

ManageWebpagesForIndividual.java adds fallback languages to the SPARQL query that retrieves webpage links as well as the labels for the link types.  Because this query involves GROUP BY, language filtering here cannot be handled by the RDFService-level filtering.

# How should this be tested?
* Create/navigate to a person.  From the Service tab, select "organizer of event".  Change the language selector, and note that event type labels in the dropdown continue to match the selected language.  For more in-depth testing, add a new URI to the list in AddOrganizerRoleToPerson.java, create that class in VIVO and supply a label in only one language, and note that the class continues to appear in the dropdown even if a label is not available that matches your current language selection.
* Go to the class hierarchy, select all classes, find "F1000 Link", and add a new subclass of that class.  Supply a label in only one language.  Navigate to a person.  Open the manage webpages page (Rolodex) and enter a new webpage of the new type you just created.  From the manage webpages page, change the language selector and note that the label for the new type continues to appear even if a label does not exist that matches the current language selection.