### PR TITLE
[i18n sprint] moving translations for map of science from ftl files to property files

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/aboutMapOfScience.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/aboutMapOfScience.ftl
@@ -1,0 +1,31 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+
+<#assign aboutImagesRoot = '${urls.images}/visualization/mapofscience/about/'>
+
+<h2>${i18n().about_map_of_science_heading}</h2>
+<h3>${i18n().reference_basemap_heading}</h3>
+<p>${i18n().reference_basemap_description}</p>
+
+<h3>${i18n().data_overlay_heading}</h3>
+<p>${i18n().data_overlay_description}</p>
+
+<img src="${aboutImagesRoot}/scimap_discipline.jpg" width="450" height="327" />
+<img src="${aboutImagesRoot}/scimap_subdiscipline.jpg" width="450" height="327" />
+
+<h3>${i18n().expertise_profile_comparision_map_heading}</h3>
+<p>${i18n().expertise_profile_comparision_map_description}</p>
+
+<img src="${aboutImagesRoot}/scimap_comparison.jpg" width="803" height="781" style=
+"margin-left: 50px;"/>
+
+<h3>${i18n().interactivity_heading}</h3>
+<p>${i18n().interactivity_description}</p>
+
+<h3>${i18n().links_heading}</h3>
+<p>
+    ${i18n().links_description_the_first_part}
+    <a href="https://doi.org/10.1371/journal.pone.0039464" target="_blank">https://doi.org/10.1371/journal.pone.0039464</a>.
+    ${i18n().links_description_the_introduction_part}
+    <a href="http://scimaps.org" target="_blank">http://scimaps.org</a> ${i18n().and}
+    <a href="http://mapofscience.com" target="_blank">http://mapofscience.com</a>.
+</p>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceTooltips.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceTooltips.ftl
@@ -1,0 +1,51 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+
+<#-- START TOOLTIP TEXT -->
+
+<div id="toolTipOne" style="display:none;">
+	${i18n().map_of_science_visualization_tool_tip_one(entityLabel)}<br /><br />
+
+	<a href='${subEntityMapOfScienceCommonURL}about'>${i18n().map_of_science_visualization_learn_more}</a>
+</div>
+
+<div id="toolTipTwo" style="display:none;">
+	${i18n().map_of_science_visualization_tool_tip_two_the_first_part}<br /><br />
+
+	${i18n().map_of_science_visualization_tool_tip_two_the_second_part}<br /><br />
+
+	${i18n().map_of_science_visualization_tool_tip_two_the_third_part}
+</div>
+
+<div id="toolTipThree" style="display:none;">
+	${i18n().map_of_science_visualization_tool_tip_three_the_first_part(entityLabel)}<br /><br />
+
+	${i18n().map_of_science_visualization_tool_tip_three_the_second_part}
+</div>
+
+<div id="exploreTooltipText" style="display:none;">
+	${i18n().explore_tool_tip_text}
+</div>
+
+<div id="compareTooltipText" style="display:none;">
+	${i18n().compare_tool_tip_text_the_first_part}
+</div>
+
+<div id="searchInfoTooltipText" style="display:none;">
+	${i18n().search_info_tool_tip_text_the_first_part}
+</div>
+
+
+<#-- COMPARISON TOOLTIP TEXT -->
+
+<div id="comparisonToolTipTwo" style="display:none;">
+	${i18n().compare_tool_tip_text_the_second_part(entityLabel)} <br /><br />
+
+	${i18n().compare_tool_tip_text_the_third_part} <br /><br />
+
+	${i18n().compare_tool_tip_text_the_fourth_part}
+</div>
+
+<div id="comparisonSearchInfoTooltipText" style="display:none;">
+	${i18n().search_info_tool_tip_text_the_second_part}
+</div>
+<#-- END TOOLTIP TEXT -->


### PR DESCRIPTION
[Companion PR](https://github.com/vivo-project/VIVO-languages/pull/114)
# What does this pull request do? #
Creates language-neutral aboutMapOfScience and mapOfScienceTooltips pages
# How to test # 
Pages to test /vis/map-of-science/ (you need a researcher profile who published a paper in the journal Science) and /vis/map-of-science/about
# Translations review # 
The translation for French is missing, there is the English translate at the moment.
Translations for other languages didn't change, just copied from ftl files to property files.