### PR TITLE
[VIVO-1949] - Fix external AGROVOC and LCSH service URLs

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
+++ b/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
@@ -58,7 +58,7 @@ public class AgrovocService implements ExternalConceptService {
 	protected final String dbpedia_endpoint = " http://dbpedia.org/sparql";
 	// URL to get all the information for a concept
 
-	protected final String conceptSkosMosBase = "http://agrovoc.uniroma2.it/agrovoc/rest/v1/";
+	protected final String conceptSkosMosBase = "https://agrovoc.uniroma2.it/agrovoc/rest/v1/";
 	protected final String conceptsSkosMosSearch = conceptSkosMosBase + "search?";
 	protected final String conceptSkosMosURL = conceptSkosMosBase + "data?";
 	@Override

--- a/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/LCSHService.java
+++ b/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/LCSHService.java
@@ -35,7 +35,7 @@ public class LCSHService implements ExternalConceptService {
 
 	protected final Log log = LogFactory.getLog(getClass());
 	private final String skosSuffix = ".skos.rdf";
-	private final String hostUri = "http://id.loc.gov";
+	private final String hostUri = "https://id.loc.gov";
 	private final String schemeUri = hostUri + "/authorities/subjects";
 	private final String baseUri = hostUri + "/search/";
 
@@ -94,7 +94,7 @@ public class LCSHService implements ExternalConceptService {
 				bestMatch = "false";
 			}
 			log.debug("-" + uri + "-");
-			//This is the URL for retrieving the concept - the pattern is http://id.loc.gov/authorities/subjects/sh85014203.skos.rdf
+			//This is the URL for retrieving the concept - the pattern is https://id.loc.gov/authorities/subjects/sh85014203.skos.rdf
 			//This is not the URI itself which would be http://id.loc.gov/authorities/subjects/sh85014203
 			String conceptURLString = getSKOSURL(uri);
 			String baseConceptURI = uri;
@@ -152,7 +152,7 @@ public class LCSHService implements ExternalConceptService {
 
 
 	private String getSKOSURL(String uri) {
-		String skosURI = uri + skosSuffix;
+		String skosURI = uri.replaceFirst("http://", "https://") + skosSuffix;
 
 		return skosURI;
 	}

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -82,10 +82,10 @@
 # ----------------------------
 #
 # Content triples source module: holds data contents
-#    The SDB-based implementation is the default option. It reads its parameters
+#    The TDB-based implementation is the default option. It reads its parameters
 #    from the runtime.properties file, for backward compatibility.
 #
-#    Other implementations are based on a local TDB instance, a "standard" SPARQL
+#    Other implementations are based on an SDB instance, a "standard" SPARQL
 #    endpoint, or a Virtuoso endpoint, with parameters as shown.
 #
 

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -5982,6 +5982,32 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
 
 
+    <!-- http://purl.obolibrary.org/obo/BCO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BCO_0000003">
+        <rdfs:label xml:lang="en">Data Collection Process</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#CollectionProcess"/>
+        <obo:IAO_0000112 xml:lang="en">Observing and recording the presence or absence of butterflies during a transect walk.; A trip camera capture of an image of a jaguar is an observation, because it is &quot;selected&quot; by the camera as worthy of obsevation simply by virtue of moving in front of the camera.; Seeing three pelicans flying overhead on Christmas day and report them as part of the Christmas Bird Count.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">A process in which a person or machine sees or detects a material entity and selects it as worthy of observation, and which has as output an information content entity about the selected material entity.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Under development</obo:IAO_0000116>
+        <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A collection process in which an information content entity is collected for research or scholarly purposes. The immediate use case is recording observations of taxa (presence/absence). Need to figure out how this relates to OBI assay OBI:0000070. maybe has broader synonym OBI:0000070</vitro:descriptionAnnot>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BCO_0000042 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BCO_0000042">
+        <rdfs:label xml:lang="en">Taxonomic Identification Process</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#IdentificationProcess"/>
+        <obo:IAO_0000112 xml:lang="en">Using a key to identify a plant in the field.; Using DNA barcoding to identify a plant species.; Associating a museum specimen with a specific taxonomic concept based on its characters.; Using BLAST to identify the taxa present in an environmental (metagenomic) sample.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">A curation process in which a taxonomic name is appied to a biological entity to denote membership in a taxon.</obo:IAO_0000115>
+    </owl:Class>
+
+
+
     <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
@@ -9754,6 +9780,20 @@ This class allows for linking an author to a publication while indicating inform
 
 
 
+    <!-- http://vivoweb.org/ontology/core#GeoreferencingProcess -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#GeoreferencingProcess">
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#CurationProcess"/>
+        <obo:IAO_0000111>Georeferenced</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115 xml:lang="en">A curation process in which a material entity is annotated with geo-coordinates to indicate the location of a collection</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Under development</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Anne Thessen</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">Georeferencing Process</rdfs:label>
+    </owl:Class>
+
+
+
     <!-- http://vivoweb.org/ontology/core#GovernmentAgency -->
 
     <owl:Class rdf:about="http://vivoweb.org/ontology/core#GovernmentAgency">
@@ -9842,6 +9882,21 @@ This class allows for linking an author to a publication while indicating inform
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An institution that provides medical, surgical, psychiatric or nursing care.</obo:IAO_0000115>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition take from: http://dictionary.reference.com/browse/hospital.</obo:IAO_0000112>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shands at the University of Florida</obo:IAO_0000112>
+    </owl:Class>
+
+
+
+    <!-- http://vivoweb.org/ontology/core#IdentificationProcess -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#IdentificationProcess">
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#CurationProcess"/>
+        <obo:IAO_0000111>Identified</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115 xml:lang="en">A curation process in which a term is appied to a material entity to denote its type or kind</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Under development</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Anne Thessen</obo:IAO_0000117>
+        <vitro:descriptionAnnot>This is intended to apply to a wide variety of material entities, not just biological specimens.</vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Identification Process</rdfs:label>
     </owl:Class>
 
 
@@ -10024,6 +10079,21 @@ This class allows for linking an author to a publication while indicating inform
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">It&apos;s anticipated that the subclasses will be used when classifying items. And, all locations can be viewable via this class.</obo:IAO_0000112>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Top level of all location classes.</obo:IAO_0000115>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Use subclasses of core:Location when classsifying items.</obo:IAO_0000112>
+    </owl:Class>
+
+
+
+    <!-- http://vivoweb.org/ontology/core#MeasurementProcess -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#MeasurementProcess">
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#CurationProcess"/>
+        <obo:IAO_0000111>Measured</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115 xml:lang="en">A curation process in which data are collected about a specimen in a collection</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Under development</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Anne Thessen</obo:IAO_0000117>
+        <vitro:descriptionAnnot>possibly has broader synonym OBI assay OBI:0000070 because all measurement processes will be assays, but not all assays will be performed on a material entity in a collection</vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Measurement Process</rdfs:label>
     </owl:Class>
 
 

--- a/webapp/src/main/webapp/templates/freemarker/body/orcid/orcidConfirm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/orcid/orcidConfirm.ftl
@@ -125,7 +125,7 @@ span.completed {
       <form method="GET" action="${orcidInfo.progressUrl}">
         <p>
           <#if continueAppears>
-            <input type="submit" name="submit" value="<#if "START" == orcidInfo.progress>${i18n().orcid_button_step1}<#else>${i18n().orcid_button_step1}</#if>" class="submit"/>
+            <input type="submit" name="submit" value="<#if "START" == orcidInfo.progress>${i18n().orcid_button_step1}<#else>${i18n().orcid_button_step2}</#if>" class="submit"/>
             or 
           </#if>
           <a class="cancel" href="${orcidInfo.profilePage}">${i18n().orcid_return_to_vivo}</a>


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1949)**:  https://jira.lyrasis.org/browse/VIVO-1949

# What does this pull request do?
Updates the AGROVOC and LCSH service URLs to the updated URLs.

# What's new?
Very simple change. AGROVOC and LCSH now require 'https' instead of 'http' and return an error without it.

# How should this be tested?
Confirm issue by clicking the folder icon next to a person's 'Research Areas' field. Click add concept, ensure AGROVOC is selected, type in anything (e.g. 'carrot') and await the result that never comes.

![Screen Shot 2021-01-25 at 3 49 10 PM](https://user-images.githubusercontent.com/10748475/105775924-e3308000-5f24-11eb-9948-499deb6bd839.png)

Apply fix, confirm you get results.

![Screen Shot 2021-01-25 at 3 40 38 PM](https://user-images.githubusercontent.com/10748475/105775748-892fba80-5f24-11eb-80be-6d3d7cdba01a.png)

Repeat for LCSH.

# Additional Notes:
N/A

# Interested parties
@VIVO-project/vivo-committers
