### PR TITLE
[VIVO-1831] - Remove duplicate text from dropdown menus

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson.ftl
@@ -84,7 +84,6 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         <label for="orgType">${i18n().document_type_capitalized} ${requiredHint}</label>
         <#assign docTypeOpts = editConfiguration.pageData.documentType />
         <select id="typeSelector" name="documentType" acGroupName="document">
-            <option value="" selected="selected">${i18n().select_one}</option>
             <#list docTypeOpts?keys as key>
                 <#if documentTypeValue = key>
                     <option value="${key}"  selected >${docTypeOpts[key]}</option>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
@@ -132,7 +132,6 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         <#--TODO: Check if possible to have existing publication options here in order to select-->
     <p class="inline"><label for="typeSelector">${i18n().publication_type}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
         <select id="typeSelector" name="pubType" acGroupName="publication" >
-             <option value="" <#if (publicationTypeValue?length = 0)>selected="selected"</#if>>${i18n().select_one}</option>
              <#list pubTypeLiteralOptions?keys as key>
                  <option value="${key}" <#if (publicationTypeValue = key)>selected="selected"</#if>>${pubTypeLiteralOptions[key]}</option>
              </#list>


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1831)**: i18n : In "Create publication" form, dropdown menu has duplicate item

# What does this pull request do?
Fixes an issue where both 'select a type' and 'select one' appeared in dropdown menus.

# What's new?
Simply removes the offending text string reference from two template files.

# How should this be tested?
On sprint i18n branch, either click the plus sign next to 'selected publications' or 'editor of' on a person's profile page. Confirm you see both 'select a type' and 'select one' in the publication type dropdown. 

![duplicate_item_publication_type_menu_en](https://user-images.githubusercontent.com/10748475/105771430-c775ab80-5f1d-11eb-8336-185f0c9b6318.png)


Apply patch. Confirm only 'select a type' appears.

![Screen Shot 2021-01-25 at 2 35 33 PM](https://user-images.githubusercontent.com/10748475/105771378-b331ae80-5f1d-11eb-8fe2-04186fe3ffa6.png)


# Additional Notes:
Did not find any other forms that were affected by this, though there certainly are other forms that use the 'select one' logic for the dropdown. The logic appeared when the [buildResourceAndLabelFieldOptions](https://github.com/vivo-project/VIVO/blob/1da890a38e51fcce8d25f1579da414156650cab8/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GeneratorUtil.java#L51) method was added to GeneratorUtil.java, but not all form generators use this new method. Simply removing the additional string in the template seems like the easiest solution here, @brianjlowe do you have any thoughts?

# Interested parties
@VIVO-project/vivo-committers
