### PR TITLE
Rename Google Refine to OpenRefine

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -406,7 +406,7 @@ visualization.temporal = enabled
 proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf/0.1/Organization
 
   #
-  # Default type(s) for Google Refine Reconciliation Service
+  # Default type(s) for OpenRefine Reconciliation Service
   # The format for this property is id, name; id1, name1; id2, name2 etc.
   # For more information, see Service Metadata from this page:
   # https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-Api


### PR DESCRIPTION
# What does this pull request do?
Rename Google Refine to OpenRefine in a comment in Runtime Properties. Google Refine was renamed a few years ago.

# How should this be tested?

# Additional Notes:
Might require a change in the documentation, if Google Refine is mentioned there as such.

# Interested parties
@VIVO-project/vivo-committers
