### PR TITLE
Multiple fixes for VIVO pages

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/homePageDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/homePageDataGetters.n3
@@ -19,12 +19,11 @@ display:academicDeptsDataGetter
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX vivo: <http://vivoweb.org/ontology/core#>
 
-    SELECT DISTINCT ?theURI (str(?label) as ?name)
+    SELECT DISTINCT ?theURI ?name
     WHERE
     {
           ?theURI a vivo:AcademicDepartment .
-          ?theURI rdfs:label ?label .
-          FILTER (lang(?label) = '?country' ) .
+          ?theURI rdfs:label ?name .
     }
 
     """ .

--- a/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
@@ -25,14 +25,14 @@ display:getDepartmentDataGetter
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str(?departmentLabel) AS ?deptLabel) ?dept
+        SELECT DISTINCT ?deptLabel ?dept
         WHERE {
             ?individualURI vivo:researchAreaOf ?person .
 			?person vivo:relatedBy ?posn .
 			?posn a vivo:Position .
             ?posn  vivo:relates ?dept .
             ?dept a foaf:Organization .
-            ?dept rdfs:label ?departmentLabel
+            ?dept rdfs:label ?deptLabel
             OPTIONAL { ?posn vivo:dateTimeInterval ?dti
                      OPTIONAL { ?dti vivo:end ?end .
                                 ?end vivo:dateTime ?endDate
@@ -51,10 +51,10 @@ display:getDepartmentDataGetter
 		        """
 		        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 		        PREFIX vivo: <http://vivoweb.org/ontology/core#>
-		        SELECT DISTINCT (str(?vocabularySourceName) AS ?vocabService)
+		        SELECT DISTINCT ?vocabService
 		        WHERE {
 		            ?individualURI rdfs:isDefinedBy ?vocabularySource .
-		            ?vocabularySource rdfs:label ?vocabularySourceName .
+		            ?vocabularySource rdfs:label ?vocabService .
 		        }
 		        """ .
 
@@ -71,27 +71,24 @@ display:getDepartmentDataGetter
     a   <java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter> ;
     <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#query>
         """
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str (?prsnLabel) AS ?personLabel)
+        SELECT DISTINCT ?personLabel
                         ?person
-                        (Str(?researchAreaLabel) AS ?raLabel)
-                        (str(?departmentLabel) AS ?orgLabel)
+                        ?raLabel
+                        ?orgLabel
                         ?ra
-                        ?org
         WHERE {
             ?orgURI vivo:relatedBy ?posn .
             ?posn a vivo:Position .
-            ?orgURI rdfs:label ?departmentLabel .
+            ?orgURI rdfs:label ?orgLabel .
             ?posn  vivo:relates ?person .
             ?person a foaf:Person .
-            ?person rdfs:label ?prsnLabel .
+            ?person rdfs:label ?personLabel .
             ?person vivo:hasResearchArea ?raURI .
-            ?raURI rdfs:label ?researchAreaLabel
+            ?raURI rdfs:label ?raLabel .
             BIND(?raURI AS ?ra)
-            BIND(?orgURI AS ?org)
-
         }
         ORDER BY ?personLabel
         """ ;

--- a/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
@@ -82,6 +82,7 @@ display:getDepartmentDataGetter
                         ?org
         WHERE {
             ?orgURI vivo:relatedBy ?posn .
+            ?orgURI a foaf:Organization .
             ?posn a vivo:Position .
             ?orgURI rdfs:label ?orgLabel .
             ?posn  vivo:relates ?person .

--- a/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/vivoConceptDataGetters.n3
@@ -79,6 +79,7 @@ display:getDepartmentDataGetter
                         ?raLabel
                         ?orgLabel
                         ?ra
+                        ?org
         WHERE {
             ?orgURI vivo:relatedBy ?posn .
             ?posn a vivo:Position .
@@ -89,6 +90,7 @@ display:getDepartmentDataGetter
             ?person vivo:hasResearchArea ?raURI .
             ?raURI rdfs:label ?raLabel .
             BIND(?raURI AS ?ra)
+            BIND(?orgURI AS ?org)
         }
         ORDER BY ?personLabel
         """ ;

--- a/home/src/main/resources/rdf/display/everytime/vivoOrganizationDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/vivoOrganizationDataGetters.n3
@@ -31,14 +31,14 @@ display:getResearchAreaDataGetter
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str(?researchAreaLabel) AS ?raLabel) ?ra
+        SELECT DISTINCT ?raLabel ?ra
         WHERE {
             ?individualURI vivo:relatedBy ?posn .
             ?posn a vivo:Position .
             ?posn  vivo:relates ?person .
             ?person a foaf:Person .
             ?person vivo:hasResearchArea ?ra .
-            ?ra rdfs:label ?researchAreaLabel
+            ?ra rdfs:label ?raLabel
             OPTIONAL { ?posn vivo:dateTimeInterval ?dti
                      OPTIONAL { ?dti vivo:end ?end .
                                 ?end vivo:dateTime ?endDate
@@ -66,21 +66,21 @@ display:getResearchAreaDataGetter
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str (?prsnLabel) AS ?personLabel)
+        SELECT DISTINCT ?personLabel
                         ?person
-                        (str(?researchAreaLabel) AS ?raLabel)
-                        (str(?organizationLabel) AS ?orgLabel)
+                        ?raLabel
+                        ?orgLabel
                         ?ra
                         ?org
         WHERE {
              ?orgURI vivo:relatedBy ?posn .
              ?posn a vivo:Position .
-             ?orgURI rdfs:label ?organizationLabel .
+             ?orgURI rdfs:label ?orgLabel .
              ?posn  vivo:relates ?person .
              ?person a foaf:Person .
-             ?person rdfs:label ?prsnLabel .
+             ?person rdfs:label ?personLabel .
              ?person vivo:hasResearchArea ?raURI .
-             ?raURI rdfs:label ?researchAreaLabel
+             ?raURI rdfs:label ?raLabel
              BIND(?raURI AS ?ra)
              BIND(?orgURI AS ?org)
         }
@@ -104,20 +104,20 @@ display:getResearchAreaDataGetter
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str (?prsnLabel) AS ?personLabel)
+        SELECT DISTINCT ?personLabel
                         ?person
-                        (Str(?researchAreaLabel) AS ?raLabel)
-                        (str(?organizationLabel) AS ?orgLabel)
+                        ?raLabel
+                        ?orgLabel
                         ?ra
         WHERE {
             ?orgURI vivo:relatedBy ?posn .
             ?posn a vivo:Position .
-            ?orgURI rdfs:label ?organizationLabel .
+            ?orgURI rdfs:label ?orgLabel .
             ?posn  vivo:relates ?person .
             ?person a foaf:Person .
-            ?person rdfs:label ?prsnLabel .
+            ?person rdfs:label ?personLabel .
             ?person vivo:hasResearchArea ?raURI .
-            ?raURI rdfs:label ?researchAreaLabel
+            ?raURI rdfs:label ?raLabel
             BIND(?raURI AS ?ra)
 
         }
@@ -177,24 +177,24 @@ display:getGrantsDataGetter
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX vivo: <http://vivoweb.org/ontology/core#>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT DISTINCT (str (?gLabel) AS ?grantLabel) ?dt (str(?departmentLabel) AS ?deptLabel) ?grant
+        SELECT DISTINCT ?grantLabel ?dt ?deptLabel ?grant
         WHERE {
              ?individualURI vivo:relatedBy ?posn .
              ?posn a vivo:Position .
-             ?individualURI rdfs:label ?departmentLabel .
+             ?individualURI rdfs:label ?deptLabel .
              ?posn  vivo:relates ?person .
              ?person a foaf:Person .
              ?person <http://purl.obolibrary.org/obo/RO_0000053> ?role .
              ?role a vivo:ResearcherRole .
              ?role vivo:relatedBy ?grant .
              ?grant a vivo:Grant .
-             ?grant rdfs:label ?gLabel .
+             ?grant rdfs:label ?grantLabel .
              ?grant vivo:dateTimeInterval ?dti .
              ?dti vivo:end ?end.
              ?end vivo:dateTime ?dt
              FILTER (?dt > now())
         }
-        ORDER BY ?gLabel
+        ORDER BY ?grantLabel
         """ ;
     <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#saveToVar> "deptGrants" .
 

--- a/home/src/main/resources/rdf/display/everytime/vivoOrganizationDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/vivoOrganizationDataGetters.n3
@@ -76,6 +76,7 @@ display:getResearchAreaDataGetter
              ?orgURI vivo:relatedBy ?posn .
              ?posn a vivo:Position .
              ?orgURI rdfs:label ?orgLabel .
+             ?orgURI a foaf:Organization .
              ?posn  vivo:relates ?person .
              ?person a foaf:Person .
              ?person rdfs:label ?personLabel .
@@ -113,6 +114,7 @@ display:getResearchAreaDataGetter
             ?orgURI vivo:relatedBy ?posn .
             ?posn a vivo:Position .
             ?orgURI rdfs:label ?orgLabel .
+            ?orgURI a foaf:Organization .
             ?posn  vivo:relates ?person .
             ?person a foaf:Person .
             ?person rdfs:label ?personLabel .

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-dept-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-dept-details.ftl
@@ -2,10 +2,10 @@
 <#if deptResearchAreas?has_content>
     <section id="pageList">
         <#list deptResearchAreas as firstRow>
-        <#assign raLink = "${urls.base}/individual?uri=${firstRow['ra']}" />
+        <#assign raLink = "${profileUrl(firstRow['ra'])}" />
         <div class="tab">
             <h2>${firstRow["orgLabel"]}</h2>
-            <p>${i18n().individuals_with_dept(firstRow['raLabel'],raLink)} <a  href="${urls.base}/individual?uri=${firstRow["org"]}">${i18n().view_all_individuals_in_dept}</a></p>
+            <p>${i18n().individuals_with_dept(firstRow['raLabel'],raLink)} <a href="${profileUrl(firstRow["org"])}">${i18n().view_all_individuals_in_dept}</a></p>
         </div>
         <#break>
         </#list>
@@ -15,7 +15,7 @@
         <ul role="list" class="deptDetailsList">
             <#list deptResearchAreas as resultRow>
 		        <li class="deptDetailsListItem">
-		                <a href="${urls.base}/individual${resultRow["person"]?substring(resultRow["person"]?last_index_of("/"))}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
 		        </li>
             </#list>
         </ul>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-dept-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-dept-details.ftl
@@ -14,9 +14,12 @@
     <section id="deptResearchAreas">
         <ul role="list" class="deptDetailsList">
             <#list deptResearchAreas as resultRow>
-		        <li class="deptDetailsListItem">
-		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
-		        </li>
+	            <#if !personUri?has_content || personUri != resultRow["person"]>
+			        <li class="deptDetailsListItem">
+			                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+			        </li>
+	          	</#if>
+   		        <#assign personUri = resultRow["person"] />
             </#list>
         </ul>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-res-area-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-res-area-details.ftl
@@ -3,7 +3,7 @@
     <section id="pageList">
         <#list affiliatedResearchAreas as firstRow>
         <#assign firstOrgLabel = firstRow["orgLabel"]?upper_case />
-        <#assign deptLink = "${urls.base}/individual?uri=${firstRow['org']}" />
+        <#assign deptLink = "${profileUrl(firstRow['org'])}" />
         <#assign i18TextString1 = "" />
         <#if ( firstOrgLabel?index_of("THE") == 0 ) >
             <#assign i18TextString1 = "${i18n().individuals_with_researh_area_one(firstRow['orgLabel'],deptLink)}" />
@@ -12,7 +12,7 @@
         </#if>
         <div class="tab">
             <h2>${firstRow["raLabel"]}</h2>
-            <p>${i18TextString1} <a  href="${urls.base}/individual?uri=${firstRow["ra"]}">${i18n().view_all_individuals_in_area}</a></p>
+            <p>${i18TextString1} <a  href="${profileUrl(firstRow["ra"])}">${i18n().view_all_individuals_in_area}</a></p>
         </div>
         <#break>
         </#list>
@@ -22,7 +22,7 @@
         <ul role="list" class="deptDetailsList">
             <#list affiliatedResearchAreas as resultRow>
 		        <li class="deptDetailsListItem">
-		                <a href="${urls.base}/individual${resultRow["person"]?substring(resultRow["person"]?last_index_of("/"))}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
 		        </li>
             </#list>
         </ul>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-res-area-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-affiliated-res-area-details.ftl
@@ -20,10 +20,13 @@
 
     <section id="deptResearchAreas">
         <ul role="list" class="deptDetailsList">
-            <#list affiliatedResearchAreas as resultRow>
-		        <li class="deptDetailsListItem">
-		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
-		        </li>
+        	<#list affiliatedResearchAreas as resultRow>
+            	<#if !personUri?has_content || personUri != resultRow["person"]>
+	            	<li class="deptDetailsListItem">
+			                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+			        </li>	
+            	</#if>
+		        <#assign personUri = resultRow["person"] />
             </#list>
         </ul>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-active-grants.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-active-grants.ftl
@@ -21,7 +21,7 @@
     </tr>
         <#list deptGrants as resultRow>
             <tr>
-		        <td><a href="${urls.base}/individual${resultRow["grant"]?substring(resultRow["grant"]?last_index_of("/"))}" title="${i18n().grant_name}">${resultRow["grantLabel"]}</a></td>
+		        <td><a href="${profileUrl(resultRow["grant"])}" title="${i18n().grant_name}">${resultRow["grantLabel"]}</a></td>
 		        <td>${dt.formatXsdDateTimeShort(resultRow["dt"], "yearMonthDayPrecision")}</td>
 		    </tr>
 		</#list>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-res-area-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-res-area-details.ftl
@@ -12,9 +12,12 @@
     <section id="deptResearchAreas">
         <ul role="list" class="deptDetailsList">
             <#list deptResearchAreas as resultRow>
-		        <li class="deptDetailsListItem">
-		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
-		        </li>
+               	<#if !personUri?has_content || personUri != resultRow["person"]>
+			        <li class="deptDetailsListItem">
+			                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+			        </li>
+			    </#if>
+		        <#assign personUri = resultRow["person"] />
             </#list>
         </ul>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-res-area-details.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-dept-res-area-details.ftl
@@ -4,7 +4,7 @@
         <#list deptResearchAreas as firstRow>
         <div class="tab">
             <h2>${firstRow["raLabel"]}</h2>
-            <p>${i18n().faculty_with_researh_area(firstRow["orgLabel"])} <a href="${urls.base}/individual?uri=${firstRow["ra"]}">${i18n().view_all_faculty_in_area}</a></p>
+            <p>${i18n().faculty_with_researh_area(firstRow["orgLabel"])} <a href="${profileUrl(firstRow["ra"])}">${i18n().view_all_faculty_in_area}</a></p>
         </div>
         <#break>
         </#list>
@@ -13,7 +13,7 @@
         <ul role="list" class="deptDetailsList">
             <#list deptResearchAreas as resultRow>
 		        <li class="deptDetailsListItem">
-		                <a href="${urls.base}/individual${resultRow["person"]?substring(resultRow["person"]?last_index_of("/"))}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
+		                <a href="${profileUrl(resultRow["person"])}" title="${i18n().person_name}">${resultRow["personLabel"]}</a>
 		        </li>
             </#list>
         </ul>


### PR DESCRIPTION
[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3723) 

# What does this pull request do?
Fixes for pages
/affiliatedDepartments
/affiliatedResearchAreas
/deptResearchAreas
/deptGrants


# How should this be tested?
Add sample data, view pages listed above, click individual links, 
verify that links are working even if individual is not from default namespace for that instance.
On [example of concept page ](https://vivo.tib.eu/vivo113rc/individual?uri=http://localhost:8080/vivo_i18n/individual/n5504) should be associated department only in one language.
Applied on https://vivo.tib.eu/vivo113rc

# Interested parties
@VIVO-project/vivo-committers
