### PR TITLE
Add self-activating profiles for building Vitro-languages and VIVO-l…

### DIFF
--- a/installer/example-settings.xml
+++ b/installer/example-settings.xml
@@ -18,10 +18,5 @@
 
     <activeProfiles>
         <activeProfile>defaults</activeProfile>
-        <!-- <activeProfile>i18n</activeProfile> -->
-        <!-- Replace the "defaults" activeProfile with "i18n" to include 
-            the Vitro-languages and VIVO-Languages repos in the Maven compilation and 
-            installation process -->
-
     </activeProfiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             <modules>
                 <module>../VIVO-languages</module>
             </modules>
-       </profile> 
+       </profile>
        <profile>
             <id>vitro</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -68,16 +68,28 @@
     </modules>
 
     <profiles>
-        <profile>
-            <id>i18n</id>
+       <profile>
+            <id>Vitro-languages</id>
+            <activation>
+                <file>
+                    <exists>../Vitro-languages/pom.xml</exists>
+                </file>
+            </activation>
             <modules>
                 <module>../Vitro-languages</module>
-                <module>../VIVO-languages</module>
-                <module>api</module>
-                <module>webapp</module>
-                <module>home</module>
             </modules>
-        </profile>
+       </profile>
+       <profile>
+            <id>VIVO-languages</id>
+            <activation>
+                <file>
+                    <exists>../VIVO-languages/pom.xml</exists>
+                </file>
+            </activation>
+            <modules>
+                <module>../VIVO-languages</module>
+            </modules>
+       </profile> 
        <profile>
             <id>vitro</id>
             <activation>


### PR DESCRIPTION
…anguages in place of i18n profile.

**[https://jira.lyrasis.org/browse/VIVO-2000](https://jira.lyrasis.org/browse/VIVO-2000)**: 

# What does this pull request do?
Removes explicit 'i18n' profile and adds two profiles that behave just as the parallel Vitro directory compilation always has.  If parallel Vitro-languages and VIVO-languages directories (and pom.xml files) exist, those modules will be built when VIVO is built.  Otherwise, the profiles will not activate.  This avoids the need to edit the active profiles in settings.xml.

# Interested parties
@VIVO-project/vivo-committers @michel-heon 
