### PR TITLE
[VIVO-1924] i18n: @en i18n properties are not loaded during first site startup.

### DIFF
--- a/api/src/main/java/org/vivoweb/webapp/startup/i18nSetup.java
+++ b/api/src/main/java/org/vivoweb/webapp/startup/i18nSetup.java
@@ -7,6 +7,12 @@ import edu.cornell.mannlib.vitro.webapp.i18n.VitroResourceBundle;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+/**
+  * Configures VIVO to look for i18n properties files prefixed with 'vivo_'.
+  * This listener must be run before any other code that uses resource bundles.
+  * As this listener does not depend on any others, it should be run at or near
+  * the top of the list in startup_listeners.txt.
+  */
 public class i18nSetup implements ServletContextListener {
 
     @Override

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -5,10 +5,8 @@
 #     https://sourceforge.net/apps/mediawiki/vivo/index.php?title=The_StartupManager
 #
 
-# Configures VIVO to look for i18n properties files prefixed with 'vivo_'.
-# This listener (i18nSetup) must be run before any other code that uses resource bundles.
-# As this listener does not depend on any others, it should be run at or near
-# the top of the list in startup_listeners.txt.
+# This listener must be run before any other code that uses resource bundles, 
+# otherwise there will be problems with i18n-support.
 org.vivoweb.webapp.startup.i18nSetup
 
 edu.cornell.mannlib.vitro.webapp.servlet.setup.JvmSmokeTests

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -5,6 +5,8 @@
 #     https://sourceforge.net/apps/mediawiki/vivo/index.php?title=The_StartupManager
 #
 
+org.vivoweb.webapp.startup.i18nSetup
+
 edu.cornell.mannlib.vitro.webapp.servlet.setup.JvmSmokeTests
 
 edu.cornell.mannlib.vitro.webapp.application.ApplicationSetup
@@ -91,5 +93,3 @@ edu.cornell.mannlib.vitro.webapp.controller.individual.VIVOIndividualResponseBui
 
 # This should be near the end, because it will issue a warning if the connection to the SearchEngine times out.
 edu.cornell.mannlib.vitro.webapp.servlet.setup.SearchEngineSmokeTest
-
-org.vivoweb.webapp.startup.i18nSetup

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -5,6 +5,10 @@
 #     https://sourceforge.net/apps/mediawiki/vivo/index.php?title=The_StartupManager
 #
 
+# Configures VIVO to look for i18n properties files prefixed with 'vivo_'.
+# This listener (i18nSetup) must be run before any other code that uses resource bundles.
+# As this listener does not depend on any others, it should be run at or near
+# the top of the list in startup_listeners.txt.
 org.vivoweb.webapp.startup.i18nSetup
 
 edu.cornell.mannlib.vitro.webapp.servlet.setup.JvmSmokeTests


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1924?src=confmacro)**

# What does this pull request do?
This PR fixes the bug described in the ticket by rearranging the startup-listeners. 

# How should this be tested?
Test the Bug:
- When starting VIVO for the very first time, i18n strings in English are not loaded. The 'theme' strings are loaded, but the top level all.properties are not. If the i18n cache is disabled, then the strings immediately appear. 
- Start your vivo (with english enabled in runtime.properties) for the first time and visit the main page (language set to en-US), there should be some missing variables (see images in JIRA-Ticket)

Test the fix:
- apply changes
- Start your vivo (with english enabled in runtime.properties) for the first time and visit the main page, everything should look normal and no missing variables


Note: The error does not occur for everyone. For more information see comments in JIRA-Ticket