### PR TITLE
Add note to runtime.properties that TPF should not be used if VIVO co…

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -407,7 +407,15 @@ Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Ro
   # If you do not wish to use the claiming interface, set this property to nothing (empty)
 createAndLink.providers = doi, pmid
 
-  # Triple pattern fragments is a very fast, very simple means for querying a triple store.
-  # The triple pattern fragments API in VIVO puts little load on the server, providing a simple means for getting data from the triple store. The API has a web interface for manual use, can be used from the command line via curl, and can be used by programs.
+  # Triple Pattern Fragments is a very fast, very simple means for querying a
+  # triple store.  The Triple Pattern Fragments API in VIVO puts little load on
+  # the server, providing a simple means for getting data from the triple store.
+  # The API has a web interface for manual use, can be used from the command
+  # line via curl, and can be used by programs.
+  #
+  # VIVO's Triple Pattern Fragments API does not require authentication and
+  # makes the full RDF graph available regardless of display or publish levels
+  # set on particular properties.  Enable Triple Pattern Fragments only if your
+  # VIVO does not contain restricted data that should not be shared with others.
   #
 # tpf.activeFlag = true


### PR DESCRIPTION
…ntains restricted data.

**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1615)**:

Companion Vitro PR: https://github.com/vivo-project/Vitro/pull/222

# What does this pull request do?
Adds a note to example.runtime.properties alerting users that they should not enable TPF if their VIVO contains restricted/sensitive data.

# Interested parties
@VIVO-project/vivo-committers
