### PR TITLE
Fallback in case of missing most specific type for microformat macro

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-microformats.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-microformats.ftl
@@ -11,12 +11,11 @@
     <#elseif individual.event()>
         itemscope itemtype="http://schema.org/Event"
 	<#elseif individual.infoContentEntity()>
-	   <#assign mst = "Document" />
 		<#list individual.mostSpecificTypes as type >
 			<#assign mst = type />
 			<#break>
 		</#list>
-       <@getItemType mst!"" "infoContentEntity"/>
+       <@getItemType mst!"Document" "infoContentEntity"/>
     <#else>
         itemscope itemtype="http://schema.org/Thing"
     </#if>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-microformats.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-microformats.ftl
@@ -7,7 +7,7 @@
 			<#assign mst = type />
 			<#break>
 		</#list>
-        <@getItemType mst "organization"/>
+        <@getItemType mst!"" "organization"/>
     <#elseif individual.event()>
         itemscope itemtype="http://schema.org/Event"
 	<#elseif individual.infoContentEntity()>
@@ -16,7 +16,7 @@
 			<#assign mst = type />
 			<#break>
 		</#list>
-    	<@getItemType mst "infoContentEntity"/>
+       <@getItemType mst!"" "infoContentEntity"/>
     <#else>
         itemscope itemtype="http://schema.org/Thing"
     </#if>


### PR DESCRIPTION
**[JIRA Issue](https://github.com/vivo-project/VIVO/issues/3612)**: Fixes #3612 

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://groups.google.com/g/vivo-tech/c/PEIjS7kuIeY/m/odmwhKXeBwAJ

# What does this pull request do?
Prevents a Freemarker error encountered in rare cases.

# What's new?
Adds blank fallback in case of issue retrieving a most specific type value within the lib-microformats.ftl file.

# How should this be tested?
Search an individual's page source for a microformat value, e.g. `itemscope itemtype="http://schema.org/Thing"` before applying change. After applying change, you should still see the microformat value on the page... but it should also prevent a freemarker error from being thrown in case the macro was unable to find a most specific type (for whatever reason...). 

# Additional Notes:
Unfortunately I don't know exactly why this error is happening... this is more of a band-aid than an actual fix for the core problem, but it doesn't hurt to work around the problem in lieu of investing more time finding the root cause.

# Interested parties
@VIVO-project/vivo-committers
