### PR TITLE
i18n N3 Generators fixes

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAssociatedConceptGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAssociatedConceptGenerator.java
@@ -333,7 +333,7 @@ public class AddAssociatedConceptGenerator  extends VivoBaseGenerator implements
 			VitroRequest vreq) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("conceptLabel").
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
@@ -349,7 +349,7 @@ public class AddAssociatedConceptGenerator  extends VivoBaseGenerator implements
 			VitroRequest vreq) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("conceptSemanticTypeLabel").
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
@@ -282,8 +282,8 @@ public class AddAuthorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setFirstNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("firstName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
@@ -291,16 +291,16 @@ public class AddAuthorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setMiddleNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("middleName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
 	private void setLastNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("lastName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.XSD;
 
@@ -272,8 +273,8 @@ public class AddAuthorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setLabelField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("label").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
@@ -329,8 +330,8 @@ public class AddAuthorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setOrgNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("orgName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.XSD;
 
@@ -251,8 +252,8 @@ public class AddEditorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setLabelField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("label").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
@@ -261,8 +261,8 @@ public class AddEditorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setFirstNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("firstName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
@@ -270,16 +270,16 @@ public class AddEditorsToInformationResourceGenerator extends VivoBaseGenerator 
 	private void setMiddleNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("middleName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 
 	private void setLastNameField(EditConfigurationVTwo editConfiguration) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("lastName").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorshipToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorshipToPersonGenerator.java
@@ -15,6 +15,7 @@ import org.apache.jena.query.QueryFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.resultset.ResultSetMem;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
@@ -114,8 +115,8 @@ public class AddEditorshipToPersonGenerator extends VivoBaseGenerator implements
 
         conf.addField( new FieldVTwo().
                 setName("documentLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI()).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddFullNameToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddFullNameToPersonGenerator.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -62,25 +62,25 @@ public class AddFullNameToPersonGenerator extends VivoBaseGenerator implements
 
         conf.addField( new FieldVTwo().
                 setName("firstName")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addField( new FieldVTwo().
                 setName("middleName")
-                .setRangeDatatypeUri( XSD.xstring.toString()) );
+                .setRangeDatatypeUri( RDF.dtLangString.getURI()) );
 
         conf.addField( new FieldVTwo().
                 setName("lastName")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addField( new FieldVTwo().
                 setName("suffix")
-                .setRangeDatatypeUri( XSD.xstring.toString()) );
+                .setRangeDatatypeUri( RDF.dtLangString.getURI()) );
 
             conf.addField( new FieldVTwo().
                 setName("prefix")
-                .setRangeDatatypeUri( XSD.xstring.toString()) );
+                .setRangeDatatypeUri( RDF.dtLangString.getURI()) );
 
         conf.addValidator(new AntiXssValidation());
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddFullNameToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddFullNameToPersonGenerator.java
@@ -8,10 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
@@ -20,7 +17,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
 
 public class AddFullNameToPersonGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
-    private Log log = LogFactory.getLog(AddFullNameToPersonGenerator.class);
 
     @Override
     public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddGrantRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddGrantRoleToPersonGenerator.java
@@ -10,8 +10,6 @@ import java.util.Map;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.vivoweb.webapp.util.ModelUtils;
 
 import org.apache.jena.ontology.OntModel;
@@ -42,7 +40,6 @@ import edu.cornell.mannlib.vitro.webapp.utils.generators.EditModeUtils;
  */
 public class AddGrantRoleToPersonGenerator implements EditConfigurationGenerator {
 
-	private Log log = LogFactory.getLog(AddGrantRoleToPersonGenerator.class);
 	private String subjectUri = null;
 	private String predicateUri = null;
 	private String objectUri = null;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddGrantRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddGrantRoleToPersonGenerator.java
@@ -475,7 +475,7 @@ public class AddGrantRoleToPersonGenerator implements EditConfigurationGenerator
 			VitroRequest vreq, Map<String, FieldVTwo> fields) {
 		String fieldName = "grantLabel";
 		//get range data type uri and range language
-		String stringDatatypeUri = XSD.xstring.toString();
+		String langStringDatatypeUri = RDF.dtLangString.getURI();
 
 		FieldVTwo field = new FieldVTwo();
     	field.setName(fieldName);
@@ -483,7 +483,7 @@ public class AddGrantRoleToPersonGenerator implements EditConfigurationGenerator
 
     	//Not really interested in validators here
     	List<String> validators = new ArrayList<String>();
-    	validators.add("datatype:" + stringDatatypeUri);
+    	validators.add("datatype:" + langStringDatatypeUri);
     	field.setValidators(validators);
 
     	fields.put(field.getName(), field);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPresenterRoleToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPresenterRoleToPersonGenerator.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -111,8 +112,8 @@ public class AddPresenterRoleToPersonGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("presentationLabel")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -124,8 +125,8 @@ public class AddPresenterRoleToPersonGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("roleLabel").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo(). // an autocomplete field
                 setName("existingConference")
@@ -133,7 +134,7 @@ public class AddPresenterRoleToPersonGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("conferenceLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
@@ -17,6 +17,7 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.resultset.ResultSetMem;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
@@ -63,6 +64,7 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     final static String dateTimeValue = vivoCore + "dateTime";
     final static String dateTimePrecision = vivoCore + "dateTimePrecision";
     final static String relatesPred = vivoCore + "relates";
+    private final String langStringDatatypeUri =  RDF.dtLangString.getURI();
 
     public AddPublicationToPersonGenerator() {}
 
@@ -660,11 +662,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setTitleField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("title").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
 	//UQAM-Linguistic-Management add vreq to get linguistic context
@@ -682,11 +683,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setCollectionLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("collection").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setCollectionDisplayField(EditConfigurationVTwo editConfiguration) {
@@ -703,11 +703,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setBookLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("book").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setBookDisplayField(EditConfigurationVTwo editConfiguration) {
@@ -724,11 +723,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setConferenceLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("conference").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setConferenceDisplayField(EditConfigurationVTwo editConfiguration) {
@@ -745,11 +743,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setEventLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("event").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setEventDisplayField(EditConfigurationVTwo editConfiguration) {
@@ -782,11 +779,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setEditorLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("editor").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setEditorDisplayField(EditConfigurationVTwo editConfiguration) {
@@ -803,11 +799,10 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setPublisherLabelField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("publisher").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setPublisherDisplayField(EditConfigurationVTwo editConfiguration) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
@@ -759,19 +759,17 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
 
 
     private void setFirstNameField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("firstName").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setLastNameField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("lastName").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
     private void setEventUriField(EditConfigurationVTwo editConfiguration) {
         editConfiguration.addField(new FieldVTwo().
@@ -819,59 +817,52 @@ public class AddPublicationToPersonGenerator extends VivoBaseGenerator implement
     }
 
     private void setLocaleField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("locale").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setVolumeField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("volume").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setNumberField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("number").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setIssueField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("issue").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setChapterNbrField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("chapterNbr").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setStartPageField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("startPage").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setEndPageField(EditConfigurationVTwo editConfiguration) {
-        String stringDatatypeUri = XSD.xstring.toString();
         editConfiguration.addField(new FieldVTwo().
                 setName("endPage").
-                setValidators(list("datatype:" + stringDatatypeUri)).
-                setRangeDatatypeUri(stringDatatypeUri));
+                setValidators(list("datatype:" + langStringDatatypeUri)).
+                setRangeDatatypeUri(langStringDatatypeUri));
     }
 
     private void setDateTimeField(EditConfigurationVTwo editConfiguration) {

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddPublicationToPersonGenerator.java
@@ -29,7 +29,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.PersonHasPublicationValid
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.DateTimeWithPrecisionVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationUtils;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
-import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.ConstantFieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldOptions;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.fields.FieldVTwo;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.AntiXssValidation;

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddRoleToPersonTwoStageGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddRoleToPersonTwoStageGenerator.java
@@ -649,11 +649,11 @@ public abstract class AddRoleToPersonTwoStageGenerator extends BaseEditConfigura
     	field.setName(fieldName);
 
     	//get range data type uri and range language
-        String stringDatatypeUri = XSD.xstring.toString();
-        field.setRangeDatatypeUri(stringDatatypeUri);
+        String langStringDatatypeUri = RDF.dtLangString.getURI() ;
+        field.setRangeDatatypeUri(langStringDatatypeUri);
 
     	List<String> validators = new ArrayList<String>();
-    	validators.add("datatype:" + stringDatatypeUri);
+    	validators.add("datatype:" + langStringDatatypeUri);
     	field.setValidators(validators);
 
     	fields.put(field.getName(), field);
@@ -729,11 +729,11 @@ public abstract class AddRoleToPersonTwoStageGenerator extends BaseEditConfigura
 		FieldVTwo field = new FieldVTwo();
     	field.setName(fieldName);
 
-    	String stringDatatypeUri = XSD.xstring.toString();
-        field.setRangeDatatypeUri(stringDatatypeUri);
+    	String langStringDatatypeUri = RDF.dtLangString.getURI();
+        field.setRangeDatatypeUri(langStringDatatypeUri);
 
     	List<String> validators = new ArrayList<String>();
-    	validators.add("datatype:" + stringDatatypeUri);
+    	validators.add("datatype:" + langStringDatatypeUri);
     	field.setValidators(validators);
 
     	fields.put(field.getName(), field);

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddUserDefinedConceptGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddUserDefinedConceptGenerator.java
@@ -10,14 +10,10 @@ import java.util.Map;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
 
-import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
 import edu.cornell.mannlib.vitro.webapp.beans.ObjectProperty;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
@@ -33,17 +29,7 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
  */
 public class AddUserDefinedConceptGenerator  extends VivoBaseGenerator implements EditConfigurationGenerator {
 
-	private Log log = LogFactory.getLog(AddUserDefinedConceptGenerator.class);
-	private boolean isObjectPropForm = false;
-	private String subjectUri = null;
-	private String predicateUri = null;
-	private String objectUri = null;
-	private String datapropKeyStr= null;
-	private int dataHash = 0;
-	private DataPropertyStatement dps = null;
-	private String dataLiteral = null;
 	private String template = "addUserDefinedConcept.ftl";
-	private static HashMap<String,String> defaultsForXSDtypes ;
 	private static String SKOSConceptType = "http://www.w3.org/2004/02/skos/core#Concept";
 
     @Override
@@ -232,7 +218,6 @@ public class AddUserDefinedConceptGenerator  extends VivoBaseGenerator implement
     private void setSparqlQueries(EditConfigurationVTwo editConfiguration, VitroRequest vreq) {
     	//Sparql queries defining retrieval of literals etc.
     	editConfiguration.setSparqlForAdditionalLiteralsInScope(new HashMap<String, String>());
-    	Map<String, String> urisInScope = new HashMap<String, String>();
     	editConfiguration.setSparqlForAdditionalUrisInScope(new HashMap<String, String>());
     	editConfiguration.setSparqlForExistingLiterals(new HashMap<String, String>());
     	editConfiguration.setSparqlForExistingUris(new HashMap<String, String>());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddUserDefinedConceptGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddUserDefinedConceptGenerator.java
@@ -14,6 +14,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.beans.DataPropertyStatement;
@@ -259,8 +260,8 @@ public class AddUserDefinedConceptGenerator  extends VivoBaseGenerator implement
 			VitroRequest vreq) {
 		editConfiguration.addField(new FieldVTwo().
 				setName("conceptLabel").
-				setValidators(list("datatype:" + XSD.xstring.toString())).
-				setRangeDatatypeUri(XSD.xstring.toString())
+				setValidators(list("datatype:" + RDF.dtLangString.getURI())).
+				setRangeDatatypeUri(RDF.dtLangString.getURI())
 				);
 	}
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantAdministeredByGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantAdministeredByGenerator.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -55,8 +56,8 @@ public class GrantAdministeredByGenerator extends VivoBaseGenerator implements
 
         conf.addField( new FieldVTwo().
                 setName("orgLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -65,8 +66,8 @@ public class GrantHasContributorGenerator  extends VivoBaseGenerator implements 
 
         conf.addField( new FieldVTwo().
                 setName("personLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("personLabelDisplay").

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/GrantHasContributorGenerator.java
@@ -75,14 +75,14 @@ public class GrantHasContributorGenerator  extends VivoBaseGenerator implements 
 
         conf.addField( new FieldVTwo().
                 setName("firstName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("lastName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
 		conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationAdministersGrantGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationAdministersGrantGenerator.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -55,8 +56,8 @@ public class OrganizationAdministersGrantGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("grantLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -104,18 +105,18 @@ public class OrganizationForTrainingGenerator  extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("personLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("awardedDegreeLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("existingAwardedDegreeLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("personLabelDisplay").

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationForTrainingGenerator.java
@@ -90,8 +90,8 @@ public class OrganizationForTrainingGenerator  extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("majorField").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("existingPerson")
@@ -124,14 +124,14 @@ public class OrganizationForTrainingGenerator  extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("firstName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("lastName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -142,13 +142,13 @@ public class OrganizationForTrainingGenerator  extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("dept").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("info").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         FieldVTwo startField = new FieldVTwo().
         						setName("startField");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
@@ -239,12 +239,12 @@ public class OrganizationHasPositionHistoryGenerator extends VivoBaseGenerator
 				.setValidators( list("datatype:" + RDF.dtLangString.getURI()) ));
 
     	conf.addField(new FieldVTwo().setName("firstName")
-    			.setRangeDatatypeUri(XSD.xstring.toString())
-				.setValidators( list("datatype:" + XSD.xstring.toString()) ));
+    			.setRangeDatatypeUri(RDF.dtLangString.getURI())
+				.setValidators( list("datatype:" + RDF.dtLangString.getURI()) ));
 
     	conf.addField(new FieldVTwo().setName("lastName")
-    			.setRangeDatatypeUri(XSD.xstring.toString())
-				.setValidators( list("datatype:" + XSD.xstring.toString()) ));
+    			.setRangeDatatypeUri(RDF.dtLangString.getURI())
+				.setValidators( list("datatype:" + RDF.dtLangString.getURI()) ));
 
     	conf.addField(new FieldVTwo().setName("personLabelDisplay")
     			.setRangeDatatypeUri(XSD.xstring.toString())

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/OrganizationHasPositionHistoryGenerator.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -227,15 +228,15 @@ public class OrganizationHasPositionHistoryGenerator extends VivoBaseGenerator
 				);
 
 		conf.addField(new FieldVTwo().setName("positionTitle")
-				.setRangeDatatypeUri(XSD.xstring.toString())
+				.setRangeDatatypeUri(RDF.dtLangString.getURI())
 				.setValidators(list("nonempty")));
 
 		//options for existingPerson will be added in browser by auto complete JS
 		conf.addField(new FieldVTwo().setName("existingPerson"));
 
 		conf.addField(new FieldVTwo().setName("personLabel")
-				.setRangeDatatypeUri(XSD.xstring.toString())
-				.setValidators( list("datatype:" + XSD.xstring.toString()) ));
+				.setRangeDatatypeUri(RDF.dtLangString.getURI())
+				.setValidators( list("datatype:" + RDF.dtLangString.getURI()) ));
 
     	conf.addField(new FieldVTwo().setName("firstName")
     			.setRangeDatatypeUri(XSD.xstring.toString())

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
@@ -120,14 +120,14 @@ public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("firstName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("lastName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo(). // options set by auto complete JS

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdviseeRelationshipGenerator.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -113,8 +114,8 @@ public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("advisingRelLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -135,8 +136,8 @@ public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("subjAreaLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -151,8 +152,8 @@ public class PersonHasAdviseeRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("advisorLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
@@ -120,14 +120,14 @@ public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("firstName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("lastName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo(). // options set by auto complete JS

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAdvisorRelationshipGenerator.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -113,8 +114,8 @@ public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("advisingRelLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -135,8 +136,8 @@ public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("subjAreaLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
@@ -151,8 +152,8 @@ public class PersonHasAdvisorRelationshipGenerator extends VivoBaseGenerator imp
 
         conf.addField( new FieldVTwo().
                 setName("adviseeLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAwardOrHonorGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAwardOrHonorGenerator.java
@@ -105,8 +105,8 @@ public class PersonHasAwardOrHonorGenerator extends VivoBaseGenerator implements
 
         conf.addField( new FieldVTwo().
                 setName("description")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo(). // options will be added in browser by auto complete JS

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAwardOrHonorGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasAwardOrHonorGenerator.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -118,20 +119,20 @@ public class PersonHasAwardOrHonorGenerator extends VivoBaseGenerator implements
 
         conf.addField( new FieldVTwo().
                 setName("awardReceiptLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("orgLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("awardLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()))
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()))
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasEducationalTraining.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasEducationalTraining.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -128,18 +129,18 @@ public class PersonHasEducationalTraining  extends VivoBaseGenerator implements 
 
         conf.addField( new FieldVTwo().
                 setName("orgLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("awardedDegreeLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("existingAwardedDegreeLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("orgLabelDisplay").

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasEducationalTraining.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasEducationalTraining.java
@@ -114,8 +114,8 @@ public class PersonHasEducationalTraining  extends VivoBaseGenerator implements 
 
         conf.addField( new FieldVTwo().
                 setName("majorField").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("existingOrg")
@@ -160,13 +160,13 @@ public class PersonHasEducationalTraining  extends VivoBaseGenerator implements 
 
         conf.addField( new FieldVTwo().
                 setName("dept").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("info").
-                setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators(list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators(list("datatype:" + RDF.dtLangString.getURI())));
 
         FieldVTwo startField = new FieldVTwo().
         						setName("startField");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasIssuedCredentialGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasIssuedCredentialGenerator.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -104,8 +105,8 @@ public class PersonHasIssuedCredentialGenerator extends VivoBaseGenerator implem
 
         conf.addField( new FieldVTwo().
                 setName("credentialLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPositionHistoryGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPositionHistoryGenerator.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -109,7 +110,7 @@ public class PersonHasPositionHistoryGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("positionTitle")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ) );
 
         conf.addField( new FieldVTwo().
@@ -124,8 +125,8 @@ public class PersonHasPositionHistoryGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("orgLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) ) );
+                setRangeDatatypeUri(RDF.dtLangString.getURI()).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) ) );
 
         conf.addField( new FieldVTwo().
                 setName("orgLabelDisplay").

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPreferredTitleGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPreferredTitleGenerator.java
@@ -8,10 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
@@ -20,7 +17,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
 
 public class PersonHasPreferredTitleGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
-    private Log log = LogFactory.getLog(PersonHasPreferredTitleGenerator.class);
 
     @Override
     public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPreferredTitleGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/PersonHasPreferredTitleGenerator.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -58,7 +58,7 @@ public class PersonHasPreferredTitleGenerator extends VivoBaseGenerator implemen
 
         conf.addField( new FieldVTwo().
                 setName("preferredTitle")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addValidator(new AntiXssValidation());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
@@ -82,14 +82,14 @@ public class ProjectHasParticipantGenerator  extends VivoBaseGenerator implement
 
         conf.addField( new FieldVTwo().
                 setName("firstName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         conf.addField( new FieldVTwo().
                 setName("lastName").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) )
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) )
                 );
 
         //Add validator

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ProjectHasParticipantGenerator.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -63,13 +64,13 @@ public class ProjectHasParticipantGenerator  extends VivoBaseGenerator implement
 
         conf.addField( new FieldVTwo().
                 setName("personLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString())));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI())));
 
         conf.addField( new FieldVTwo().
                 setName("roleLabel").
-                setRangeDatatypeUri(XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString(),"nonempty")));
+                setRangeDatatypeUri(RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI(),"nonempty")));
 
         conf.addField( new FieldVTwo().
                 setName("personLabelDisplay").

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasMailingAddressGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasMailingAddressGenerator.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -68,12 +68,12 @@ public class SubjectHasMailingAddressGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("streetAddress")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addField( new FieldVTwo().
                 setName("country")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addField( new FieldVTwo().
@@ -83,13 +83,13 @@ public class SubjectHasMailingAddressGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("locality")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ) );
 
         conf.addField( new FieldVTwo().
                 setName("region")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
-                setValidators( list("datatype:" + XSD.xstring.toString()) ) );
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
+                setValidators( list("datatype:" + RDF.dtLangString.getURI()) ) );
 
         conf.addValidator(new AntiXssValidation());
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasMailingAddressGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasMailingAddressGenerator.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
@@ -20,7 +18,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
 
 public class SubjectHasMailingAddressGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
-    private Log log = LogFactory.getLog(SubjectHasMailingAddressGenerator.class);
 
     @Override
     public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasPhoneFaxNumberGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasPhoneFaxNumberGenerator.java
@@ -8,9 +8,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -23,7 +20,6 @@ import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.validators.
 
 public class SubjectHasPhoneFaxNumberGenerator extends VivoBaseGenerator implements
         EditConfigurationGenerator {
-    private Log log = LogFactory.getLog(SubjectHasPhoneFaxNumberGenerator.class);
 
     @Override
     public EditConfigurationVTwo getEditConfiguration(VitroRequest vreq,

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasPhoneFaxNumberGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/SubjectHasPhoneFaxNumberGenerator.java
@@ -14,8 +14,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-
-import org.apache.jena.vocabulary.XSD;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.EditConfigurationVTwo;
@@ -75,7 +74,7 @@ public class SubjectHasPhoneFaxNumberGenerator extends VivoBaseGenerator impleme
 
         conf.addField( new FieldVTwo().
                 setName("telephoneNumber")
-                .setRangeDatatypeUri( XSD.xstring.toString() ).
+                .setRangeDatatypeUri( RDF.dtLangString.getURI() ).
                 setValidators( list("nonempty") ));
 
         conf.addValidator(new AntiXssValidation());

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVODefaultAddMissingIndividualFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVODefaultAddMissingIndividualFormGenerator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -79,6 +80,7 @@ public class VIVODefaultAddMissingIndividualFormGenerator extends DefaultAddMiss
     	    //make name field
     	    FieldVTwo labelField = new FieldVTwo();
 	        labelField.setName("label");
+	        labelField.setRangeDatatypeUri( RDF.dtLangString.getURI() );
 
     	    FieldVTwo firstNameField = new FieldVTwo();
 	        firstNameField.setName("firstName");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVONewIndividualFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVONewIndividualFormGenerator.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpSession;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
-import org.apache.jena.vocabulary.XSD;
 
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
@@ -71,17 +70,17 @@ public class VIVONewIndividualFormGenerator extends BaseEditConfigurationGenerat
 
     	config.addField(new FieldVTwo().
     	        setName("firstName").
-    	        setRangeDatatypeUri(XSD.xstring.getURI()).
+    	        setRangeDatatypeUri(RDF.dtLangString.getURI()).
     	        setValidators(getFirstNameValidators(vreq)));
 
     	config.addField(new FieldVTwo().
     	        setName("middleName").
-    	        setRangeDatatypeUri(XSD.xstring.getURI()).
+    	        setRangeDatatypeUri(RDF.dtLangString.getURI()).
     	        setValidators(getMiddleNameValidators(vreq)));
 
     	config.addField(new FieldVTwo().
                 setName("lastName").
-    	        setRangeDatatypeUri(XSD.xstring.getURI()).
+    	        setRangeDatatypeUri(RDF.dtLangString.getURI()).
                 setValidators(getLastNameValidators(vreq)));
 
     	config.addField(new FieldVTwo().

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVONewIndividualFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/VIVONewIndividualFormGenerator.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.servlet.http.HttpSession;
 
 import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.XSD;
 
@@ -85,7 +86,7 @@ public class VIVONewIndividualFormGenerator extends BaseEditConfigurationGenerat
 
     	config.addField(new FieldVTwo().
                 setName("label").
-    	        setRangeDatatypeUri(XSD.xstring.getURI()).
+    	        setRangeDatatypeUri(RDF.dtLangString.getURI()).
                 setValidators(getLabelValidators(vreq)));
 
         addFormSpecificData(config, vreq);

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -4974,7 +4974,6 @@ See also core:localAwardId.
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#country">
         <rdfs:label xml:lang="en">country</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
     </owl:DatatypeProperty>
 
@@ -4995,7 +4994,6 @@ See also core:localAwardId.
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#familyName">
         <rdfs:label xml:lang="en">has last name</rdfs:label>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Called Family Name in vCard</rdfs:comment>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
     </owl:DatatypeProperty>
 
@@ -5039,7 +5037,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#givenName">
         <rdfs:label xml:lang="en">first name</rdfs:label>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">called Given Name invCard</rdfs:comment>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
     </owl:DatatypeProperty>
 
@@ -5050,7 +5047,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#honorificPrefix">
         <rdfs:label xml:lang="en">honorific prefix</rdfs:label>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Called Honorific Prefix in vCard</rdfs:comment>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
     </owl:DatatypeProperty>
 
@@ -5060,7 +5056,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#honorificSuffix">
         <rdfs:label xml:lang="en">honorific suffix</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
     </owl:DatatypeProperty>
 
@@ -5100,7 +5095,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#locality">
         <rdfs:label xml:lang="en">locality</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
     </owl:DatatypeProperty>
 
@@ -5189,7 +5183,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#region">
         <rdfs:label xml:lang="en">region</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
     </owl:DatatypeProperty>
 
@@ -5256,7 +5249,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#streetAddress">
         <rdfs:label xml:lang="en">street address</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
     </owl:DatatypeProperty>
 
@@ -5285,7 +5277,6 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
 
     <owl:DatatypeProperty rdf:about="http://www.w3.org/2006/vcard/ns#title">
         <rdfs:label xml:lang="en">title</rdfs:label>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:domain rdf:resource="http://www.w3.org/2006/vcard/ns#Title"/>
     </owl:DatatypeProperty>
 
@@ -9468,7 +9459,7 @@ This class allows for linking an author to a publication while indicating inform
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#supplementalInformation"/>
-                <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+                <owl:allValuesFrom rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -10857,30 +10848,14 @@ Contents
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#country"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#country"/>
-                                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#locality"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#locality"/>
-                                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
+                   <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#country"/>
+                        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#locality"/>
+                        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+                    </owl:Restriction>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
                             <owl:Restriction>
@@ -10893,30 +10868,14 @@ Contents
                             </owl:Restriction>
                         </owl:intersectionOf>
                     </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#region"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#region"/>
-                                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#streetAddress"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#streetAddress"/>
-                                <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#region"/>
+                        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#streetAddress"/>
+                        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+                    </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
@@ -11914,54 +11873,22 @@ Was called IMPP in vCard.</rdfs:comment>
                             </owl:Restriction>
                         </owl:intersectionOf>
                     </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#familyName"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#familyName"/>
                                 <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#givenName"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#givenName"/>
                                 <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
                             </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#honorificPrefix"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-                            </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#honorificPrefix"/>
                                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#honorificSuffix"/>
-                                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#honorificSuffix"/>
                                 <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">0</owl:minCardinality>
                             </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>


### PR DESCRIPTION
[GitHub Issue](https://github.com/vivo-project/VIVO/issues/3717)
Goes with [PR](https://github.com/vivo-project/Vitro/pull/296)

Fixed N3 Generators to save rdf:langString literals with language tags instead of xsd:string. 

Removed xsd:string ranges from data properties:
http://www.w3.org/2006/vcard/ns#givenName
http://www.w3.org/2006/vcard/ns#familyName
http://www.w3.org/2006/vcard/ns#honorificSuffix
http://www.w3.org/2006/vcard/ns#honorificPrefix
http://www.w3.org/2006/vcard/ns#locality
http://www.w3.org/2006/vcard/ns#streetAddress
http://www.w3.org/2006/vcard/ns#country
http://www.w3.org/2006/vcard/ns#region
http://www.w3.org/2006/vcard/ns#title
http://vivoweb.org/ontology/core#supplementalInformation

### How to test
For each of modified generators:
1. Creating individuals
2. Verify that created individuals have labels and other literals with language tags

Applied on https://vivo.tib.eu/vivo113rc