### PR TITLE
[VIVO-1982] - Set default email params to blank

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -75,8 +75,8 @@ argon2.time = 1000
   #     email.smtpHost = smtp.mydomain.edu
   #     email.replyTo = vivoAdmin@mydomain.edu
   #
-email.smtpHost =
-email.replyTo =
+# email.smtpHost =
+# email.replyTo =
 
   #
   # URL of Solr context used in local VIVO search. This will usually consist of:

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -71,8 +71,12 @@ argon2.time = 1000
   # Email parameters which VIVO can use to send mail. If these are left empty,
   # the "Contact Us" form will be disabled and users will not be notified of
   # changes to their accounts.
-# email.smtpHost = smtp.mydomain.edu
-# email.replyTo = vivoAdmin@mydomain.edu
+  #   Example:
+  #     email.smtpHost = smtp.mydomain.edu
+  #     email.replyTo = vivoAdmin@mydomain.edu
+  #
+email.smtpHost =
+email.replyTo =
 
   #
   # URL of Solr context used in local VIVO search. This will usually consist of:


### PR DESCRIPTION
**[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1982)**: https://jira.lyrasis.org/browse/VIVO-1982

# What does this pull request do?
Changes default email parameters to a blank value, which disables the Contact us form and prevents a warning from being thrown on initial start up.

# What's new?


# How should this be tested?
Deploy change, ensure VIVO starts without smoke test warning about email server being disabled.

# Additional Notes:
Previously merged as part of https://github.com/vivo-project/VIVO/pull/214/files but lost to the sands of time and reversions.

# Interested parties
@VIVO-project/vivo-committers
