### PR TITLE
[VIVO-1930] - Update example.runtime.properties

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -72,20 +72,23 @@ argon2.time = 1000
   # Email parameters which VIVO can use to send mail. If these are left empty,
   # the "Contact Us" form will be disabled and users will not be notified of
   # changes to their accounts.
+  #   Example:
+  #     email.smtpHost = smtp.mydomain.edu
+  #     email.replyTo = vivoAdmin@mydomain.edu
   #
-email.smtpHost = smtp.mydomain.edu
-email.replyTo = vivoAdmin@mydomain.edu
+email.smtpHost =
+email.replyTo =
 
   #
   # URL of Solr context used in local VIVO search. This will usually consist of:
-  #     scheme + server_name + port + vivo_webapp_name + "solr"
-  # In the standard installation, the Solr context will be on the same server as VIVO,
-  # and in the same Tomcat instance. The path will be the VIVO webapp.name (specified
-  # in build.properties) + "solr"
+  #     scheme + server_name + port + "solr" + solr_core_name
+  # In a standard Solr installation, the Solr service will be available on port
+  # 8983. The path will be /solr followed by the name used when adding a core
+  # for VIVO.
   #   Example:
-  #     vitro.local.solr.url = http://localhost:8080/vivosolr
+  #     vitro.local.solr.url = http://localhost:8983/solr/vivocore
   #
-vitro.local.solr.url = http://localhost:8080/vivosolr
+vitro.local.solr.url = http://localhost:8983/solr/vivocore
 
 
 # -----------------------------------------------------------------------------
@@ -217,26 +220,43 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
 # ORCID INTEGRATION
 # -----------------------------------------------------------------------------
 
+  # The Client ID from your ORCID credentials
+  # When your application for credentials is accepted, you will receive a Client
+  # ID to be used in communications with the API. If you apply for sandbox
+  # credentials first, and then production credentials, you will likely receive
+  # two different Client IDs.
 # orcid.clientId = 0000-0000-0000-000X
+
+  # The Client Secret from your ORCID credentials
+  # When your application for credentials is accepted, you will receive a Client
+  # Secret to be used in communications with the API. If you apply for sandbox
+  # credentials first, and then production credentials, you will likely receive
+  # two different Client Secrets.
 # orcid.clientPassword = 00000000-0000-0000-0000-000000000000
 
-   #
-   # The orcid.webappBaseUrl must end in a front slash (/)
-   # if it includes a path past the domain and (if required) port.
-   #
+  # The base URL for your VIVO application, as seen from outside.
+  # VIVO will use this to construct a callback URL that the ORCID API can use to
+  # return control to VIVO. The actual callback URL will be the string you
+  # provide here with the suffix of /orcid/callback added at the end.
+  # The orcid.webappBaseUrl must end in a front slash (/)
+  # if it includes a path past the domain and (if required) port.
+  #
 # orcid.webappBaseUrl = http://vivo.mydomain.edu/vivo/
 # orcid.externalIdCommonName = VIVO Cornell Identifier
 
-   # 1.2, 2.0
+  # The version of ORCIDs API protocol that VIVO will expect. Currently, the
+  # only supported version is 2.0.
 # orcid.apiVersion = 2.0
 
-   # release, sandbox
+  # The entry point for ORCID's public API.
+  # This changes, depending on whether you are using the sandbox API or the
+  # production API. Value is either release or sandbox.
 # orcid.api = sandbox
 
-   # Specify the type of API access that you have - public or member
-   #   public - only allows you to confirm ORCID IDs
-   #   member - allows VIVO to write a link to the VIVO profile in the ORCID record
-   # If you only have a public API key, ensure that you have entered public here
+  # Specify the type of API access that you have - public or member
+  #   public - only allows you to confirm ORCID IDs
+  #   member - allows VIVO to write a link to the VIVO profile in the ORCID record
+  # If you only have a public API key, ensure that you have entered public here
 #orcid.apiLevel = public
 
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1930)**: VIVO-1930

# What does this pull request do?
Improves example.runtime.properties so installation is easier for new users

# What's new?
1. Changes a couple default values in example.runtime.properties so first startup is smoother. 
&nbsp;&nbsp;&nbsp;&nbsp;- Change default Solr URL to match most common installation URL
&nbsp;&nbsp;&nbsp;&nbsp;- Remove email server defaults so VIVO doesn't throw warning on first startup.
2. Adds clarification to ORCID integration and removes reference to old v1.2 API.

# How should this be tested?
On a new VIVO install, you should be able to copy example.runtime.properties into a runtime.properties file and VIVO should start up without errors or warnings (assuming you are using TDB and Solr exists at the typical location).


# Interested parties
@VIVO-project/vivo-committers
