### PR TITLE
Upgrade of the orcid-api-client library

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>orcid-api-client</artifactId>
-            <version>0.6.3</version>
+            <version>0.6.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3693](https://github.com/vivo-project/VIVO/issues/3693)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.) - https://mvnrepository.com/artifact/org.vivoweb/orcid-api-client/0.6.3 

# What does this pull request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
It is upgrading orcid-api-client library to 0.6.4 (https://mvnrepository.com/artifact/org.vivoweb/orcid-api-client/0.6.4) which is based on jackon-databind 2.10.1, the same as jena-arq 3.16.0 used in Vitro (https://mvnrepository.com/artifact/org.apache.jena/jena-arq/3.16.0). The version is upgraded in the api/pom.xml file.


Example:
* Does this change add any new dependencies?  Replace orcid-api-client 0.6.3 with the version 0.6.4

# Important note 
* The upgraded orcid-api-client still have two vulnerability issues related to jackson-databind 2.10.1. We will follow jena-arq mitigation of this issue (https://mvnrepository.com/artifact/org.apache.jena/jena-arq/3.16.0), and in the case it is resolved there, we should publish orcid-api-client 0.6.5 based on jackson-databind 2.13.2.2 and update pom.xml for versions of jena-arq and orcid-api-client.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
