### PR TITLE
[VIVO-1798] - Internationalize first and last name validation

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/FirstAndLastNameValidator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/FirstAndLastNameValidator.java
@@ -11,15 +11,18 @@ import org.apache.jena.rdf.model.Literal;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.N3ValidatorVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.MultiValueEditSubmission;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class FirstAndLastNameValidator implements N3ValidatorVTwo {
 
-    private static String MISSING_FIRST_NAME_ERROR = "You must enter a value in the First Name field.";
-    private static String MISSING_LAST_NAME_ERROR = "You must enter a value in the Last Name field.";
-    private static String MALFORMED_LAST_NAME_ERROR = "The last name field may not contain a comma. Please enter first name in First Name field.";
+    private static String MISSING_FIRST_NAME_ERROR = "first_name_empty_msg";
+    private static String MISSING_LAST_NAME_ERROR = "last_name_empty_msg";
+    private static String MALFORMED_LAST_NAME_ERROR = "malformed_last_name_msg";
+    private I18nBundle i18n;
     private String uriReceiver;
 
-    public FirstAndLastNameValidator(String uriReceiver) {
+    public FirstAndLastNameValidator(String uriReceiver, I18nBundle i18n) {
+        this.i18n = i18n;
         this.uriReceiver = uriReceiver;
     }
 
@@ -68,14 +71,14 @@ public class FirstAndLastNameValidator implements N3ValidatorVTwo {
         }
 
         if (lastName == null) {
-            errors.put("lastName", MISSING_LAST_NAME_ERROR);
+            errors.put("lastName", i18n.text(MISSING_LAST_NAME_ERROR));
         // Don't reject space in the last name: de Vries, etc.
         } else if (lastNameValue.contains(",")) {
-            errors.put("lastName", MALFORMED_LAST_NAME_ERROR);
+            errors.put("lastName", i18n.text(MALFORMED_LAST_NAME_ERROR));
         }
 
         if (firstName == null) {
-            errors.put("firstName", MISSING_FIRST_NAME_ERROR);
+            errors.put("firstName", i18n.text(MISSING_FIRST_NAME_ERROR));
         }
 
         return errors.size() != 0 ? errors : null;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
@@ -32,6 +32,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUti
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 /**
  * This is a slightly unusual generator that is used by Manage Editors on
@@ -83,7 +84,7 @@ public class AddEditorsToInformationResourceGenerator extends VivoBaseGenerator 
         //template file
         editConfiguration.setTemplate("addEditorsToInformationResource.ftl");
         //add validators
-        editConfiguration.addValidator(new FirstAndLastNameValidator("personUri"));
+        editConfiguration.addValidator(new FirstAndLastNameValidator("personUri", I18n.bundle(vreq)));
 
         //Adding additional data, specifically edit mode
         addFormSpecificData(editConfiguration, vreq);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
@@ -19,6 +19,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class GrantHasContributorGenerator  extends VivoBaseGenerator implements EditConfigurationGenerator{
 
@@ -92,7 +93,7 @@ public class GrantHasContributorGenerator  extends VivoBaseGenerator implements 
 
         //Add validator
         conf.addValidator(new AntiXssValidation());
-        conf.addValidator(new FirstAndLastNameValidator("existingPerson"));
+        conf.addValidator(new FirstAndLastNameValidator("existingPerson", I18n.bundle(vreq)));
 
         //Adding additional data, specifically edit mode
         addFormSpecificData(conf, vreq);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
@@ -22,6 +22,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.IndividualsVi
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class OrganizationForTrainingGenerator  extends VivoBaseGenerator implements EditConfigurationGenerator{
 
@@ -166,7 +167,7 @@ public class OrganizationForTrainingGenerator  extends VivoBaseGenerator impleme
         //Add validator
         conf.addValidator(new DateTimeIntervalValidationVTwo("startField","endField"));
         conf.addValidator(new AntiXssValidation());
-        conf.addValidator(new FirstAndLastNameValidator("existingPerson"));
+        conf.addValidator(new FirstAndLastNameValidator("existingPerson", I18n.bundle(vreq)));
 
         //Adding additional data, specifically edit mode
         addFormSpecificData(conf, vreq);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
@@ -17,6 +17,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.DateTimeWithPrecisio
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ChildVClassesWithParent;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class OrganizationHasPositionHistoryGenerator extends VivoBaseGenerator
 		implements EditConfigurationGenerator {
@@ -256,7 +257,7 @@ public class OrganizationHasPositionHistoryGenerator extends VivoBaseGenerator
 		conf.addField(endField.setEditElement(new DateTimeWithPrecisionVTwo(
 				endField, URI_PRECISION_YEAR, URI_PRECISION_NONE)));
 
-        conf.addValidator(new FirstAndLastNameValidator("existingPerson"));
+        conf.addValidator(new FirstAndLastNameValidator("existingPerson", I18n.bundle(vreq)));
 		conf.addValidator(new AntiXssValidation());
 		conf.addValidator(new DateTimeIntervalValidationVTwo("startField",
 				"endField"));

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
@@ -20,6 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ChildVClasses
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.IndividualsViaVClassOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
@@ -184,7 +185,7 @@ public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addValidator(new DateTimeIntervalValidationVTwo("startField","endField"));
         conf.addValidator(new AntiXssValidation());
-        conf.addValidator(new FirstAndLastNameValidator("existingAdvisor"));
+        conf.addValidator(new FirstAndLastNameValidator("existingAdvisor", I18n.bundle(vreq)));
         addFormSpecificData(conf, vreq);
 
         prepare(vreq, conf);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
@@ -20,6 +20,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ChildVClasses
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.IndividualsViaVClassOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
 
 public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
@@ -184,7 +185,7 @@ public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addValidator(new DateTimeIntervalValidationVTwo("startField","endField"));
         conf.addValidator(new AntiXssValidation());
-        conf.addValidator(new FirstAndLastNameValidator("existingAdvisee"));
+        conf.addValidator(new FirstAndLastNameValidator("existingAdvisee", I18n.bundle(vreq)));
         addFormSpecificData(conf, vreq);
 
         prepare(vreq, conf);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
@@ -18,7 +18,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
 import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
-import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class ProjectHasParticipantGenerator  extends VivoBaseGenerator implements EditConfigurationGenerator{
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
@@ -17,6 +17,8 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;
 import edu.cornell.mannlib.vitro.webapp.utils.FrontEndEditingUtils.EditMode;
 import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 
 public class ProjectHasParticipantGenerator  extends VivoBaseGenerator implements EditConfigurationGenerator{
 
@@ -92,7 +94,7 @@ public class ProjectHasParticipantGenerator  extends VivoBaseGenerator implement
 
         //Add validator
         conf.addValidator(new AntiXssValidation());
-        conf.addValidator(new FirstAndLastNameValidator("existingPerson"));
+        conf.addValidator(new FirstAndLastNameValidator("existingPerson", I18n.bundle(vreq)));
 
         //Adding additional data, specifically edit mode
         addFormSpecificData(conf, vreq);


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1798) **: [i18n: english dropdown elements and error messages in french version of 'Create position history entry for nXXXX'](https://jira.lyrasis.org/browse/VIVO-1798)

# What does this pull request do?
Internationalizes hard-coded English in the first and last name validation class.

# What's new?
Passes context to FirstAndLastNameValidator.java so it can determine the proper i18n string to display
3 strings added to all languages, which were previously hard-coded in English in FirstAndLastNameValidator.java.

# How should this be tested?
See https://jira.lyrasis.org/browse/VIVO-1798 for process to confirm issue.
Deploy changes, including those in the [companion PR](https://github.com/vivo-project/VIVO-languages/pull/84) at VIVO-languages. Replicate process and confirm the proper language is displayed. Note, you must already be in the preferred language when you click through to the form. If you switch language contexts while on the form itself a mixture of languages is displayed.

**Before**
![Screen Shot 2021-01-26 at 2 40 01 PM](https://user-images.githubusercontent.com/10748475/105922875-b8aff700-5ff8-11eb-9e8e-9d3d20858f59.png)

**After**
![Screen Shot 2021-01-26 at 4 39 44 PM](https://user-images.githubusercontent.com/10748475/105922890-c1083200-5ff8-11eb-98ae-6f7942ef8cf5.png)


# Additional Notes:
REQUIRES https://github.com/vivo-project/VIVO-languages/pull/84
Mirrors effort for other validation forms here: https://github.com/vivo-project/Vitro/commit/05c3a89df497bae49acdc4160731dcb6984c8264


# Interested parties
@VIVO-project/vivo-committers
