### PR TITLE
[i18n sprint] Language-neutral help text in autocomplete forms

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyAutoComplete.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyAutoComplete.ftl
@@ -125,7 +125,7 @@ Also multiple types parameter set to true only if more than one type returned-->
     };
     var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson.ftl
@@ -136,7 +136,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addGrantRoleToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addGrantRoleToPerson.ftl
@@ -168,7 +168,7 @@ var customFormData  = {
     };
     var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
 </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson.ftl
@@ -185,7 +185,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson.ftl
@@ -325,7 +325,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     };
     var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage.ftl
@@ -229,7 +229,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 	};
 	var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addUserDefinedConcept.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addUserDefinedConcept.ftl
@@ -63,7 +63,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     };
     var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
@@ -72,7 +72,7 @@ Also multiple types parameter set to true only if more than one type returned-->
     };
     var i18nStrings = {
         selectExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
@@ -71,7 +71,6 @@ Also multiple types parameter set to true only if more than one type returned-->
         defaultTypeName: '${propertyPublicName}'
     };
     var i18nStrings = {
-        selectExisting: '${i18n().select_an_existing?js_string}',
         selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/grantAdministeredBy.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/grantAdministeredBy.ftl
@@ -115,7 +115,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
 };
 </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/grantHasContributor.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/grantHasContributor.ftl
@@ -158,7 +158,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithDataAutocomplete.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithDataAutocomplete.js
@@ -421,7 +421,7 @@ var customForm = {
 
         // First case applies on page load; second case applies when the type gets changed.
         if (!this.acSelector.val() || this.acSelector.hasClass(this.acHelpTextClass)) {
-        	var helpText = customForm.selectExisting + " " + typeText + " " + customForm.orCreateNewOne;
+        	var helpText = customForm.selectAnExistingOrCreateNewOne ;
         	//Different for object property autocomplete
 			this.acSelector.val(helpText)
 		               	   .addClass(this.acHelpTextClass);

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationAdministersGrant.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationAdministersGrant.ftl
@@ -115,7 +115,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
 };
 </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationForTraining.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationForTraining.ftl
@@ -204,7 +204,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationHasPositionHistory.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/organizationHasPositionHistory.ftl
@@ -166,7 +166,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 	};
 	var i18nStrings = {
         selectAnExisting: '${i18n().select_an_existing?js_string}',
-        orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+        selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
         selectedString: '${i18n().selected?js_string}'
     };
     </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdviseeRelationship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdviseeRelationship.ftl
@@ -218,7 +218,7 @@ var customFormData  = {
 <#--Also removed this: ,doNotRemoveOriginalObject: '${doNotRemoveOriginalObject}'-->
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
     advisingString: '${i18n().advising?js_string}',
     advisingRelationshipString: '${i18n().advising_relationship?js_string}'

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdvisorRelationship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAdvisorRelationship.ftl
@@ -218,8 +218,8 @@ var customFormData  = {
 <#--Also removed this: ,doNotRemoveOriginalObject: '${doNotRemoveOriginalObject}'-->
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     advisingString: '${i18n().advising?js_string}',
     advisingRelationshipString: '${i18n().advising_relationship?js_string}'
 };

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAwardOrHonor.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasAwardOrHonor.ftl
@@ -197,7 +197,7 @@ var customFormData  = {
 var i18nStrings = {
     selectAnOrganization: '${i18n().select_or_create_organization?js_string}',
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining.ftl
@@ -225,7 +225,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasIssuedCredential.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasIssuedCredential.ftl
@@ -200,7 +200,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}',
 };
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
@@ -184,7 +184,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 </script>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/projectHasParticipant.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/projectHasParticipant.ftl
@@ -154,7 +154,7 @@ var customFormData  = {
 };
 var i18nStrings = {
     selectAnExisting: '${i18n().select_an_existing?js_string}',
-    orCreateNewOne: '${i18n().or_create_new_one?js_string}',
+    selectAnExistingOrCreateNewOne: '${i18n().select_an_existing_or_create_a_new_one?js_string}',
     selectedString: '${i18n().selected?js_string}'
 };
 


### PR DESCRIPTION
[Companion Vitro-languages PR](https://github.com/vivo-project/Vitro-languages/pull/64)
[Companion Vitro PR](https://github.com/vivo-project/Vitro/pull/338)
# What does this pull request do?
Use language-neutral selectAnExistingOrCreateNewOne translation key as help text in forms with auto-completion

# How should this be tested?
Try out forms with auto-completion to see new text

# Interested parties
@tawahle 
