### PR TITLE
Uncomment missing language dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV JAVA_OPTS="${JAVA_OPTS} -Dtdb:fileMode=$TDB_FILE_MODE"
 RUN mkdir /usr/local/vivo
 RUN mkdir /usr/local/vivo/home
 
-COPY ./installer/home/target/vivo-installer-home-1.12.1 /vivo-home
+COPY ./installer/home/target/vivo /vivo-home
 COPY ./installer/webapp/target/vivo.war /usr/local/tomcat/webapps/ROOT.war
 
 COPY start.sh /start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV JAVA_OPTS="${JAVA_OPTS} -Dtdb:fileMode=$TDB_FILE_MODE"
 RUN mkdir /usr/local/vivo
 RUN mkdir /usr/local/vivo/home
 
-COPY ./installer/home/target/vivo /vivo-home
+COPY ./installer/home/target/vivo-installer-home-1.12.1 /vivo-home
 COPY ./installer/webapp/target/vivo.war /usr/local/tomcat/webapps/ROOT.war
 
 COPY start.sh /start.sh

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -103,11 +103,11 @@
             <type>tar.gz</type>
         </dependency>
         <!-- Dependency for multilingual support -->
-        <!-- <dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vivo-languages-home-core</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
-        </dependency> -->
+        </dependency>
     </dependencies>
 </project>

--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -25,6 +25,7 @@
                 <property><name>vivo-dir</name></property>
             </activation>
             <build>
+                <finalName>${app-name}</finalName>
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -42,16 +42,16 @@
                                     <type>war</type>
                                 </overlay>
                                 <!-- Overlays for multilingual support -->
-                                <!-- overlay>
+                                <overlay>
                                     <groupId>org.vivoweb</groupId>
-                                    <artifactId>vitro-languages-webapp</artifactId>
+                                    <artifactId>vitro-languages-webapp-core</artifactId>
                                     <type>war</type>
                                 </overlay>
                                 <overlay>
                                     <groupId>org.vivoweb</groupId>
-                                    <artifactId>vivo-languages-webapp</artifactId>
+                                    <artifactId>vivo-languages-webapp-core</artifactId>
                                     <type>war</type>
-                                </overlay -->
+                                </overlay>
                             </overlays>
                             <webResources>
                                 <resource>
@@ -150,18 +150,18 @@
             <type>war</type>
         </dependency>
         <!-- Dependencies for multilingual support -->
-        <!-- dependency>
+        <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vitro-languages-webapp</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vitro-languages-webapp-core</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
-            <artifactId>vivo-languages-webapp</artifactId>
-            <version>[2.0.0,2.1.0)</version>
+            <artifactId>vivo-languages-webapp-core</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
-        </dependency -->
+        </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>


### PR DESCRIPTION
**[Issue](https://github.com/vivo-project/VIVO/issues/3610)**: resolves https://github.com/vivo-project/VIVO/issues/3610

# What does this pull request do?
Re-adds language dependencies into pom.xml files. VIVO and Vitro languages must now always been included, even when using VIVO with a single language.

# How should this be tested?
Follow instructions on how to install VIVO at https://wiki.lyrasis.org/display/VIVODOC112x/Installing+VIVO. If VIVO installs and does not complain about missing language files or strings upon startup, it was a success. 

# Interested parties
@roflinn 
