### PR TITLE
Fix issues preventing rendering and functioning of temporal graph. Re…

### DIFF
--- a/webapp/src/main/webapp/js/visualization/entitycomparison/util.js
+++ b/webapp/src/main/webapp/js/visualization/entitycomparison/util.js
@@ -1069,7 +1069,7 @@ function prepareTableForDataTablePagination(jsonData, dataTableParams){
 
 //	console.log(processJSONData.currentEntityLevel);
 
-	if (processJSONData.currentEntityLevel.toUpperCase() === "ORGANIZATIONS AND PEOPLE") {
+	if (processJSONData.currentEntityLevel === i18nStringsGuiEvents.organizationsAndPeople) {
 		$.fn.dataTableExt.afnFiltering.push(DatatableCustomFilters.peopleOrOrganizations);
 	}
 
@@ -1193,7 +1193,7 @@ function prepareTableForDataTablePagination(jsonData, dataTableParams){
  */
 function reloadDataTablePagination(preselectedEntityURIs, jsonData){
 
-	if (processJSONData.currentEntityLevel.toUpperCase() === "ORGANIZATIONS AND PEOPLE") {
+	if (processJSONData.currentEntityLevel === i18nStringsGuiEvents.organizationsAndPeople) {
 
 		/*
 		 * This will make sure that duplicate filters are not added.

--- a/webapp/src/main/webapp/templates/freemarker/visualization/entitycomparison/entityComparisonSetup.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/entitycomparison/entityComparisonSetup.ftl
@@ -34,7 +34,7 @@
 
 <#assign temporalGraphDownloadCSVCommonURL = '${urls.base}${dataVisualizationURLRoot}?uri=${organizationURI}&labelField=label'>
 
-<#assign publicationParameter = {   "name": "${i18n().publication?js_string}",
+<#assign publicationParameter = {   "name": "publication",
                                     "pluralName": "${i18n().publications?js_string}",
                                     "verbName": "${i18n().published?js_string}",
                                     "dropDownText": "${i18n().by_publications?js_string}",
@@ -44,7 +44,7 @@
                                     "csvLink": "${temporalGraphDownloadCSVCommonURL}&vis=entity_comparison",
                                     "value": "${i18n().publications?js_string}" }>
 
-<#assign grantParameter = {   "name": "${i18n().grant?js_string}",
+<#assign grantParameter = {   "name": "grant",
                               "pluralName": "${i18n().grants?js_string}",
                               "verbName": "${i18n().granted?js_string}",
                               "dropDownText": "${i18n().by_grants?js_string}",
@@ -74,7 +74,7 @@ var activitiesLabel = {
     plural: '${i18n().activities?js_string}'
 };
 var i18nStringsGuiEvents = {
-    temporalGraphCapped: '${i18n().temporal_graph_capitalized?js_string?js_string},
+    temporalGraphCapped: '${i18n().temporal_graph_capitalized?js_string?js_string}',
     temporalGraphLower: '${i18n().temporal_graph?js_string?js_string}',
     viewString: '${i18n().view?js_string}',
     entityMaxNote: '${i18n().max_entity_note?js_string}',


### PR DESCRIPTION
…solve https://jira.lyrasis.org/browse/VIVO-1978

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1978)**: (please link to issue)

# What does this pull request do?
- Adds missing single quote that broke temporal graph rendering
- Uses non-i18n strings for parameter keys to avoid broken temporal graph in non-English languages
- Uses i18n strings to re-enable switching between organizations/persons/all

# How should this be tested?
Pre-PR:
1. Load sample data attached to JIRA issue, or use a VIVO with organizations and persons who have publications.
2. Navigate to any organization.
3. Select Temporal graph. Blank page results.
Post-PR:
Repeat above.  May need to do a hard refresh to make sure new util.js is loaded.  Temporal graph should render and function normally (including orgs/person/all toggle in middle of page).  Should continue to render and function when switching between languages.

# Interested parties
@VIVO-project/vivo-committers
