### PR TITLE
Non-functional change to comment in example.applicationSetup.n3

### DIFF
--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -82,10 +82,10 @@
 # ----------------------------
 #
 # Content triples source module: holds data contents
-#    The SDB-based implementation is the default option. It reads its parameters
+#    The TDB-based implementation is the default option. It reads its parameters
 #    from the runtime.properties file, for backward compatibility.
 #
-#    Other implementations are based on a local TDB instance, a "standard" SPARQL
+#    Other implementations are based on an SDB instance, a "standard" SPARQL
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 


### PR DESCRIPTION
Related to: https://jira.lyrasis.org/browse/VIVO-1741

# What does this pull request do?
Updates a comment in example.applicationSetup.n3 to note TDB as default triplestore

# How should this be tested?
No functional changes

# Interested parties
@VIVO-project/vivo-committers
