### PR TITLE
[VIVO-1911] - Bugfix for type restriction in search index config

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
@@ -23,7 +23,7 @@
         searchIndex:documentBuilding.DocumentModifier ,
         searchIndex:extensions.LabelsAcrossContextNodes ;
     rdfs:label "Labels across relatedBy/relates" ;
-    :hasTypeRestriction "http://vivoweb.org/ontology/core#Relationship" ;
+    :appliesToContextNodeType "http://vivoweb.org/ontology/core#Relationship" ;
     :hasIncomingProperty "http://vivoweb.org/ontology/core#relatedBy" ;
     :hasOutgoingProperty "http://vivoweb.org/ontology/core#relates" .
 


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1911)**: VIVO-1911 ALLTEXT field in search index not as robust as before

# What does this pull request do?
Hopefully fixes an issue where labels of relevant object connected via faux properties are not added to the search index's ALLTEXT field.

# What's new?
A reversion of functionality without re-introduction of overzealous indexing.

# How should this be tested?
Confirm current behavior: Assuming VIVO database has person connected to a publication, inspect search index record for person. The ALLTEXT field will not have the publication label included.
Deploy fix. Repeat procedure, confirm ALLTEXT field includes publication text.

# Interested parties
@brianjlowe  @VIVO-project/vivo-committers
