### PR TITLE
Retrieve sitemap profile URLs only after consuming result set in orde…

### DIFF
--- a/api/src/main/java/org/vivoweb/webapp/sitemap/SiteMapServlet.java
+++ b/api/src/main/java/org/vivoweb/webapp/sitemap/SiteMapServlet.java
@@ -2,29 +2,40 @@
 
 package org.vivoweb.webapp.sitemap;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.query.QuerySolution;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
-import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
-import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
-import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
-import edu.cornell.mannlib.vitro.webapp.visualization.constants.QueryConstants;
-import org.apache.commons.io.IOUtils;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.jena.query.QuerySolution;
+
+import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
+import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
+import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFServiceException;
+import edu.cornell.mannlib.vitro.webapp.rdfservice.ResultSetConsumer;
+import edu.cornell.mannlib.vitro.webapp.visualization.constants.QueryConstants;
 
 @WebServlet(name = "SiteMapServlet", urlPatterns = {"/robots.txt","/sitemap.xml"})
 public class SiteMapServlet extends VitroHttpServlet {
+    
+    private static final int MAX_URLS = 50000; // max URLs per sitemap
+    private static final Log log = LogFactory.getLog(SiteMapServlet.class);
+    
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) 
+            throws ServletException, IOException {
         String requestURI  = request.getRequestURI();
 
         if (requestURI != null) {
@@ -60,7 +71,7 @@ public class SiteMapServlet extends VitroHttpServlet {
                         "WHERE\n" +
                         "{\n" +
                         "  ?person a foaf:Person .\n" +
-                        "}\n";
+                        "} LIMIT " + MAX_URLS + "\n";
 
                 final VitroRequest vreq = new VitroRequest(request);
                 final ServletOutputStream out = response.getOutputStream();
@@ -68,28 +79,33 @@ public class SiteMapServlet extends VitroHttpServlet {
                 out.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
                 out.println("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
 
+                List<String> personURIs = new ArrayList<String>();
+                
                 try {
                     vreq.getRDFService().sparqlSelectQuery(query, new ResultSetConsumer() {
                         @Override
                         protected void processQuerySolution(QuerySolution qs) {
-                            String person = qs.getResource("person").getURI();
-
-                            String profileUrl = UrlBuilder.getIndividualProfileUrl(person, vreq);
-
-                            if (!StringUtils.isEmpty(profileUrl)) {
-                                try {
-                                    out.println("  <url>");
-                                    out.println("    <loc>" + schemeAndServer + profileUrl + "</loc>");
-                                    out.println("    <changefreq>weekly</changefreq>");
-                                    out.println("  </url>");
-                                } catch (Exception e) {
-                                }
-                            }
+                            personURIs.add(qs.getResource("person").getURI());                            
                         }
                     });
                 } catch (RDFServiceException rse) {
+                    log.error(rse, rse);
                 }
 
+                for(String person : personURIs) {
+                    String profileUrl = UrlBuilder.getIndividualProfileUrl(person, vreq);    
+                    if (!StringUtils.isEmpty(profileUrl)) {
+                        try {
+                            out.println("  <url>");
+                            out.println("    <loc>" + schemeAndServer + profileUrl + "</loc>");
+                            out.println("    <changefreq>weekly</changefreq>");
+                            out.println("  </url>");
+                        } catch (Exception e) {
+                            log.error(e, e);
+                        }
+                    }
+                }
+                
                 out.println("</urlset>");
             }
         }
@@ -104,7 +120,8 @@ public class SiteMapServlet extends VitroHttpServlet {
         if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
             StringBuilder builder = new StringBuilder();
             builder.append(scheme).append("://").append(serverName);
-            if (("http".equalsIgnoreCase(scheme) && serverPort != 80) || ("https".equalsIgnoreCase(scheme) && serverPort != 443) ) {
+            if (("http".equalsIgnoreCase(scheme) && serverPort != 80) 
+                    || ("https".equalsIgnoreCase(scheme) && serverPort != 443) ) {
                 builder.append(":").append(serverPort);
             }
 


### PR DESCRIPTION
…r to avoid transaction errors with TDB. Resolve https://jira.lyrasis.org/browse/VIVO-1910

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1910)**: 

# What does this pull request do?
Fixes bug where sitemap.xml failed to generate when using TDB.

# What's new?
Profile URLs for the sitemap are retrieved after iterating through the ResultSet of person URIs.  This avoids the problem of trying to start a new TDB transaction while inside an existing one.  The sitemap will also retrieve a maximum of 50000 to conform to Google's limit.

# How should this be tested?
Use with TDB (default) and create a person or two from SiteAdmin if your database doesn't already have some.  Without the PR, a request for /sitemap.xml will result in an error in the browser ("no elements found ...").  After applying the pull request, sitemap.xml will render with a list of person URLs.

# Interested parties
@VIVO-project/vivo-committers
