### PR TITLE
Privilages for editing grant contributors

### DIFF
--- a/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
+++ b/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
@@ -1936,7 +1936,7 @@ local:grantRelatesConfig a :ObjectPropertyDisplayConfig ;
     :displayName "contributor" ;
     vitro:displayRankAnnot 55;
     vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
-    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:nobody ;
+    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:editor ;
     vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.GrantHasContributorGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
     :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> .
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3733](https://github.com/vivo-project/VIVO/issues/3733)

# What does this pull request do?
Adding rights to editor and site admin for editing grant contributors from the grant individual page

# How should this be tested?

1. Log in as a root user
2. Create an editor
3. Log in as an editor
4. Open a person profile page
5. Click on Research tab
6. Click on plus next to Investigator and add a grant
7. Click on the grant link (a grant individual page will be open)
8. Click on the tab Affiliation
9. Click on the plus sign next to the contributors and add a contributor 

1. Log in as a root user
2. Create a site admin
3. Log in as site admin
4. Open a person profile page
5. Click on Research tab
6. Click on plus next to Investigator and add a grant
7. Click on the grant link (a grant individual page will be open)
8. Click on the tab Affiliation
9. Click on the plus sign next to the contributors and add a contributor 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
