### PR TITLE
Fix contact form link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are several ways to contact the VIVO community.
 Whatever your interest, we would be pleased to hear from you.
 
 ### Contact form 
-http://vivoweb.org/support/user-feedback
+https://vivo.lyrasis.org/contact/
 
 ### Mailing lists
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [(please link to issue)](https://vivo.lyrasis.org/contact/)

# What does this pull request do?
Link to new contact form is added, old link removed.

# How should this be tested?
Click on the link.


# Interested parties
@VIVO-project/vivo-committers
