### PR TITLE
Allow 'create new' for vivo:governingAuthorityFor.  Resolve https://j…

### DIFF
--- a/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
+++ b/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
@@ -5071,7 +5071,9 @@ vivo:governingAuthorityFor
       vitro:displayRankAnnot
               "70"^^xsd:int ;
       vitro:inPropertyGroupAnnot
-              <http://vivoweb.org/ontology#vitroPropertyGroupaddress> .
+              <http://vivoweb.org/ontology#vitroPropertyGroupaddress> ;
+      vitro:offerCreateNewOptionAnnot
+              "true"^^xsd:boolean .
 
 geo:agriculturalAreaYear
       vitro:hiddenFromDisplayBelowRoleLevelAnnot


### PR DESCRIPTION
…ira.lyrasis.org/browse/VIVO-1820

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1820)**:

# What does this pull request do?
Sets "allow create new" option on vivo:governingAuthorityFor.

# How should this be tested?
Create or navigate to an organization's profile page.  Locate the property "governing authority for".  Click (+) to add a new value.  Form should display both an autocomplete form (where the name of any existing Thing -- such as on one of the built-in FAO countries -- can be entered) and a form for creating a new individual that does not already exist.

# Interested parties
@VIVO-project/vivo-committers
