### PR TITLE
[ i18n sprint ] I18n fixes for edit forms

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorRoleToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorRoleToPerson.ftl
@@ -18,9 +18,11 @@ roleExamples-->
 
 
 <#--Variable assignments for Add Clinical Role To Person-->
+<#setting url_escaping_charset="UTF-8">
+<#setting output_encoding="UTF-8">
 <#assign roleDescriptor = "${i18n().collection_series_editor_role}" />
 <#assign typeSelectorLabel = "${i18n().editor_role_in}" />
-<#assign genericLabel = "Collection or Series" />
+<#assign genericLabel = "${i18n().collection_or_series}" />
 
 <#assign acTypes = "{activity: 'http://purl.org/ontology/bibo/Collection'}" />
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
@@ -126,12 +126,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
 <@lvf.unsupportedBrowser urls.base />
 
-<section id="add${roleDescriptor?capitalize}RoleToPersonTwoStage" role="region">
+<section id="add${roleDescriptor?cap_first}RoleToPersonTwoStage" role="region">
 
-    <form id="add${roleDescriptor?capitalize}RoleToPersonTwoStage" class="customForm noIE67" action="${submitUrl}"  role="add/edit grant role">
+    <form id="add${roleDescriptor?cap_first}RoleToPersonTwoStage" class="customForm noIE67" action="${submitUrl}"  role="add/edit grant role">
 
        <p class="inline">
-        <label for="typeSelector">${typeSelectorLabel?capitalize}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+        <label for="typeSelector">${typeSelectorLabel?cap_first}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
         <#--Code below allows for selection of first 'select one' option if no activity type selected-->
         <#if activityTypeValue?has_content>
         	<#assign selectedActivityType = activityTypeValue />
@@ -160,7 +160,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
 <#--   <div class="fullViewOnly"> -->
             <p>
-                <label for="activity">${genericLabel?capitalize} ${i18n().name_capitalized} ${requiredHint}</label>
+                <label for="activity">${genericLabel?cap_first} ${i18n().name_capitalized} ${requiredHint}</label>
                 <input class="acSelector" size="50"  type="text" id="activity" name="activityLabel"  acGroupName="activity" value="${activityLabelValue}" />
                 <input class="display" type="hidden" id="activityDisplay" acGroupName="activity" name="activityLabelDisplay" value="${activityLabelDisplayValue}">
             </p>
@@ -170,7 +170,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
             <div class="acSelection" acGroupName="activity">
                 <p class="inline">
-                    <label></label>
+                    <label>${i18n().selected}</label>
                     <span class="acSelectionInfo"></span>
                     <a href="/vivo/individual?uri=" class="verifyMatch" title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
                     <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>
@@ -181,7 +181,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
             </div>
 
             <#if showRoleLabelField = true>
-            <p><label for="roleLabel">${i18n().role_in} ${genericLabel?capitalize} ${roleExamples}</label>
+            <p><label for="roleLabel">${i18n().role_in} ${genericLabel?cap_first} ${roleExamples}</label>
                 <input  size="50"  type="text" id="roleLabel" name="roleLabel" value="${roleLabel}" />
             </p>
         	</#if>
@@ -195,12 +195,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
             <#else>
                 <h4 class="label">${i18n().years_participating} </h4>
                 <#if htmlForElements?keys?seq_contains("startField")>
-                	    <label class="dateTime" for="startField">${i18n().start_capitalized}</label>
+                	    <label class="dateTime" for="startField">${i18n().start_year}</label>
                		    ${htmlForElements["startField"]} ${yearHint}
                </#if>
                <p></p>
                <#if htmlForElements?keys?seq_contains("endField")>
-               		    <label class="dateTime" for="endField">${i18n().end_capitalized}</label>
+               		    <label class="dateTime" for="endField">${i18n().end_year}</label>
                		    ${htmlForElements["endField"]} ${yearHint}
                </#if>
             </#if>
@@ -222,7 +222,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 	    acTypes: ${acTypes!},
 	    <#if acMultipleTypes??>acMultipleTypes: ${acMultipleTypes!},</#if>
 	    // used in repair mode: button text and org name label
-	    defaultTypeName: <#if genericLabel??>'${genericLabel}'<#else>'activity'</#if>,
+	    defaultTypeName: <#if genericLabel??>'${genericLabel?js_string}'<#else>'activity'</#if>,
 	    baseHref: '${urls.base}/individual?uri=',
         blankSentinel: '${blankSentinel}',
         flagClearLabelForExisting: '${flagClearLabelForExisting}'

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
@@ -190,18 +190,18 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
                <#--Generated html is a map with key name mapping to html string-->
                <#if htmlForElements?keys?seq_contains("startField")>
                 	<label class="dateTimeLabel" for="startField">${i18n().start_year}</label>
-               		${htmlForElements["startField"]} ${yearHint}
+               		<@lvf.printYearField "startField" /> ${yearHint}
                </#if>
             <#else>
                 <h4 class="label">${i18n().years_participating} </h4>
                 <#if htmlForElements?keys?seq_contains("startField")>
-                	    <label class="dateTime" for="startField">${i18n().start_year}</label>
-               		    ${htmlForElements["startField"]} ${yearHint}
+                	<label class="dateTime" for="startField">${i18n().start_year}</label>
+               		<@lvf.printYearField "startField" /> ${yearHint}
                </#if>
                <p></p>
                <#if htmlForElements?keys?seq_contains("endField")>
-               		    <label class="dateTime" for="endField">${i18n().end_year}</label>
-               		    ${htmlForElements["endField"]} ${yearHint}
+                    <label class="dateTime" for="endField">${i18n().end_year}</label>
+               		<@lvf.printYearField "endField" /> ${yearHint}
                </#if>
             </#if>
 <#--        </div> -->

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -3,7 +3,7 @@
 <#import "lib-vivo-form.ftl" as lvf>
 
 <#assign formTitle>
- "${editConfiguration.propertyPublicDomainTitle}" entry for ${editConfiguration.subjectName}
+${i18n.new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
 </#assign>
 <#if editConfiguration.objectUri?has_content>
     <#assign formTitle>${i18n().edit_capitalized} ${formTitle} </#assign>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -3,7 +3,7 @@
 <#import "lib-vivo-form.ftl" as lvf>
 
 <#assign formTitle>
-${i18n.new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
+${i18n().new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfiguration.subjectName)}
 </#assign>
 <#if editConfiguration.objectUri?has_content>
     <#assign formTitle>${i18n().edit_capitalized} ${formTitle} </#assign>

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-vivo-form.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-vivo-form.ftl
@@ -107,3 +107,10 @@ return - returns empty string if no value found-->
 	</#if>
 	<#return false>
 </#function>
+
+<#macro printYearField fieldName required=false>
+    <fieldset class="dateTime">
+        <input class="text-field" name="${fieldName}-year" id="${fieldName}-year" type="text" value="${year!}" size="4" maxlength="4" <#if required>required </#if> />
+    </fieldset>
+</#macro>
+


### PR DESCRIPTION
[Companion PR VIVO-languages](https://github.com/vivo-project/VIVO-languages/pull/116)
[Companion PR Vitro](https://github.com/vivo-project/Vitro/pull/336)
[Companion PR Vitro-languages](https://github.com/vivo-project/Vitro-languages/pull/63)
# What does this pull request do?
This pull request is one of many efforts to improve language neutral Freemarker templates and thus eliminate the need to support language specific templates

Imported fixes from language specific 
https://github.com/vivo-project/VIVO-languages/pull/116/files#diff-bf3f484c537ac9a4842a00b9fd05fa8a5b2736a063d227ea267a4a41a234e1c1
https://github.com/vivo-project/VIVO-languages/pull/116/files#diff-78d57e69e61fc3f97b28ce03f1e1880b2defb2cd999c4c78cdc90c1df272f430
https://github.com/vivo-project/VIVO-languages/pull/116/files#diff-c426a780340d83909740bb200dd8860ac6c52813c1654205c67fe7fff2ada59f

# How to test
* Create a person
* Add role head of 
* Add role memeber of 
* Add advisees 
Create publication
* Add authors via Manage list of authors
* Add editors via Manage list of editors
* Open person profile, click add geographic location, click add new item of this type (leave Campus selected)
You should see something like Create "geographic location" entry for ... 
