### PR TITLE
Prevent copying pom files to home directory

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -108,13 +108,13 @@
             <groupId>org.vivoweb</groupId>
             <artifactId>vivo-languages-home-core</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>tar.gz</type>
         </dependency>
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vitro-languages-home-core</artifactId>
             <version>${project.version}</version>
-            <type>pom</type>
+            <type>tar.gz</type>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Changes artifact type from pom to tar.gz to prevent copying pom files ( vitro-languages-home-core-1.12.3-SNAPSHOT.pom
and vivo-languages-home-core-1.12.3-SNAPSHOT.pom ) to home directory.

**How to test**
Install VIVO from sources before applying, notice that files are added to home directory.
Clean home directory
Apply this PR
Install VIVO from sources, verify that files are not added to home directory

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
