### PR TITLE
Escaping single quotes as ascii codes in publication count .ftl

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationCountNoSparkline.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationCountNoSparkline.ftl
@@ -59,7 +59,7 @@
 
                 var td1Text = totalPublicationCount;
                 var td2Text = "";
-                var infoImgText = "<img class='infoIcon' src='" + infoIconSrc + "' height='14px' width='14px' alt='${i18n().info_icon}' title='${i18n().numbers_based_on_publications_in_vivo}' />";
+                var infoImgText = "<img class='infoIcon' src='" + infoIconSrc + "' height='14px' width='14px' alt='${i18n().info_icon?replace("'","&#39;")}' title='${i18n().numbers_based_on_publications_in_vivo?replace("'","&#39;")}' />";
 
                 if ( !onlyUnknownYearPublications ) {
                     if ( td1Text == tenYearCount ) {
@@ -74,7 +74,7 @@
                     }
                 }
                 else {
-                    td2Text += "total <img class='infoIcon' src='" + infoIconSrc + "' height='14px' width='14px' alt='${i18n().info_icon}' title='${i18n().numbers_based_on_publications_in_vivo}' />";
+                    td2Text += "total <img class='infoIcon' src='" + infoIconSrc + "' height='14px' width='14px' alt='${i18n().info_icon?replace("'","&#39;")}' title='${i18n().numbers_based_on_publications_in_vivo?replace("'","&#39;")}' />";
                 }
 
                 $('#${sparklineContainerID} td#totalPubs').html(td1Text);

--- a/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationSparklineContent.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationSparklineContent.ftl
@@ -165,13 +165,13 @@
                                         if (totalPubs !== totalPublicationCount) {
                                         //sparksText += ' (' + totalPublicationCount + ' ${i18n().total})' ;
                                         }
-                                        sparksText += "&nbsp;<img class='infoIcon' src='" + infoIconSrc + "' height='16px' width='16px' alt='${i18n().info_icon}' title='${i18n().numbers_based_on_publications_in_vivo}' />" ;
+                                        sparksText += "&nbsp;<img class='infoIcon' src='" + infoIconSrc + "' height='16px' width='16px' alt='${i18n().info_icon?replace("'","&#39;")}' title='${i18n().numbers_based_on_publications_in_vivo?replace("'","&#39;")}' />" ;
 
                                     }
                                     else {
                                     var totalPubs = onlyUnknownYearPublications ? unknownYearPublicationCounts : renderedSparks;
 
-                                    $('#${sparklineContainerID} td.sparkline_number').html(totalPubs + "  total <img class='infoIcon' src='" + infoIconSrc + "' height='16px' width='16px' alt='${i18n().info_icon}' title='${i18n().numbers_based_on_publications_in_vivo}' />").attr("class", "grey-text");
+                                    $('#${sparklineContainerID} td.sparkline_number').html(totalPubs + "  total <img class='infoIcon' src='" + infoIconSrc + "' height='16px' width='16px' alt='${i18n().info_icon?replace("'","&#39;")}' title='${i18n().numbers_based_on_publications_in_vivo?replace("'","&#39;")}' />").attr("class", "grey-text");
                                    }
 
                                  <#else>


### PR DESCRIPTION
Resolves https://jira.lyrasis.org/browse/VIVO-1814

### What does this pull request do?
It is a known issue that some properties containing single quotes can cause conflict when Javascript is inserted into ftl files, hence the need to use the `js_string` builtin to escape problematic characters (see https://jira.lyrasis.org/browse/VIVO-1842). 

In the two files modified in this PR, however, the conflict occurs in the html written by the Javascript, where the single quotes are displayed in the attributes of an `img` tag.

> ![image](https://user-images.githubusercontent.com/46490666/106614354-3ca63980-6539-11eb-82f6-305f1ed7a6ec.png)

In [Freemarker >2.3.24](https://freemarker.apache.org/docs/ref_builtins_string.html#ref_builtin_html), those special characters are automatically escaped as ascii codes. However, if VIVO is installed with an older version of Freemarker, it would have to be escaped with the (deprecated) `html` builtin.

This PR proposes to fix the bug by using the `replace` builtin, in order to manually convert the single quotes into ascii code. While not very elegant, this method has the merit of working regardless of the version of Freemarker used.

### How should this be tested?
With the fr_CA context selected, browse to the profile of an individual, then check the mouseover text of the Information icon in the left pane.
> ![image](https://user-images.githubusercontent.com/46490666/106616441-90b21d80-653b-11eb-812d-c1325aeea051.png)

The text should read as :  **"Ces chiffres sont basés uniquement sur les publications qui ont été chargées dans cette application VIVO. Si c'est votre profil, vous pouvez entrer d'autres publications ci-dessous."**