### PR TITLE
VIVO-1961: GitHub Action to Publish Docker Image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
+          file: ./Dockerfile
           push: true
           tags: vivoweb/vivo:latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Docker
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  docker:
     runs-on: ubuntu-latest
 
     env:
@@ -30,12 +30,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
 
-      - name: Maven Deploy
-        run: mvn --batch-mode deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      - name: Maven Build
+        run: mvn clean install
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: vivoweb/vivo
+          tag_with_ref: true
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - VIVO-1961
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches:
-      - main
+      - VIVO-1961
   workflow_dispatch:
 
 jobs:
@@ -34,11 +34,24 @@ jobs:
       - name: Maven Build
         run: mvn clean install
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: vivoweb/vivo
-          tag_with_ref: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: vivoweb/vivo:latest
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM tomcat:9-jdk11-openjdk
+
+ENV JAVA_OPTS="${JAVA_OPTS} -Dvivo-dir=/opt/vivo/home/"
+
+RUN mkdir /opt/vivo
+RUN mkdir /opt/vivo/home
+
+COPY ./installer/webapp/target/vivo.war /usr/local/tomcat/webapps/ROOT.war
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Resolves [VIVO-1961](https://jira.lyrasis.org/browse/VIVO-1961)

# What does this pull request do?

Simple GitHub action workflow and Dockerfile to build VIVO tomcat image and publish to [vivoweb/vivo](https://hub.docker.com/r/vivoweb/vivo)

# What's new?

`Dockerfile` and `.github/workflows/deploy.yml`

# How should this be tested?

The Dockerfile can be tested locally following these commands with Docker installed.

```
mvn clean install
docker build --no-cache -t vivo .
docker run -p 8080:8080 vivo
```

Or using the published image with a single command.

```
docker run -p 8080:8080 vivoweb/vivo:latest
```

Then navigate the browser to http://localhost:8080. You should see VIVO running as root Tomcat webapp. It will not have search functionality.

Solr and database sold separately.

@VIVO-project/vivo-committers
