### PR TITLE
Replace hardcoded en locale with current locale in lang attributes

### DIFF
--- a/webapp/src/main/webapp/themes/tenderfoot/templates/page/page-home.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/page/page-home.ftl
@@ -15,7 +15,7 @@
 <#import "lib-home-page.ftl" as lh>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
         <#if geoFocusMapsEnabled >

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/page/page.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/page/page.ftl
@@ -3,7 +3,7 @@
 <#import "lib-list.ftl" as l>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
     </head>

--- a/webapp/src/main/webapp/themes/wilma/templates/page-home.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/page-home.ftl
@@ -15,7 +15,7 @@
 <#import "lib-home-page.ftl" as lh>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
         <#if geoFocusMapsEnabled >

--- a/webapp/src/main/webapp/themes/wilma/templates/page.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/page.ftl
@@ -3,7 +3,7 @@
 <#import "lib-list.ftl" as l>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${country}">
     <head>
         <#include "head.ftl">
     </head>


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1343)**

Companion Vitro pull request: https://github.com/vivo-project/Vitro/pull/228

# What's new?
Uses the existing (if oddly-named) "country" value supplied by FreemarkerHttpServlet to populate HTML lang and xml:lang values.  Replaces hardcoded "en" value.

# How should this be tested?
Test that value (visible at top of page source) changes properly with language selection in both Wilma and Tenderfoot on both the home page and other pages.  Test also with no language filtering enabled or a forced locale.

# Additional Notes:
Some pages that are not generated via the standard Freemarker stack (e.g. smoke tests, goToIndividual.jsp and other JSPs) have not been modified.  As these are not crawled by search engines and are used only by admins, the consequences of incorrect tags are probably minimal.

# Interested parties
@VIVO-project/vivo-committers
