### PR TITLE
[ i18n sprint ] VIVO-3748 Remove "Other" special case from ChildVClassesWithParent

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
@@ -55,11 +55,9 @@
     <#assign urlTypeOpts = editConfiguration.pageData.urlType />
     <select name="urlType" style="margin-top:-2px" >
         <#list urlTypeOpts?keys as key>
-            <option value="${key}"  <#if editMode == "add" && urlTypeOpts[key] == "Other">selected<#elseif urlTypeValue == key>selected</#if> >
+            <option value="${key}" >
                 <#if urlTypeOpts[key] == "F1000 Link">
                     ${i18n().faculty_of_1000}
-                <#elseif urlTypeOpts[key] == "Other">
-                    ${i18n().standard_web_link}
                 <#else>
                     ${urlTypeOpts[key]}
                 </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson.ftl
@@ -104,7 +104,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
       <select id="typeSelector" name="presentationType" acGroupName="presentation">
         <option value="" selected="selected">${i18n().select_one}</option>
         <#list presentationTypeOpts?keys as key>
-            <option value="${key}" <#if presentationTypeValue = key>selected</#if>><#if presentationTypeOpts[key] == "Other">${i18n().presentation_capitalized}<#else>${presentationTypeOpts[key]}</#if></option>
+            <option value="${key}" <#if presentationTypeValue = key>selected</#if>>${presentationTypeOpts[key]}</option>
         </#list>
     </select>
     </p>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/grantHasContributor.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/grantHasContributor.ftl
@@ -129,7 +129,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <select name="roleType" style="margin-top:-2px" >
         <option value="" <#if roleTypeValue == "">selected</#if>>${i18n().select_one}</option>
         <#list roleTypeOpts?keys as key>
-            <option value="${key}"  <#if roleTypeValue == key>selected</#if>><#if roleTypeOpts[key] == "Other">${i18n().researcher_role}<#else>${roleTypeOpts[key]}</#if></option>
+            <option value="${key}"  <#if roleTypeValue == key>selected</#if>>${roleTypeOpts[key]}</option>
         </#list>
     </select>
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationForTraining.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationForTraining.ftl
@@ -134,7 +134,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <select name="trainingType" style="margin-top:-2px" >
         <option value="" <#if trainingTypeValue == "">selected</#if>>${i18n().select_one}</option>
         <#list trainingTypeOpts?keys as key>
-            <option value="${key}"  <#if trainingTypeValue == key>selected</#if>><#if trainingTypeOpts[key] == "Other">${i18n().academic_studies_or_other}<#else>${trainingTypeOpts[key]}</#if></option>
+            <option value="${key}"  <#if trainingTypeValue == key>selected</#if>>${trainingTypeOpts[key]}</option>
         </#list>
     </select>
     <p>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining.ftl
@@ -147,7 +147,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <select name="trainingType" style="margin-top:-2px" >
         <option value="" <#if trainingTypeValue == "">selected</#if>>${i18n().select_one}</option>
         <#list trainingTypeOpts?keys as key>
-            <option value="${key}"  <#if trainingTypeValue == key>selected</#if>><#if trainingTypeOpts[key] == "Other">${i18n().academic_studies_or_other}<#else>${trainingTypeOpts[key]}</#if></option>
+            <option value="${key}"  <#if trainingTypeValue == key>selected</#if>>${trainingTypeOpts[key]}</option>
         </#list>
     </select>
     <p>

--- a/webapp/src/main/webapp/themes/nemo/i18n/all.properties
+++ b/webapp/src/main/webapp/themes/nemo/i18n/all.properties
@@ -334,7 +334,6 @@ add_webpage_for = Add webpage for
 add_webpage = Add Web Page
 url_type = URL Type
 faculty_of_1000 = Faculty of 1000 Link
-standard_web_link = Standard Web Link
 webpage_name = Webpage Name
 
 investigator_entry_for = investigator entry for
@@ -367,7 +366,6 @@ outreach_comm_service_in = outreach & community service in
 select_or_enter_name = Please select an existing value or enter a new value in the Name field.
 enter_new_role_value = Please enter a new value in the Role field.
 presentation_entry_for = presentation entry for
-presentation_capitalized = Presentation
 presentation_type = Presentation Type
 role_in = Role in
 presentation_hint = e.g., Moderator, Speaker, Panelist
@@ -514,7 +512,6 @@ missing_degree = missing degree
 major_field = Major Field of Degree
 supplemental_information = Supplemental Information
 supplemental_information_hint = (e.g., Thesis title, Transfer info, etc.)
-academic_studies_or_other = Academic Studies or Other Training
 
 edit_mailing_address = Edit Mailing Address
 create_mailing_address = Create Mailing Address


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3748)**
[Companion VIVO-languages PR](https://github.com/vivo-project/VIVO-languages/pull/112)
[Companion Vitro PR](https://github.com/vivo-project/Vitro/pull/328)

# What does this pull request do?
Removed check for "Other" special case. Removed unused translations.

# How should this be tested?
Verify that described issue is no longer reproducible after this fix applied.
Verify forms:
- Add webpage for individual
- Add presenter role to person (described in the issue)
- Add education and training to person
- Add contributor to grant
- Add organization for training to organization

# Interested parties
@VIVO-project/vivo-committers
