### PR TITLE
Add usePreciseSubqueries property to example.runtime.properties with default to true

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -110,6 +110,22 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
   #
 #externalAuth.netIdHeaderName = remote_userID
 
+# -----------------------------------------------------------------------------
+# OPTIMIZING LIST VIEW QUERIES
+# -----------------------------------------------------------------------------
+
+  #
+  # Include sections between <precise-subquery></precise-subquery>
+  # tags when executing 'list view' queries that retrieve data
+  # for property lists on profile pages.
+  #
+  # Including these optional sections does not change the query
+  # semantics, but may improve performance.
+  #
+  # Default is true if not set.
+  # (Prior to v1.12, default was true for SDB and false for TDB.)
+  #
+# listview.usePreciseSubquery = true
 
 # -----------------------------------------------------------------------------
 # TUNING THE DATABASE CONNECTION POOL
@@ -127,7 +143,6 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
   # of the maximum number of active connections.
   #
 # VitroConnection.DataSource.pool.maxIdle = 10
-
 
 # -----------------------------------------------------------------------------
 # USING A DIFFERENT DATABASE


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1974)**: 

Companion Vitro PR: https://github.com/vivo-project/Vitro/pull/220

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://wiki.lyrasis.org/display/VIVO/2021-03-23+-+VIVO+Development+IG

# What does this pull request do?
Updates example.runtime.properties to include listview.usePreciseSubqueries control.

Other considerations:
* Installation documentation will likely need updating to include this setting.

# Interested parties
@VIVO-project/vivo-committers
