### PR TITLE
Add additional URI finder that will reindex a person if its associate…

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
@@ -126,15 +126,6 @@
     :hasPredicateRestriction "http://www.w3.org/2006/vcard/ns#hasTitle" ;
     :hasPredicateRestriction "http://www.w3.org/2006/vcard/ns#hasEmail" ;
     :hasSelectQuery """
-        PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-        PREFIX obo: <http://purl.obolibrary.org/obo/>
-        SELECT ?uri
-        WHERE {
-            ?uri obo:ARG_2000028 ?subject .
-        }
-        """ ;
-    :hasSelectQuery """
-        PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
         SELECT ?uri
         WHERE {

--- a/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchIndexerConfigurationVivo.n3
@@ -117,6 +117,31 @@
         }
         """ .
 
+# URI finder that will find the relevant person to update when the 
+# property linking to the email or preferred title resource is removed
+:vivoUriFinder_VCard_2
+    a   searchIndex:indexing.IndexingUriFinder ,
+        searchIndex:indexing.SelectQueryUriFinder ;
+    rdfs:label "Preferred title / email person URI finder #2" ;
+    :hasPredicateRestriction "http://www.w3.org/2006/vcard/ns#hasTitle" ;
+    :hasPredicateRestriction "http://www.w3.org/2006/vcard/ns#hasEmail" ;
+    :hasSelectQuery """
+        PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+        PREFIX obo: <http://purl.obolibrary.org/obo/>
+        SELECT ?uri
+        WHERE {
+            ?uri obo:ARG_2000028 ?subject .
+        }
+        """ ;
+    :hasSelectQuery """
+        PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+        PREFIX obo: <http://purl.obolibrary.org/obo/>
+        SELECT ?uri
+        WHERE {
+            ?uri obo:ARG_2000028 ?subject .
+        }
+        """ .
+
 :vivodocumentModifier_PreferredTitle
     a   searchIndex:documentBuilding.SelectQueryDocumentModifier ,
         searchIndex:documentBuilding.DocumentModifier ;


### PR DESCRIPTION
…d title or email resource is deleted altogether.

**[JIRA Issue](https://jira.lyrasis.org/projects/VIVO/issues/VIVO-1969)**:

# What does this pull request do?
Adds an additional URI finder to the search indexing configuration in the display model that will add a person's URI to the reindexing queue if their associated vCard email or title object is completely removed.

# How should this be tested?
* Before applying pull request, go to Add/Remove RDF.
* Add file test_add.n3.
* Search for "yep.sure@totally.example.com" and/or "President".
* The individual "sure, yep" should be found.  The title and email will probably show up in the search snippet.
* From Add/Remove RDF, remove test_remove.n3.
* Repeat the searches and note that the email and title are still indexed.
* Apply pull request.
* Repeat addition of test_add.n3 and removal of test_remove.n3.
* Note that the email and title search strings no longer find the person.

[test_add.n3.txt](https://github.com/vivo-project/VIVO/files/6102086/test_add.n3.txt)
[test_remove.n3.txt](https://github.com/vivo-project/VIVO/files/6102088/test_remove.n3.txt)

# Interested parties
@VIVO-project/vivo-committers
