### PR TITLE
VIVO-1964: installer tomcat deploy profile

### DIFF
--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -104,6 +104,42 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>tomcat-deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>${project.artifactId}</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>war</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${env.CATALINA_HOME}/webapps</outputDirectory>
+                                            <destFileName>${app-name}.war</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.vivoweb</groupId>


### PR DESCRIPTION
[VIVO-1964](https://jira.lyrasis.org/browse/VIVO-1964)

# What does this pull request do?

Afford to deploy to tomcat with maven command.

# What's new?

Maven `tomcat-deploy` profile in VIVO installer module.

# How should this be tested?

Ensure CATALINA_HOME is defined.

```
echo $CATALINA_HOME
```

or on windows

```
echo %CATALINA_HOME%
```

Should be to your tomcat home directory i.e. `/opt/tomcat`

If not

```
export CATALINA_HOME=/opt/tomcat
```

with /opt/tomcat being your location of tomcat home.

Build and deploy.

```
mvn clean install -Ptomcat-deploy
```

# Interested parties
@VIVO-project/vivo-committers
