### PR TITLE
Replacement of language comparisons using '=' by the 'langMatches'

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
+++ b/api/src/main/java/edu/cornell/mannlib/semservices/service/impl/AgrovocService.java
@@ -49,24 +49,24 @@ import edu.cornell.mannlib.vitro.webapp.web.URLEncoder;
 
 public class AgrovocService implements ExternalConceptService {
 
-	protected final Log logger = LogFactory.getLog(getClass());
-	private final String schemeUri = "http://aims.fao.org/aos/agrovoc/agrovocScheme";
-	private final String ontologyName = "agrovoc";
-	private final String format = "SKOS";
-	private final String lang = "en";
-	private final String searchMode = "starts with";//Used to be Exact Match, or exact word or starts with
-	protected final String dbpedia_endpoint = " http://dbpedia.org/sparql";
-	// URL to get all the information for a concept
+    protected final Log logger = LogFactory.getLog(getClass());
+    private final String schemeUri = "http://aims.fao.org/aos/agrovoc/agrovocScheme";
+    private final String ontologyName = "agrovoc";
+    private final String format = "SKOS";
+    private final String lang = "en";
+    private final String searchMode = "starts with";//Used to be Exact Match, or exact word or starts with
+    protected final String dbpedia_endpoint = " http://dbpedia.org/sparql";
+    // URL to get all the information for a concept
 
-	protected final String conceptSkosMosBase = "https://agrovoc.uniroma2.it/agrovoc/rest/v1/";
-	protected final String conceptsSkosMosSearch = conceptSkosMosBase + "search?";
-	protected final String conceptSkosMosURL = conceptSkosMosBase + "data?";
-	@Override
-	public List<Concept> getConcepts(String term) throws Exception {
-		List<Concept> conceptList = new ArrayList<>();
+    protected final String conceptSkosMosBase = "https://agrovoc.uniroma2.it/agrovoc/rest/v1/";
+    protected final String conceptsSkosMosSearch = conceptSkosMosBase + "search?";
+    protected final String conceptSkosMosURL = conceptSkosMosBase + "data?";
+    @Override
+    public List<Concept> getConcepts(String term) throws Exception {
+        List<Concept> conceptList = new ArrayList<>();
 
-		//For the RDF webservices mechanism, utilize the following
-		/*
+        //For the RDF webservices mechanism, utilize the following
+        /*
 		String result = getTermExpansion(this.ontologyName, term,
 				this.searchMode, this.format, this.lang);
 
@@ -77,319 +77,322 @@ public class AgrovocService implements ExternalConceptService {
 
 		// Get the list of the concept URIs in the RDF
 		List<String> conceptUris = getConceptURIsListFromRDF(result);
-		*/
+         */
 
-		//For the SKOSMos search mechanism, utilize this instead
-		String result = getSKOSMosSearchResults(term, this.lang);
-		List<String> conceptUris = getConceptURIsListFromSkosMosResult(result);
-		if (conceptUris.size() == 0)
-			return conceptList;
-		int conceptCounter = 0;
+        //For the SKOSMos search mechanism, utilize this instead
+        String result = getSKOSMosSearchResults(term, this.lang);
+        List<String> conceptUris = getConceptURIsListFromSkosMosResult(result);
+        if (conceptUris.size() == 0)
+            return conceptList;
+        int conceptCounter = 0;
 
-		HashSet<String> encounteredURI = new HashSet<>();
+        HashSet<String> encounteredURI = new HashSet<>();
 
-		// Loop through each of these URIs and load using the SKOSManager
-		for (String conceptUri : conceptUris) {
-			conceptCounter++;
-			if (StringUtils.isEmpty(conceptUri)) {
-				// If the conceptURI is empty, keep going
-				continue;
-			}
-			if(encounteredURI.contains(conceptUri)) {
-				//If we have already encountered this concept URI, do not redisplay or reprocess
-				continue;
-			}
-			encounteredURI.add(conceptUri);
+        // Loop through each of these URIs and load using the SKOSManager
+        for (String conceptUri : conceptUris) {
+            conceptCounter++;
+            if (StringUtils.isEmpty(conceptUri)) {
+                // If the conceptURI is empty, keep going
+                continue;
+            }
+            if(encounteredURI.contains(conceptUri)) {
+                //If we have already encountered this concept URI, do not redisplay or reprocess
+                continue;
+            }
+            encounteredURI.add(conceptUri);
 
-			// Test and see if the URI is valid
-			URI uri = null;
-			try {
-				uri = new URI(conceptUri);
-			} catch (URISyntaxException e) {
-				logger.error("Error occurred with creating the URI ", e);
-				continue;
-			}
-			// Returns concept information in the format specified, which is
-			// currently XML
-			// Utilizing Agrovoc's getConceptInfo returns alternate and
-			// preferred labels but
-			// none of the exact match or close match descriptions
-			String bestMatch = "false";
-			//Assume the first result is considered the 'best match'
-			//Although that is not something we are actually retrieving from the service itself explicitly
-			if(conceptCounter == 1) {
-				bestMatch = "true";
-			}
-			Concept c = this.createConcept(bestMatch, conceptUri);
-			if (c != null) {
-				// Get definition from dbpedia references stored in the close
-				// Match list
-				List<String> closeMatches = c.getCloseMatchURIList();
-				for (String closeMatch : closeMatches) {
+            // Test and see if the URI is valid
+            URI uri = null;
+            try {
+                uri = new URI(conceptUri);
+            } catch (URISyntaxException e) {
+                logger.error("Error occurred with creating the URI ", e);
+                continue;
+            }
+            // Returns concept information in the format specified, which is
+            // currently XML
+            // Utilizing Agrovoc's getConceptInfo returns alternate and
+            // preferred labels but
+            // none of the exact match or close match descriptions
+            String bestMatch = "false";
+            //Assume the first result is considered the 'best match'
+            //Although that is not something we are actually retrieving from the service itself explicitly
+            if(conceptCounter == 1) {
+                bestMatch = "true";
+            }
+            Concept c = this.createConcept(bestMatch, conceptUri);
+            if (c != null) {
+                // Get definition from dbpedia references stored in the close
+                // Match list
+                List<String> closeMatches = c.getCloseMatchURIList();
+                for (String closeMatch : closeMatches) {
 
-					if (closeMatch.startsWith("http://dbpedia.org")) {
-						try {
-							String description = getDbpediaDescription(closeMatch);
-							c.setDefinition(description);
-						} catch (Exception ex) {
-							logger.error("An error occurred in the process of retrieving dbpedia description", ex);
-						}
-					}
-				}
-				conceptList.add(c);
-			}
-		}
+                    if (closeMatch.startsWith("http://dbpedia.org")) {
+                        try {
+                            String description = getDbpediaDescription(closeMatch);
+                            c.setDefinition(description);
+                        } catch (Exception ex) {
+                            logger.error("An error occurred in the process of retrieving dbpedia description", ex);
+                        }
+                    }
+                }
+                conceptList.add(c);
+            }
+        }
 
-		return conceptList;
-	}
-
-
+        return conceptList;
+    }
 
 
 
 
-	public List<Concept> processResults(String term) throws Exception {
-		return getConcepts(term);
-	}
-
-	public Concept createConcept(String bestMatch, String skosConceptURI) {
-
-		Concept concept = new Concept();
-		concept.setUri(skosConceptURI);
-		concept.setConceptId(stripConceptId(skosConceptURI));
-		concept.setBestMatch(bestMatch);
-		concept.setDefinedBy(schemeUri);
-		concept.setSchemeURI(this.schemeUri);
-		concept.setType("");
-
-		String encodedURI = URLEncoder.encode(skosConceptURI);
-		String encodedFormat = URLEncoder.encode("application/rdf+xml");
-		String url = conceptSkosMosURL + "uri=" + encodedURI + "&format="
-				+ encodedFormat;
-
-		// Utilize the XML directly instead of the SKOS API
-		try {
-
-			concept = SKOSUtils
-					.createConceptUsingXMLFromURL(concept, url, "en", false);
-
-		} catch (Exception ex) {
-			logger.debug("Error occurred for creating concept "
-					+ skosConceptURI, ex);
-			return null;
-		}
-
-		return concept;
-	}
-
-	public List<Concept> getConceptsByURIWithSparql(String uri)
-			throws Exception {
-		// deprecating this method...just return an empty list
-		List<Concept> conceptList = new ArrayList<>();
-		return conceptList;
-	}
-
-	protected String getAgrovocTermCode(String rdf) throws Exception {
-		String termcode = "";
-		try {
-			Document doc = XMLUtils.parse(rdf);
-			NodeList nodes = doc.getElementsByTagName("hasCodeAgrovoc");
-			if (nodes.item(0) != null) {
-				Node node = nodes.item(0);
-				termcode = node.getTextContent();
-			}
-
-		} catch (SAXException | IOException | ParserConfigurationException e) {
-			// e.printStackTrace();
-			throw e;
-		}
-		return termcode;
-	}
-
-	protected String getConceptURIFromRDF(String rdf) {
-		String conceptUri = "";
-		try {
-			Document doc = XMLUtils.parse(rdf);
-			NodeList nodes = doc.getElementsByTagName("skos:Concept");
-			Node node = nodes.item(0);
-
-			NamedNodeMap attrs = node.getAttributes();
-			Attr idAttr = (Attr) attrs.getNamedItem("rdf:about");
-			conceptUri = idAttr.getTextContent();
-		} catch (IOException | ParserConfigurationException | SAXException e) {
-			e.printStackTrace();
-			System.err.println("rdf: " + rdf);
-		}
-		return conceptUri;
-
-	}
-
-	// When utilizing the getTermExpansion method, will get a list of URIs back
-	// and not just one URI
-	protected List<String> getConceptURIsListFromRDF(String rdf) {
-		List<String> conceptUris = new ArrayList<>();
-		try {
-			Document doc = XMLUtils.parse(rdf);
-				NodeList nodes = doc.getElementsByTagName("skos:Concept");
-				int numberNodes = nodes.getLength();
-				int n;
-				for (n = 0; n < numberNodes; n++) {
-					Node node = nodes.item(n);
-					NamedNodeMap attrs = node.getAttributes();
-					Attr idAttr = (Attr) attrs.getNamedItem("rdf:about");
-					String conceptUri = idAttr.getTextContent();
-					conceptUris.add(conceptUri);
-				}
 
 
-		} catch (IOException | ParserConfigurationException | SAXException e) {
-			e.printStackTrace();
-			System.err.println("rdf: " + rdf);
-		}
-		return conceptUris;
+    public List<Concept> processResults(String term) throws Exception {
+        return getConcepts(term);
+    }
 
-	}
+    public Concept createConcept(String bestMatch, String skosConceptURI) {
 
-	protected String getDbpediaDescription(String uri) throws Exception {
-		String descriptionSource = " (Source: DBpedia)";
-		String description = "";
-		String qs = ""
-				+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
-				+ "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
-				+ "PREFIX foaf: <http://xmlns.com/foaf/0.1/> \n"
-				+ "PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>\n"
-				+ "SELECT DISTINCT ?description WHERE { \n" + "<" + uri
-				+ "> rdfs:comment ?description . \n"
-				+ "FILTER (LANG(?description)='en' ) \n" + "}";
-		// System.out.println(qs);
-		List<HashMap> resultList = new ArrayList<>();
-		QueryExecution qexec = null;
-		try {
+        Concept concept = new Concept();
+        concept.setUri(skosConceptURI);
+        concept.setConceptId(stripConceptId(skosConceptURI));
+        concept.setBestMatch(bestMatch);
+        concept.setDefinedBy(schemeUri);
+        concept.setSchemeURI(this.schemeUri);
+        concept.setType("");
 
-			Query query = QueryFactory.create(qs);
-			qexec = QueryExecutionFactory.sparqlService(this.dbpedia_endpoint, query);
-			qexec.setTimeout(5000, TimeUnit.MILLISECONDS);
-			resultList = new ArrayList<>();
-			ResultSet resultSet = qexec.execSelect();
-			int resultSetSize = 0;
-			while (resultSet.hasNext()) {
-				resultSetSize++;
-				QuerySolution solution = resultSet.nextSolution();
-				Iterator varnames = solution.varNames();
-				HashMap<String, String> hm = new HashMap<>();
-				while (varnames.hasNext()) {
-					String name = (String) varnames.next();
-					RDFNode rdfnode = solution.get(name);
-					// logger.info("rdf node name, type: "+ name
-					// +", "+getRDFNodeType(rdfnode));
-					if (rdfnode.isLiteral()) {
-						Literal literal = rdfnode.asLiteral();
-						String nodeval = literal.getString();
-						hm.put(name, nodeval);
-					} else if (rdfnode.isResource()) {
-						Resource resource = rdfnode.asResource();
-						String nodeval = resource.toString();
-						hm.put(name, nodeval);
-					}
-				}
-				resultList.add(hm);
-			}
-			description = "";
-			for (HashMap map : resultList) {
-				if (map.containsKey("description")) {
-					description = (String) map.get("description");
-				}
-			}
-		} catch (Exception ex) {
-			throw ex;
-		}
-		// Adding source so it is clear that this description comes from DBPedia
-		return description + descriptionSource;
-	}
+        String encodedURI = URLEncoder.encode(skosConceptURI);
+        String encodedFormat = URLEncoder.encode("application/rdf+xml");
+        String url = conceptSkosMosURL + "uri=" + encodedURI + "&format="
+                + encodedFormat;
 
-	/**
-	 * @param uri The URI
-	 */
-	protected String stripConceptId(String uri) {
-		String conceptId = "";
-		int lastslash = uri.lastIndexOf('/');
-		conceptId = uri.substring(lastslash + 1, uri.length());
-		return conceptId;
-	}
+        // Utilize the XML directly instead of the SKOS API
+        try {
 
-	/**
-	 * @param str The String
-	 */
-	protected String extractConceptId(String str) {
-		try {
-			return str.substring(1, str.length() - 1);
-		} catch (Exception ex) {
-			return "";
-		}
-	}
+            concept = SKOSUtils
+                    .createConceptUsingXMLFromURL(concept, url, "en", false);
 
-	/**
-	 * The code here utilizes the SKOSMOS REST API for Agrovoc
-	 * This returns JSON LD so we would parse JSON instead of RDF
-	 * The code above can still be utilized if we need to employ the web services directly
-	 */
-	//Get search results for a particular term and language code
-		private String getSKOSMosSearchResults(String term, String lang) {
-			String urlEncodedTerm = URLEncoder.encode(term);
-			//Utilize 'starts with' using the * operator at the end
-			String searchUrlString = this.conceptsSkosMosSearch + "query=" + urlEncodedTerm + "*" + "&lang=" + lang;
-			URL searchURL = null;
-			try {
-				searchURL = new URL(searchUrlString);
-			} catch (Exception e) {
-				logger.error("Exception occurred in instantiating URL for "
-						+ searchUrlString, e);
-				// If the url is having trouble, just return null for the concept
-				return null;
-			}
+        } catch (Exception ex) {
+            logger.debug("Error occurred for creating concept "
+                    + skosConceptURI, ex);
+            return null;
+        }
 
-			String results = null;
-			try {
+        return concept;
+    }
 
-				StringWriter sw = new StringWriter();
+    public List<Concept> getConceptsByURIWithSparql(String uri)
+            throws Exception {
+        // deprecating this method...just return an empty list
+        List<Concept> conceptList = new ArrayList<>();
+        return conceptList;
+    }
 
-				BufferedReader in = new BufferedReader(new InputStreamReader(
-						searchURL.openStream()));
-				String inputLine;
-				while ((inputLine = in.readLine()) != null) {
-					sw.write(inputLine);
-				}
-				in.close();
+    protected String getAgrovocTermCode(String rdf) throws Exception {
+        String termcode = "";
+        try {
+            Document doc = XMLUtils.parse(rdf);
+            NodeList nodes = doc.getElementsByTagName("hasCodeAgrovoc");
+            if (nodes.item(0) != null) {
+                Node node = nodes.item(0);
+                termcode = node.getTextContent();
+            }
 
-				results = sw.toString();
-				logger.debug(results);
-			} catch (Exception ex) {
-				logger.error("Error occurred in getting concept from the URL "
-						+ searchUrlString, ex);
-				return null;
-			}
-			return results;
+        } catch (SAXException | IOException | ParserConfigurationException e) {
+            // e.printStackTrace();
+            throw e;
+        }
+        return termcode;
+    }
 
-		}
+    protected String getConceptURIFromRDF(String rdf) {
+        String conceptUri = "";
+        try {
+            Document doc = XMLUtils.parse(rdf);
+            NodeList nodes = doc.getElementsByTagName("skos:Concept");
+            Node node = nodes.item(0);
 
-		//JSON-LD array
-		private List<String> getConceptURIsListFromSkosMosResult(String results) {
-			List<String> conceptURIs = new ArrayList<>();
-			ObjectNode json = (ObjectNode) JacksonUtils.parseJson(results);
-			//Format should be: { ..."results":["uri":uri...]
-			if (json.has("results")) {
-				ArrayNode jsonArray = (ArrayNode) json.get("results");
-				int numberResults = jsonArray.size();
-				int i;
-				for(i = 0; i < numberResults; i++) {
-					ObjectNode jsonObject = (ObjectNode) jsonArray.get(i);
-					if(jsonObject.has("uri")) {
-						conceptURIs.add(jsonObject.get("uri").asText());
-					}
-				}
-			}
-			return conceptURIs;
-		}
+            NamedNodeMap attrs = node.getAttributes();
+            Attr idAttr = (Attr) attrs.getNamedItem("rdf:about");
+            conceptUri = idAttr.getTextContent();
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            e.printStackTrace();
+            System.err.println("rdf: " + rdf);
+        }
+        return conceptUri;
+
+    }
+
+    // When utilizing the getTermExpansion method, will get a list of URIs back
+    // and not just one URI
+    protected List<String> getConceptURIsListFromRDF(String rdf) {
+        List<String> conceptUris = new ArrayList<>();
+        try {
+            Document doc = XMLUtils.parse(rdf);
+            NodeList nodes = doc.getElementsByTagName("skos:Concept");
+            int numberNodes = nodes.getLength();
+            int n;
+            for (n = 0; n < numberNodes; n++) {
+                Node node = nodes.item(n);
+                NamedNodeMap attrs = node.getAttributes();
+                Attr idAttr = (Attr) attrs.getNamedItem("rdf:about");
+                String conceptUri = idAttr.getTextContent();
+                conceptUris.add(conceptUri);
+            }
+
+
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            e.printStackTrace();
+            System.err.println("rdf: " + rdf);
+        }
+        return conceptUris;
+
+    }
+
+    protected String getDbpediaDescription(String uri) throws Exception {
+        String descriptionSource = " (Source: DBpedia)";
+        String description = "";
+        String qs = ""
+                + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
+                + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
+                + "PREFIX foaf: <http://xmlns.com/foaf/0.1/> \n"
+                + "PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>\n"
+                + "SELECT DISTINCT ?description WHERE { \n" + "<" + uri
+                + "> rdfs:comment ?description . \n"
+                + "FILTER (langMatches(LANG(?description),'en' )) \n"
+                + "}";
+        //				+ "FILTER (LANG(?description)='en' ) \n" + "}";
+
+        // System.out.println(qs);
+        List<HashMap> resultList = new ArrayList<>();
+        QueryExecution qexec = null;
+        try {
+
+            Query query = QueryFactory.create(qs);
+            qexec = QueryExecutionFactory.sparqlService(this.dbpedia_endpoint, query);
+            qexec.setTimeout(5000, TimeUnit.MILLISECONDS);
+            resultList = new ArrayList<>();
+            ResultSet resultSet = qexec.execSelect();
+            int resultSetSize = 0;
+            while (resultSet.hasNext()) {
+                resultSetSize++;
+                QuerySolution solution = resultSet.nextSolution();
+                Iterator varnames = solution.varNames();
+                HashMap<String, String> hm = new HashMap<>();
+                while (varnames.hasNext()) {
+                    String name = (String) varnames.next();
+                    RDFNode rdfnode = solution.get(name);
+                    // logger.info("rdf node name, type: "+ name
+                    // +", "+getRDFNodeType(rdfnode));
+                    if (rdfnode.isLiteral()) {
+                        Literal literal = rdfnode.asLiteral();
+                        String nodeval = literal.getString();
+                        hm.put(name, nodeval);
+                    } else if (rdfnode.isResource()) {
+                        Resource resource = rdfnode.asResource();
+                        String nodeval = resource.toString();
+                        hm.put(name, nodeval);
+                    }
+                }
+                resultList.add(hm);
+            }
+            description = "";
+            for (HashMap map : resultList) {
+                if (map.containsKey("description")) {
+                    description = (String) map.get("description");
+                }
+            }
+        } catch (Exception ex) {
+            throw ex;
+        }
+        // Adding source so it is clear that this description comes from DBPedia
+        return description + descriptionSource;
+    }
+
+    /**
+     * @param uri The URI
+     */
+    protected String stripConceptId(String uri) {
+        String conceptId = "";
+        int lastslash = uri.lastIndexOf('/');
+        conceptId = uri.substring(lastslash + 1, uri.length());
+        return conceptId;
+    }
+
+    /**
+     * @param str The String
+     */
+    protected String extractConceptId(String str) {
+        try {
+            return str.substring(1, str.length() - 1);
+        } catch (Exception ex) {
+            return "";
+        }
+    }
+
+    /**
+     * The code here utilizes the SKOSMOS REST API for Agrovoc
+     * This returns JSON LD so we would parse JSON instead of RDF
+     * The code above can still be utilized if we need to employ the web services directly
+     */
+    //Get search results for a particular term and language code
+    private String getSKOSMosSearchResults(String term, String lang) {
+        String urlEncodedTerm = URLEncoder.encode(term);
+        //Utilize 'starts with' using the * operator at the end
+        String searchUrlString = this.conceptsSkosMosSearch + "query=" + urlEncodedTerm + "*" + "&lang=" + lang;
+        URL searchURL = null;
+        try {
+            searchURL = new URL(searchUrlString);
+        } catch (Exception e) {
+            logger.error("Exception occurred in instantiating URL for "
+                    + searchUrlString, e);
+            // If the url is having trouble, just return null for the concept
+            return null;
+        }
+
+        String results = null;
+        try {
+
+            StringWriter sw = new StringWriter();
+
+            BufferedReader in = new BufferedReader(new InputStreamReader(
+                    searchURL.openStream()));
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                sw.write(inputLine);
+            }
+            in.close();
+
+            results = sw.toString();
+            logger.debug(results);
+        } catch (Exception ex) {
+            logger.error("Error occurred in getting concept from the URL "
+                    + searchUrlString, ex);
+            return null;
+        }
+        return results;
+
+    }
+
+    //JSON-LD array
+    private List<String> getConceptURIsListFromSkosMosResult(String results) {
+        List<String> conceptURIs = new ArrayList<>();
+        ObjectNode json = (ObjectNode) JacksonUtils.parseJson(results);
+        //Format should be: { ..."results":["uri":uri...]
+        if (json.has("results")) {
+            ArrayNode jsonArray = (ArrayNode) json.get("results");
+            int numberResults = jsonArray.size();
+            int i;
+            for(i = 0; i < numberResults; i++) {
+                ObjectNode jsonObject = (ObjectNode) jsonArray.get(i);
+                if(jsonObject.has("uri")) {
+                    conceptURIs.add(jsonObject.get("uri").asText());
+                }
+            }
+        }
+        return conceptURIs;
+    }
 
 
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
@@ -77,10 +77,10 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
         paramMap.put("editForm" , this.getEditForm() );
         paramMap.put("cancelTo", "manage");
         if(domainUri != null && !domainUri.isEmpty()) {
-        	paramMap.put("domainUri", domainUri);
+            paramMap.put("domainUri", domainUri);
         }
         if(rangeUri != null && !rangeUri.isEmpty()) {
-        	paramMap.put("rangeUri", rangeUri);
+            paramMap.put("rangeUri", rangeUri);
         }
         path = UrlBuilder.getUrl( UrlBuilder.Route.EDIT_REQUEST_DISPATCH ,paramMap);
 
@@ -150,42 +150,80 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
             + "    }\n"
             + "}\n";
 
+    private static String WEBPAGE_QUERY_ = "" // UQAM Before adding langMatches in  filter
+            + "PREFIX core: <http://vivoweb.org/ontology/core#> \n"
+            + "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> \n"
+            + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
+            + "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n"
+            + "SELECT DISTINCT ?vcard ?link ?url (MIN(?rank_) AS ?rank) \n"
+            + "(MIN(?typeLabel_) AS ?typeLabel) \n"
+            + "(group_concat(distinct ?linkLabel;separator=\"/\") as ?label) WHERE { \n"
+            + "    ?subject <http://purl.obolibrary.org/obo/ARG_2000028> ?vcard . \n"
+            + "    ?vcard vcard:hasURL ?link . \n"
+            + "    ?link a vcard:URL \n"
+            + "    OPTIONAL { ?link vcard:url ?url } \n"
+            + "    OPTIONAL { ?link rdfs:label ?linkLabel } \n"
+            + "    OPTIONAL { ?link core:rank ?rank_ } \n"
+            + "    OPTIONAL { ?link vitro:mostSpecificType ?type } \n"
+            // UQAM-Linguistic-Management Add linguistic control on label
+            // Try full locale 
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelPrimary . \n"
+            + "               FILTER (LANG(?typeLabelPrimary) = ?locale) \n"
+            + "    } \n"
+            // Try language only
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelSecondary . \n"
+            + "               FILTER (LANG(?typeLabelSecondary) = ?language) \n"
+            + "    } \n"
+            // Try the same language in another other locale
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelTertiary . \n"
+            + "               FILTER (STRBEFORE(STR(LANG(?typeLabelTertiary)), \"-\") = ?language) \n"
+            + "    } \n"
+            // Try any other available label
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelFallback . \n"
+            + "               FILTER (LANG(?typeLabelFallback) != ?locale \n"
+            + "                        && LANG(?typeLabelFallback) != ?language) \n"
+            + "    } \n"
+            + "    BIND(COALESCE(?typeLabelPrimary, ?typeLabelSecondary, ?typeLabelTertiary, ?typeLabelFallback) AS ?typeLabel_) \n"
+            + "} GROUP BY ?vcard ?link ?url \n"
+            + "  ORDER BY ?rank";
+
     private static String WEBPAGE_QUERY = ""
-        + "PREFIX core: <http://vivoweb.org/ontology/core#> \n"
-        + "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> \n"
-        + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
-        + "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n"
-        + "SELECT DISTINCT ?vcard ?link ?url (MIN(?rank_) AS ?rank) \n"
-        + "(MIN(?typeLabel_) AS ?typeLabel) \n"
-        + "(group_concat(distinct ?linkLabel;separator=\"/\") as ?label) WHERE { \n"
-        + "    ?subject <http://purl.obolibrary.org/obo/ARG_2000028> ?vcard . \n"
-        + "    ?vcard vcard:hasURL ?link . \n"
-        + "    ?link a vcard:URL \n"
-        + "    OPTIONAL { ?link vcard:url ?url } \n"
-        + "    OPTIONAL { ?link rdfs:label ?linkLabel } \n"
-        + "    OPTIONAL { ?link core:rank ?rank_ } \n"
-        + "    OPTIONAL { ?link vitro:mostSpecificType ?type } \n"
-        // UQAM-Linguistic-Management Add linguistic control on label
-        // Try full locale 
-        + "    OPTIONAL { ?type rdfs:label ?typeLabelPrimary . \n"
-        + "               FILTER (LANG(?typeLabelPrimary) = ?locale) \n"
-        + "    } \n"
-        // Try language only
-        + "    OPTIONAL { ?type rdfs:label ?typeLabelSecondary . \n"
-        + "               FILTER (LANG(?typeLabelSecondary) = ?language) \n"
-        + "    } \n"
-        // Try the same language in another other locale
-        + "    OPTIONAL { ?type rdfs:label ?typeLabelTertiary . \n"
-        + "               FILTER (STRBEFORE(STR(LANG(?typeLabelTertiary)), \"-\") = ?language) \n"
-        + "    } \n"
-        // Try any other available label
-        + "    OPTIONAL { ?type rdfs:label ?typeLabelFallback . \n"
-        + "               FILTER (LANG(?typeLabelFallback) != ?locale \n"
-        + "                        && LANG(?typeLabelFallback) != ?language) \n"
-        + "    } \n"
-        + "    BIND(COALESCE(?typeLabelPrimary, ?typeLabelSecondary, ?typeLabelTertiary, ?typeLabelFallback) AS ?typeLabel_) \n"
-        + "} GROUP BY ?vcard ?link ?url \n"
-    	+ "  ORDER BY ?rank";
+            + "PREFIX core: <http://vivoweb.org/ontology/core#> \n"
+            + "PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> \n"
+            + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
+            + "PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> \n"
+            + "SELECT DISTINCT ?vcard ?link ?url (MIN(?rank_) AS ?rank) \n"
+            + "(MIN(?typeLabel_) AS ?typeLabel) \n"
+            + "(group_concat(distinct ?linkLabel;separator=\"/\") as ?label) WHERE { \n"
+            + "    ?subject <http://purl.obolibrary.org/obo/ARG_2000028> ?vcard . \n"
+            + "    ?vcard vcard:hasURL ?link . \n"
+            + "    ?link a vcard:URL \n"
+            + "    OPTIONAL { ?link vcard:url ?url } \n"
+            + "    OPTIONAL { ?link rdfs:label ?linkLabel } \n"
+            + "    OPTIONAL { ?link core:rank ?rank_ } \n"
+            + "    OPTIONAL { ?link vitro:mostSpecificType ?type } \n"
+            // UQAM-Linguistic-Management Add linguistic control on label
+            // Try full locale 
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelPrimary . \n"
+            + "               FILTER (langMatches(LANG(?typeLabelPrimary), ?locale)) \n"
+            + "    } \n"
+            // Try language only
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelSecondary . \n"
+            + "               FILTER (langMatches(LANG(?typeLabelSecondary), ?language)) \n"
+            + "    } \n"
+            // Try the same language in another other locale
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelTertiary . \n"
+            + "               FILTER (langMatches(STRBEFORE(STR(LANG(?typeLabelTertiary)), \"-\"), ?language)) \n"
+            + "    } \n"
+            // Try any other available label 
+            // lcase of languages allows for interoperable comparison with the triplestore used
+            + "    OPTIONAL { ?type rdfs:label ?typeLabelFallback . \n"
+            + "               FILTER (lcase(LANG(?typeLabelFallback)) != lcase(?locale) \n"
+            + "                        && lcase(LANG(?typeLabelFallback)) != lcase(?language)) \n"
+            + "    } \n"
+            + "    BIND(COALESCE(?typeLabelPrimary, ?typeLabelSecondary, ?typeLabelTertiary, ?typeLabelFallback) AS ?typeLabel_) \n"
+            + "} GROUP BY ?vcard ?link ?url \n"
+            + "  ORDER BY ?rank";
 
 
     private List<Map<String, String>> getWebpages(String subjectUri, VitroRequest vreq) {
@@ -226,7 +264,7 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
 
     //Putting this into a method allows overriding it in subclasses
     protected String getEditForm() {
-    	return AddEditWebpageFormGenerator.class.getName();
+        return AddEditWebpageFormGenerator.class.getName();
     }
 
     protected String getQuery(VitroRequest vreq) {
@@ -238,10 +276,10 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
                 WEBPAGE_QUERY);
         queryPstr.setLiteral("locale", locale.toString().replace("_", "-"));
         queryPstr.setLiteral("language", locale.getLanguage());
-    	return queryPstr.toString();
+        return queryPstr.toString();
     }
 
     protected String getTemplate() {
-    	return "manageWebpagesForIndividual.ftl";
+        return "manageWebpagesForIndividual.ftl";
     }
 }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
@@ -61,7 +61,7 @@ final public class VisualizationCaches {
         publicationToYear.build(rdfService);
         personToGrant.build(rdfService);
         grantToYear.build(rdfService);
-//        people.build(rdfService);
+        //        people.build(rdfService);
     }
 
     public static void buildMissing() {
@@ -78,7 +78,7 @@ final public class VisualizationCaches {
         if (!publicationToYear.isCached())               { publicationToYear.build(null); }
         if (!personToGrant.isCached())                   { personToGrant.build(null); }
         if (!grantToYear.isCached())                     { grantToYear.build(null); }
-//        if (!people.isCached())                          { people.build(null); }
+        //        if (!people.isCached())                          { people.build(null); }
     }
 
     /**
@@ -224,7 +224,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Cache of organization labels (uri -> label)
@@ -244,24 +244,29 @@ final public class VisualizationCaches {
                                     langCtx += "-" + vreq.getLocale().getCountry();
                                 }
                             } catch (Exception e) { }
-
+                            // UQAM - In the filter, Case-insensitive language processing
                             String query = QueryConstants.getSparqlPrefixQuery() +
                                     "SELECT ?org (Min(?orgLabel_) AS ?orgLabel) \n" +
                                     "WHERE\n" +
                                     "{\n" +
                                     "  ?org a foaf:Organization \n" +
                                     "  OPTIONAL { ?org rdfs:label ?orgLabelPrimary . \n" +
-                                    "       FILTER (LANG(?orgLabelPrimary) = '" + langCtx + "') \n" +
+                                    //"       FILTER (LANG(?orgLabelPrimary) = '" + langCtx + "') \n" +
+                                    "       FILTER (langMatches(lang(?orgLabelPrimary), '" + langCtx+"' ) ) \n" +
                                     "} \n" +
                                     "  OPTIONAL { ?org rdfs:label ?orgLabelSecondary . \n" +
-                                    "       FILTER (LANG(?orgLabelSecondary) = '" + language + "') \n" +
+                                    //"       FILTER (LANG(?orgLabelSecondary) = '" + language + "') \n" +
+                                    "       FILTER (langMatches(lang(?orgLabelSecondary), '" + language+"' ) ) \n" +
                                     "} \n" +
                                     "  OPTIONAL { ?org rdfs:label ?orgLabelTertiary .\n" +
-                                    "       FILTER (STRBEFORE(STR(LANG(?orgLabelTertiary)), '-') = '" + language + "') \n" +
+                                    //"       FILTER (STRBEFORE(STR(LANG(?orgLabelTertiary)), '-') = '" + language + "') \n" +
+                                    "       FILTER (STRBEFORE(lcase(STR(LANG(?orgLabelTertiary))), '-') = '" + language.toLowerCase() + "') \n" +
                                     "} \n" +
                                     "  OPTIONAL { ?org rdfs:label ?orgLabelFallback .\n" +
-                                    "       FILTER (LANG(?orgLabelFallback) != '" + langCtx + "' \n" + 
-                                    "           && LANG(?orgLabelFallback) != '" + language + "' ) \n" +
+                                    //"       FILTER (LANG(?orgLabelFallback) != '" + langCtx + "' \n" + 
+                                    //"           && LANG(?orgLabelFallback) != '" + language + "' ) \n" +
+                                    "       FILTER (lcase(STR(LANG(?orgLabelFallback))) != '" + langCtx.toLowerCase() + "' \n" + 
+                                    "           && lcase(STR(LANG(?orgLabelFallback))) != '" + language.toLowerCase() + "' ) \n" +
                                     "} \n" +
                                     "BIND(COALESCE(?orgLabelPrimary, ?orgLabelSecondary, ?orgLabelTertiary, ?orgLabelFallback) AS ?orgLabel_) \n" +
                                     "} GROUP BY ?org \n";
@@ -281,7 +286,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Cache of organization to sub organizations (uri -> list of uris)
@@ -321,7 +326,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Organization most specific type label (uri -> string)
@@ -354,7 +359,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Map of people within an organisation (org uri -> list of person uri)
@@ -406,7 +411,7 @@ final public class VisualizationCaches {
                             return orgToPeopleMap;
                         }
                     }
-            );
+                    );
 
     /**
      * Concept to label
@@ -434,12 +439,10 @@ final public class VisualizationCaches {
                                     "    ?person core:hasResearchArea ?concept .\n" +
                                     "    ?concept a skos:Concept .\n" +
                                     "    ?concept rdfs:label ?label .\n" +
-                                    "    FILTER (lang(?label) = '" + langCtx+"' )  \n" +
+                                    "    FILTER (langMatches(lang(?label), '" + langCtx+"' ) ) \n" +
                                     "}\n";
-
-//                            final Map<String, String> map = new HashMap<>();
                             final ConceptLabelMap map = new ConceptLabelMap();
-                            
+
                             rdfService.sparqlSelectQuery(query, new ResultSetConsumer() {
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String conceptURI = qs.getResource("concept").getURI().intern();
@@ -463,7 +466,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Map of people associated with a concept
@@ -513,7 +516,7 @@ final public class VisualizationCaches {
                             return conceptPeopleMap;
                         }
                     }
-            );
+                    );
 
     /**
      * Display labels for people (uri -> label)
@@ -546,7 +549,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Most specific type for person (uri -> label)
@@ -579,7 +582,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Person to publication Map (person uri -> list of publication uri)
@@ -620,7 +623,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Publication to journal (publication uri -> journal label)
@@ -654,7 +657,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Publication to year (publication uri -> year)
@@ -694,7 +697,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Person to grant (person uri -> grant uri)
@@ -741,7 +744,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Grant to year (grant uri -> year)
@@ -782,7 +785,7 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 
     /**
      * Grant to year of start in role (grant uri -> year)
@@ -824,5 +827,5 @@ final public class VisualizationCaches {
                             return map;
                         }
                     }
-            );
+                    );
 }


### PR DESCRIPTION
**[Issue #3767 Problems associated with the use of sparqlContentTripleSource in the applicationSetup.n3 configuration file](https://github.com/vivo-project/VIVO/issues/3767)**: 

# What does this pull request do?
This PR fixes the language context management issue in the Capability Map when using VIVO which uses AWS-Neptune TripleStore

# What's new?
As described in the issue, VIVO's CapabilityMap using AWS-Neptune as a TripleStore is not working properly. The malfunction is related to the disfunction of the expertise search bar. The cause of this malfunction is that, unlike the other triple stores, the linguistic value of the tags is stored in lower case. For example: the term "Label"@en-CA is actually stored in AWS-Neptune as "Label"@en-ca. 
The solution is to modify the SPARQL queries in the Java code so that the filters process the language parameters regardless of case sensitivity.
> Here is a code sample to be replaced 

    FILTER (LANG(?orgLabelSecondary) = '" + language + "') \n" +

> Replacement code example 

    FILTER (langMatches(lang(?orgLabelSecondary), '" + language+"' ) ) \n"

# How should this be tested?
## VIVO installation using AWS-Neptune
1. Installing AWS-Neptune
 To reproduce the BUG, it is absolutely necessary to install an instance of AWS-Neptune. 
 The following documentation [Setting up Neptune](https://docs.aws.amazon.com/neptune/latest/userguide/neptune-setup.html) allows to install a Neptune instance.

 2. Installing VIVO (master branch)
- Extract and compile VIVO
- Install a VIVO-home according to the specifications indicated by VIVO's documentations: 

>  [Using web-based triple stores](https://wiki.lyrasis.org/display/VIVODOC18x/Using+a+different+data+store#Usingadifferentdatastore-Usingweb-basedtriplestores) 
  > [Fuseki as alternate triple store](https://wiki.lyrasis.org/display/VIVODOC111x/Fuseki+as+alternate+triple+store)

3. Run VIVO and load Sample Data
After starting VIVO, you can download the sample data contained at:
-[VIVO Sample data Repo](https://github.com/vivo-project/sample-data/tree/main/i18n)
Upload files:

> sample-data-i18n-de_DE.ttl 
> sample-data-i18n-en_CA.ttl
> sample-data-i18n-en_US.ttl 
> sample-data-i18n-fr_CA.ttl
> sample-data-i18n-fr_FR.ttl
> sample-data-i18n.ttl
4. Observe the problem
Browse the CapabilityMap and try to search for an expertise. You will see that it is **not possible** to perform a search.

5. Evaluate the RP
- Stop VIVO; extract the code from the PR, compile VIVO; and start VIVO
- Browse the CapabilityMap and try to search for an expertise. You will see that it **is possible** to perform a search.

# Additional Notes:
see also:
- [Vitro PR-342](https://github.com/vivo-project/Vitro/pull/342)
- [VIVO-Languages PR-112](https://github.com/vivo-project/VIVO-languages/pull/118)

# Interested parties
@VIVO-project/vivo-committers
