### PR TITLE
Improved safety for visualisation cahes queries.

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
@@ -272,7 +272,11 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String org      = qs.getResource("org").getURI();
-                                    String orgLabel = qs.getLiteral("orgLabel").getString();
+                                    Literal labelLiteral = qs.getLiteral("orgLabel");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String orgLabel = labelLiteral.getString();
 
                                     map.put(org.intern(), orgLabel.intern());
                                 }
@@ -346,7 +350,11 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String org = qs.getResource("org").getURI();
-                                    String typeLabel  = qs.getLiteral("typeLabel").getString();
+                                    Literal labelLiteral = qs.getLiteral("typeLabel");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String typeLabel  = labelLiteral.getString();
                                     map.put(org.intern(), typeLabel.intern());
                                 }
                             });
@@ -443,7 +451,11 @@ final public class VisualizationCaches {
                             rdfService.sparqlSelectQuery(query, new ResultSetConsumer() {
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String conceptURI = qs.getResource("concept").getURI().intern();
-                                    String label  = qs.getLiteral("label").getString().intern();
+                                    Literal labelLiteral = qs.getLiteral("label");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String label  = labelLiteral.getString().intern();
                                     String labelLower = label.toLowerCase().intern();
 
                                     map.conceptToLabel.put(conceptURI, label);
@@ -537,8 +549,11 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String person      = qs.getResource("person").getURI();
-                                    String personLabel = qs.getLiteral("personLabel").getString();
-
+                                    Literal labelLiteral = qs.getLiteral("personLabel");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String personLabel  = labelLiteral.getString();
                                     map.put(person.intern(), personLabel.intern());
                                 }
                             });
@@ -571,7 +586,11 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String person = qs.getResource("person").getURI();
-                                    String typeLabel  = qs.getLiteral("typeLabel").getString();
+                                    Literal labelLiteral = qs.getLiteral("typeLabel");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String typeLabel  = labelLiteral.getString();
                                     map.put(person.intern(), String.valueOf(typeLabel).intern());
                                 }
                             });
@@ -645,8 +664,11 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String document      = qs.getResource("document").getURI();
-                                    String journalLabel = qs.getLiteral("journalLabel").getString();
-
+                                    Literal labelLiteral = qs.getLiteral("journalLabel");
+                                    if (labelLiteral == null) {
+                                    	return;
+                                    }
+                                    String journalLabel  = labelLiteral.getString();
                                     map.put(document.intern(), journalLabel.intern());
                                 }
                             });

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
@@ -701,15 +701,19 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String document = qs.getResource("document").getURI();
-                                    String pubDate  = qs.getLiteral("publicationDate").getString();
-                                    if (pubDate != null) {
-                                        DateTime validParsedDateTimeObject = UtilityFunctions
-                                                .getValidParsedDateTimeObject(pubDate);
-
-                                        if (validParsedDateTimeObject != null) {
-                                            map.put(document.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
-                                        }
+                                    Literal dateLiteral = qs.getLiteral("publicationDate");
+                                    if (dateLiteral == null) {
+                                    	return;
                                     }
+                                    String pubDate = dateLiteral.getString();
+                                    if (pubDate == null) {
+                                    	return;
+                                    }
+                                    DateTime validParsedDateTimeObject = UtilityFunctions.getValidParsedDateTimeObject(pubDate);
+                                    if (validParsedDateTimeObject == null) {
+                                    	return;
+                                    }
+                                    map.put(document.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
                                 }
                             });
 
@@ -789,15 +793,19 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String grant = qs.getResource("grant").getURI();
-                                    String startDate  = qs.getLiteral("startDateTimeValue").getString();
-                                    if (startDate != null) {
-                                        DateTime validParsedDateTimeObject = UtilityFunctions
-                                                .getValidParsedDateTimeObject(startDate);
-
-                                        if (validParsedDateTimeObject != null) {
-                                            map.put(grant.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
-                                        }
+                                    Literal dateLiteral = qs.getLiteral("startDateTimeValue");
+                                    if (dateLiteral == null) {
+                                        return;
                                     }
+                                    String startDate = dateLiteral.getString();
+                                    if (startDate == null) {
+                                    	return;
+                                    }
+                                    DateTime validParsedDateTimeObject = UtilityFunctions.getValidParsedDateTimeObject(startDate);
+                                    if (validParsedDateTimeObject == null) {
+                                    	return;
+                                    }
+                                    map.put(grant.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
                                 }
                             });
 
@@ -831,15 +839,19 @@ final public class VisualizationCaches {
                                 @Override
                                 protected void processQuerySolution(QuerySolution qs) {
                                     String grant = qs.getResource("grant").getURI();
-                                    String startDate  = qs.getLiteral("startDateTimeValue").getString();
-                                    if (startDate != null) {
-                                        DateTime validParsedDateTimeObject = UtilityFunctions
-                                                .getValidParsedDateTimeObject(startDate);
-
-                                        if (validParsedDateTimeObject != null) {
-                                            map.put(grant.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
-                                        }
+                                    Literal dateLiteral = qs.getLiteral("startDateTimeValue");
+                                    if (dateLiteral == null) {
+                                    	return;
                                     }
+                                    String startDate  = dateLiteral.getString();
+                                    if (startDate == null) {
+                                    	return;
+                                    }
+                                    DateTime validParsedDateTimeObject = UtilityFunctions.getValidParsedDateTimeObject(startDate);
+                                    if (validParsedDateTimeObject == null) {
+                                    	return;
+                                    }
+                                    map.put(grant.intern(), String.valueOf(validParsedDateTimeObject.getYear()).intern());
                                 }
                             });
 


### PR DESCRIPTION
# What does this pull request do?
Added null checks in visualisation caches to prevent NPEs in case labels aren't exist or exists but not literals.

# How should this be tested?
A description of what steps someone could take to:
* Load  [broken_data.n3.zip](https://github.com/vivo-project/VIVO/files/9952902/broken_data.n3.zip)
* Verify that capability map is working

# Interested parties
@VIVO-project/vivo-committers

