### PR TITLE
Changed hard coded strings in addPublicationToPerson.ftl to language-neutral variables

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
@@ -318,7 +318,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         acTypes: {publication: 'http://purl.org/ontology/bibo/Document', collection: 'http://purl.org/ontology/bibo/Periodical', book: 'http://purl.org/ontology/bibo/Book', conference: 'http://purl.org/NET/c4dm/event.owl#Event', event: 'http://purl.org/NET/c4dm/event.owl#Event', editor: 'http://xmlns.com/foaf/0.1/Person', publisher: 'http://xmlns.com/foaf/0.1/Organization'},
         editMode: '${editMode}',
         defaultTypeName: '${i18n().publication?js_string}', // used in repair mode to generate button text
-        multipleTypeNames: {collection: '${i18n().publication?js_string}', book: '${i18n().book?js_string}', conference: '${i18n().conference?js_string}', event: '${i18n().event?js_string}', editor: '${i18n().editor?js_string}', publisher: '${i18n().publisher?js_string}'},
+        multipleTypeNames: {publication : '${i18n().publication?js_string}', collection: '${i18n().publication?js_string}', book: '${i18n().book?js_string}', conference: '${i18n().conference?js_string}', event: '${i18n().event?js_string}', editor: '${i18n().editor?js_string}', publisher: '${i18n().publisher?js_string}'},
         baseHref: '${urls.base}/individual?uri=',
         blankSentinel: '${blankSentinel}',
         flagClearLabelForExisting: '${flagClearLabelForExisting}'

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
@@ -317,8 +317,8 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         acUrl: '${urls.base}/autocomplete?tokenize=true',
         acTypes: {publication: 'http://purl.org/ontology/bibo/Document', collection: 'http://purl.org/ontology/bibo/Periodical', book: 'http://purl.org/ontology/bibo/Book', conference: 'http://purl.org/NET/c4dm/event.owl#Event', event: 'http://purl.org/NET/c4dm/event.owl#Event', editor: 'http://xmlns.com/foaf/0.1/Person', publisher: 'http://xmlns.com/foaf/0.1/Organization'},
         editMode: '${editMode}',
-        defaultTypeName: 'publication', // used in repair mode to generate button text
-        multipleTypeNames: {collection: 'publication', book: 'book', conference: 'conference', event: 'event', editor: 'editor', publisher: 'publisher'},
+        defaultTypeName: '${i18n().publication?js_string}', // used in repair mode to generate button text
+        multipleTypeNames: {collection: '${i18n().publication?js_string}', book: '${i18n().book?js_string}', conference: '${i18n().conference?js_string}', event: '${i18n().event?js_string}', editor: '${i18n().editor?js_string}', publisher: '${i18n().publisher?js_string}'},
         baseHref: '${urls.base}/individual?uri=',
         blankSentinel: '${blankSentinel}',
         flagClearLabelForExisting: '${flagClearLabelForExisting}'


### PR DESCRIPTION
**[VIVO GitHub issue 3752](https://github.com/vivo-project/VIVO/issues/3752)**

# What does this pull request do?
Changes hardcoded strings 'publication', 'collection' , 'book', 'editor', 'conference', 'event', 'publisher' to language-neutral variables in the entry form for selected publications (Create publication entry for) 


Example:
* Changes defaultTypeName: 'publication' to defaultTypeName: '${i18n().publication?js_string}' 
* Changes multipleTypeNames: {publication : '${i18n().publication?js_string}', collection: 'publication', book: 'book' , conference: 'conference' , event: 'event', editor: 'editor', publisher: 'publisher' } to multipleTypeNames: {collection: '${i18n().publication?js_string}', book: '${i18n().book?js_string}', conference: '${i18n().conference?js_string}', event: '${i18n().event?js_string}', editor: '${i18n().editor?js_string}', publisher: '${i18n().publisher?js_string}'}


# How should this be tested?

* publication, book, conference, event, editor and publisher should be first added to https://github.com/vivo-project/VIVO-languages i18n property files.
* Test in the entry form ### Create publication entry for


# Interested parties
 @VIVO-project/vivo-committers
