### PR TITLE
configuration of reconcile api in the example.runtime.properties

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -411,13 +411,13 @@ proxy.eligibleTypeList = http://xmlns.com/foaf/0.1/Person, http://xmlns.com/foaf
   # For more information, see Service Metadata from this page:
   # https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-Api
   #
-Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Role; \
-    http://vivoweb.org/ontology/core#AcademicDegree, core:Academic Degree; \
-    http://purl.org/NET/c4dm/event.owl#Event, event:Event; \
-    http://vivoweb.org/ontology/core#Location, core:Location; \
-    http://xmlns.com/foaf/0.1/Organization, foaf:Organization; \
-    http://xmlns.com/foaf/0.1/Person, foaf:Person; \
-    http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030
+# Vitro.reconcile.defaultTypeList = http://vivoweb.org/ontology/core#Role, core:Role; \
+#   http://vivoweb.org/ontology/core#AcademicDegree, core:Academic Degree; \
+#   http://purl.org/NET/c4dm/event.owl#Event, event:Event; \
+#   http://vivoweb.org/ontology/core#Location, core:Location; \
+#   http://xmlns.com/foaf/0.1/Organization, foaf:Organization; \
+#   http://xmlns.com/foaf/0.1/Person, foaf:Person; \
+#   http://purl.obolibrary.org/obo/IAO_0000030, obo:IAO_0000030
 
   # Configure the support for claiming by DOI or PMID
   # This is a list of all the providers that are active for claiming articles from


### PR DESCRIPTION
# What does this pull request do?
removing default configuration of reconcile api (it is available in comments when it is needed to be turned on) 

# How should this be tested?
- Go to https://reconciliation-api.github.io/testbench/#/client/
- Enter the Endpoint of a VIVO reconciliation API, for example http://localhost:8080/reconcile
- Enter "Spain" in the name box, click on the Reconcile button.
- there shouldn't be any response

You can also try to open in the web browser http://localhost:8080/reconcile, defultTypes shouldn't be there as it is present at https://vivo.tib.eu/fis/reconcile

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
