### PR TITLE
[i18n-3762] Moving UI labels translations into vivo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Clone Vitro
         run: git clone https://github.com/vivo-project/Vitro.git ../Vitro
 
-      - name: Clone Vitro-languages
-        run: git clone https://github.com/vivo-project/Vitro-languages.git ../Vitro-languages
-
-      - name: Clone VIVO-languages
-        run: git clone https://github.com/vivo-project/VIVO-languages.git ../VIVO-languages
-
       - name: Maven Cache
         uses: actions/cache@v2
         with:
@@ -35,9 +29,5 @@ jobs:
 
       - name: Maven Build
         run: |
-          cd ../Vitro-languages
-          mvn clean install
-          cd ../VIVO-languages
-          mvn clean install
           cd ../VIVO
           mvn clean package -s installer/example-settings.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,6 @@ jobs:
 
       - name: Clone Vitro
         run: git clone https://github.com/vivo-project/Vitro.git ../Vitro
-        
-      - name: Clone Vitro-languages
-        run: git clone https://github.com/vivo-project/Vitro-languages.git ../Vitro-languages
-
-      - name: Clone VIVO-languages
-        run: git clone https://github.com/vivo-project/VIVO-languages.git ../VIVO-languages
-
 
       - name: Maven Cache
         uses: actions/cache@v2
@@ -43,10 +36,6 @@ jobs:
 
       - name: Maven Deploy
         run: |
-          cd ../Vitro-languages
-          mvn clean install
-          cd ../VIVO-languages
-          mvn clean install
           cd ../VIVO
           mvn --batch-mode deploy -Pskip
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Clone Vitro
         run: git clone https://github.com/vivo-project/Vitro.git ../Vitro
 
-      - name: Clone Vitro-languages
-        run: git clone https://github.com/vivo-project/Vitro-languages.git ../Vitro-languages
-
-      - name: Clone VIVO-languages
-        run: git clone https://github.com/vivo-project/VIVO-languages.git ../VIVO-languages
-
       - name: Maven Cache
         uses: actions/cache@v2
         with:
@@ -39,10 +33,6 @@ jobs:
 
       - name: Maven Build
         run: |
-          cd ../Vitro-languages
-          mvn clean install
-          cd ../VIVO-languages
-          mvn clean install
           cd ../VIVO
           mvn clean package -s installer/example-settings.xml
 

--- a/README.md
+++ b/README.md
@@ -40,21 +40,11 @@ RESET_CORE=false
 - `RESET_HOME`: Convenience to reset VIVO home when starting container. **Caution**, will delete local configuration, content, and configuration model.
 - `RESET_CORE`: Convenience to reset VIVO Solr core when starting container. **Caution**, will require complete reindex.
 
-Before building VIVO, you will also need to clone (and switch to the same branch, if other than main) of [Vitro](https://github.com/vivo-project/Vitro). The Vitro project must be cloned to a sibling directory next to VIVO so that it can be found during the build. You will also need to clone (and switch to the appropriate branch) of [Vitro-languages](https://github.com/vivo-project/Vitro-languages) and [VIVO-languages](https://github.com/vivo-project/VIVO-languages).
+Before building VIVO, you will also need to clone (and switch to the same branch, if other than main) of [Vitro](https://github.com/vivo-project/Vitro). The Vitro project must be cloned to a sibling directory next to VIVO so that it can be found during the build. 
 
 Build and start VIVO.
 
-1. In Vitro-languages, run:
-```
-mvn install
-```
-
-2. In VIVO-languages, run:
-```
-mvn install
-```
-
-3. In VIVO (with Vitro cloned alongside it), run:
+1. In VIVO (with Vitro cloned alongside it), run:
 ```
 mvn clean package -s installer/example-settings.xml
 docker-compose up

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -223,7 +223,8 @@ selfEditing.idMatchingProperty = http://vivo.mydomain.edu/ns#networkId
   #
   # A list of supported languages or Locales that the user may choose to
   # use instead of the one specified by the browser. The selected language(s)
-  # must exist in the VIVO-languages repository. This affects
+  # must exist in the list of property files in webapps or in the list of ttl
+  # files in interface-i18n directories within VIVO home. This affects
   # RDF data retrieved from the model, if RDFService.languageFilter is true.
   # This also affects the text of pages that have been modified to support
   # multiple languages.

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE.ttl
@@ -1,0 +1,6271 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: die Person kann nicht von der Seite der Organisation ausgeschlossen werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Konferenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Organisation hat weder Unterorganisationen noch Personen mit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nur Organisationen deren Name diesen Text enthält."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Ausbildung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in den letzten 10 vollen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurücksetzen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Webseite"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte pro Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verzeichnis und alle Unterverzeichnisse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "den Beruf unterstützende Dienstleistung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bisher wurden keine Modelle erstellt, die zur Visualisierung genutzt werden können."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in einem abgeschlossenen Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autoren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte einen Wert im Feld Art der Position auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisationen vergleichen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vollständiger Name von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "weitere E-Mail-Adressen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Damit eine lokale Ontologie erkannt werden kann, muss die Namensraum-URI diesem Muster folgen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen für <br />{0}<br /> importieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anzahl"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unvollständiger Datums-/ Uhrzeitwert"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "den Beruf unterstützende Dienstleistung in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Weiter"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Quelle"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Markieren Sie die Forschungsprojekte und Projekte, die auf der Profilseite nicht berücksichtigt werden sollen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Postleitzahl einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Im VIVO-Harvester ist die Datei"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wie möchten Sie vergleichen?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hauptfach des Hochschul- oder Universitätsabschlusses"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loggen Sie sich ein, um auf Ihrer Profilseite zusätzliche Angaben zu Ihren Forschungsprojekten zu machen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutionen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Forschungsprojekte anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mehr Informationen über QR-Codes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine Beziehung zur Veröffentlichung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Positionstitel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auf das Icon der Webseite klicken."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Art der Ausbildung einen Wert auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "z. B., LehrerIn, ModeratorIn, MitarbeiterIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Konzepts"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "betreute Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Auszeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard-QR-Code"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Weitere Informationen zur Wissenschaftskarte und des Klassifikationssystems der UCSD finden Sie unter"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvesting abgeschlossen. Zum Wiederholen bitte die Seite aktualisieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veranstaltungsart"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie können mehrere DOIs entweder als DOI oder als URL eingeben:<br /><br />z. B."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld E-Mail-Adresse einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Ursache ist sehr wahrscheinlich eine falsche Harvester-Konfiguration. Bitte überprüfen Sie folgendes:"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "keine Verknüpfung zu einem/einer HerausgeberIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "FEHLER ENTITÄTSEBENE NICHT DEFINIERT"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Herausgeberschaft bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine geeignete Klasse vorhanden?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "einzelne KoforscherInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hinweis: unten aufgelistet sind nur Organisationen oder Personen, die unmittelbar in der Hierarchie der Organisation folgen. Wählen Sie das Chart-Symbol neben dem Namen einer ausgewählten Unterorganisation rechts unter dem Graphen, um in einem Hierarchieaufriss die Organisationen oder Personen einer gegebenen Unterorganisation zu sehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entferne Gruppe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseiten verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Link"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unbekanntes Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Fehlermeldung sollte der/dem EndnutzerIn normalerweise nicht angezeigt werden, daher handelt es sich wahrscheinlich um einen Fehler, der gemeldet werden sollte."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Die ORCID iD ist als {0} bestätigt.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Harvester is installed."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entferne Begriff"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "quer durch alle 554 wissenschaftlichen Subdisziplinen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Komplette Zeitleiste und KoforscherInnen-Netzwerk anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auf Ihrer Profilseite können Sie zusätzliche Angaben zu Ihren Forschungsprojekten machen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "klinische Tätigkeit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Über VIVOs Map of Science"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art des Vortrags"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kontrolliertes Vokabular externer Dienstleister"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Das Hinzufügen der externen ID ist fehlgeschlagen.</p> <p>Die Verknüpfung konnte nicht erstellt werden.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: Begriff wurde nicht gelöscht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Für weitere Wissenschaftskarten siehe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Leitungsrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zeitlicher Graph"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gesamtzahl der"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Der Eintrag wurde erfolgreich von der Profilseite ausgeschlossen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patent"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gruppenbeschriftungen ausblenden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Spalte <b># of pubs.</b> zeigt, wie viele der Publikationen auf die einzelnen Teildisziplinen abgebildet wurden. Diese Zählung kann aufgeteilt sein, da einige Publikationsorte mit mehr als einer Teildisziplin verbunden sind. Jede Publikation an einem solchen Ort trägt nach einem Gewichtungsschema zu allen zugehörigen Teildisziplinen bei."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datensatz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telefon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Dienstleisterrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Im VIVO-Harvester hat die/der Webserver-NutzerIn (normalerweise tomcat6) Lese- und Schreibzugang zu"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung der Betreuerin / des Betreuers"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Buch"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-Code"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titel nicht gefunden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ergänzende Informationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "weitere E-Mail-Adressen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte beachten Sie: Diese Information beruht ausschließlich auf Forschungsprojekten, die in das VIVO-System geladen wurden und die möglicherweise nur eine kleine Auswahl des Gesamtwerkes der Person darstellen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name einen Wert eintragen oder auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Visualisierung basiert auf den Publikationen, die wir für {0} finden konnten, und ist daher möglicherweise nicht vollständig repräsentativ für die gesamte Publikationstätigkeit für {0}."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie haben diese Veröffentlichung bereits für sich beansprucht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte VerleiherIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "GutachterIn von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgefüllte/s Template/s hochladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler: ein problematischer Abschnitt wie oben sollte bereits verarbeitet sein."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Review"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle laufenden Forschungsprojekte anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Screenshot der Webseite {0}"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Script being executed"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nicht aufgelisteter Autor."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teilgenommen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie müssen einen Wert in das Feld Nachname eingeben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-Icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung (Typ)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "und dann hierher zurückkehren, um die interne Klasse für die Institution zu definieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "einzelne KoforscherInnen pro Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "neu erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Art der Organisation einen Wert auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ingest-Menü"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fortschritt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Publikationstätigkeit von bis zu drei Organisationen oder Personen kann über \"Organisationen vergleichen\" verglichen werden. Wählen Sie in der Tabelle links bis zu drei Organisationen aus. Das Kompetenzprofil jeder Organisation wird als Daten-Overlay dargestellt. Jede Organisation ist in einer eigenen Farbe dargestellt und eine Top-10-Liste der Subdisziplinen mit der höchsten Anzahl an Publikationen ist unterhalb der Vergleichskarte aufgeführt. Die Daten können als CSV-Datei gespeichert werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erscheinungsdatum"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art des Betreuungsverhältnisses"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webpage"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontaktdaten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bild"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekt wird verwaltet von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle des/der HerausgeberIn in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählter Vortrag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Klasse wird zur Bezeichnung der einzelnen Kategorien innerhalb der Institution benutzt."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schulen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erstes Ergebnis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Neuordnung der Webseiten ist fehlgeschlagen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Das Feld Nachname darf kein Komma enthalten. Bitte geben Sie den Vornamen in das Feld Vorname ein."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO leitet Sie auf die  ORCID Seite um.</li> <li>Melden Sie sich mit Ihrem ORCID Account an. <ul class=\"inner\"><li>Wenn Sie noch keinen Account besitzen, können Sie einen neuen Account erstellen.</li></ul></li> <li>Bestätigen Sie ORCID, dass VIVO Ihren ORCID Eintrag lesen darf.</li> <li>VIVO liest Ihren ORCID Eintrag aus.</li> <li>Im VIVO wird Ihre ORCID iD jetzt als bestätigt angezeigt.</li></ul>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dies ermöglicht die Begrenzung der im Menü angezeigten einzelnen Kategorien (Personen, Forschung etc. auf diejenigen, die sich auf die Institution beziehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle einer Herausgeberin/ eines Herausgebers einer Sammlung oder Reihe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thesis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag für Ausbildung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle VIVO-Forschungsprojekte und dazugehöriges KoforscherInnen-Netzwerk anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "einzelne KoautorInnen pro Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "werden aktualisiert. Die Visualisierung wird geladen, sobald die Berechnung abgeschlossen ist - Sie können VIVO durchstöbern oder nach anderen Daten suchen und in wenigen Minuten zurückkehren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikation(en)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Veranstaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Begutachtungsrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Weitere Informationen zur Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte/r BeraterIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in der VIVO-Datenbank."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Begriff"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung der Veranstaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Netzwerke"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schließen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nach Forschungsprojekten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationstyp"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: die Webseite wurde nicht gelöscht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entitätstyp"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legislation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conference Paper"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "zeitlicher Graph"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entitätsbezeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vorname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ID hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die VIVO Map of Science (Wissenschaftskarte) verwendet die Map of Science und das Klassifikationssystems des UCSD, die unter Verwendung von artikelbezogenen Daten aus etwa 25.000 Zeitschriften von Elseviers Scopus und Thomson Reuters' Web of Science (WoS) für die Jahre 2001-2010 berechnet wurde. Die UCSD-Wissenschaftskarte ordnet die 25.000 Zeitschriften 554 Teildisziplinen zu, die in 13 Hauptwissenschaften zusammengefasst sind. In der Karte hat jede Disziplin eine eigene Farbe (grün für 'Biologie', braun für 'Geowissenschaften' usw.) und ein Label. (Unter-)Disziplinen, die sich ähneln, liegen auf der Karte nahe beieinander. (Teil-)Disziplinen, die sich besonders ähnlich sind, sind durch graue Linien verbunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay und Prüfung von Kompetenzprofilen für eine Organisation. Farbcodierung nach Disziplin."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veranstalter von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erscheinungsdatum bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie benötigen den Adobe Flash Player, um diesen Inhalt anzusehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Person wurde erfolgreich von der Seite der Organisation ausgeschlossen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie haben einen ungültigen Wert für den QR-Code-Anzeigeparameter übergeben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit speichern wir diese Modelle im Hauptspeicherbereich zwischen. Der Zwischenspeicher wird (nur einmal) bei der ersten Benutzeranfrage nach einem Neustart des Servers aufgebaut. Daher wird bis zum nächsten Neustart das gleiche Modell bedient. Das bedeutet, dass die Daten in den Modellen veralten können, je nachdem, wann das Modell zum letzten Mal erstellt wurde. Das funktioniert fürs Erste gut. In kommenden Releases werden wir diese Lösung dahingehend verbessern, dass Modelle auf Festplatte gespeichert und regelmäßig aktualisiert werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr der Auszeichung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erscheinungsdatum erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gesamtzahl"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speech"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Startseite"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgewählte Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wissenschaftslandkarte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PubMed ID"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag für HerausgeberIn von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag der Projektleitung für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Öffentlichkeitsarbeit und Community-Arbeit in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen für verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte mit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 Verbindungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine der Publikationen im System wurden dieser Organisation zugeordnet."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gewählte Auszeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vergleich"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewähltes Buch"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "JJJJ"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte einen Vornamen für diese Person eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisationen und Personen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "innerhalb meiner Institution"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte wählen Sie mindestens eine externe Quelle kontrollierten Vokabulars für die Suche aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende/r AutorIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 2 (empfohlen): Verbinden Sie Ihren ORCID Eintrag mit VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preis oder Auszeichnung für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mehr über VIVOs Map of Science lernen?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Neuordnung der HerausgeberInnen ist fehlgeschlagen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine der"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Beratung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Warum ist das erforderlich?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Öffentlichkeitsarbeitsrolle bearbeiten Edit this outreach provider role"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Einen vollständigen Überblick"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zahl der"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese klinische Position bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primäre E-Mail-Adresse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soll dieser Begriff wirklich gelöscht werden?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URL-Typ"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Herausgeberschaft hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eine neue Klasse erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Dokumentart einen Wert auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Neuordnung der AutorInnen ist fehlgeschlagen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AutorInnen-Link entfernen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bewerbung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hochschulschriften"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hintergrundbild oberer Bereich"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AutorInnen verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reihe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verwaltende Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bei der Suche ist ein Fehler aufgetreten."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgewähltes Konzept hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aktuelle Suchbegriffe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard-QR"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag der Position"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 Verbindungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "interne Klasse für die Institution"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen in dem Fachbereich {0}, die sich für dieses Forschungsgebiet interessieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Straße"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die aufgeführten Organisationen sind Kinder des Knotens {0} in der Organisationshierarchie. Sie können \"drill down\" verwenden, um die Organisationen unterhalb einer bestimmten Unterorganisation zu sehen, indem Sie das Diagrammsymbol neben dem Namen einer ausgewählten Unterorganisation unterhalb des Diagramms auf der rechten Seite auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Um diese Funktion zu nutzen, definieren Sie bitte einen Wert für diese Eigenschaft, der auf das Harvester-Installations-Verzeichnis verweist, bevor sie die Anwendung neu kompilieren und neu starten."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "neue Suche"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hyperlink"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wissenschaftslandkarte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Herausgeberin/ des Herausgebers"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Protokollverzeichnis und die/der Webserver-NutzerIn hat Lese- und Schreibzugang dazu."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "oder fügen Sie eine/n neue/n AutorIn hinzu."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVOs Map of Science stellt die aktuelle Expertise einer Universität, Organisation oder Person dar, die auf vergangenen Publikationen basiert, die in VIVO geladen wurden. Hier ist das {0}-Kompetenzprofil dargestellt - größere Kreisgrößen bedeuten mehr Publikationen pro Themenbereich."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hier klicken, um die {0} Webseite zu sehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postleitzahl"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Leitungsrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suchen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "z. B. ModeratorIn, SprecherIn, DiskussionsteilnehmerIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Übereinstimmung verifizieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artikel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erweitern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Faxnummer einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewähltes Dokument"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine {0} Forschungsprojekte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseite bearbeiten von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es sind noch {0} IDs übrig."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "es konnte keine Übereinstimmung mit einer Stelle auf der Karte, die ihre Zeitschriftenangaben benutzt, gefunden werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Info"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil dieser Person anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nummer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld bevorzugter Titel einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit gibt es keine erkannten lokalen Ontologien."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endjahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende/r HerausgeberIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "alle als CSV speichern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte pro Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 Verbindungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "zugeschriebenen Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Öffentlichkeitsarbeitsrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewähltes Fachgebiet"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suchbegriffe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung der Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungseintrag für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload file(s)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suchen und Erweitern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Titel eine bestehende Publikation auswählen oder eine neue eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualisierung der Wissenschaftslandkarte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konzept hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gruppenbeschriftungen einblenden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-Code exportieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Links"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Finden Sie nicht das gewünschte Konzept? Erstellen Sie Ihr eigenes Konzept."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "neue lokale Ontologie"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr der Ausstellung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Rolle in der Lehre hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sammlung oder Serie"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die folgende Tabelle fasst die auf der Karte der Wissenschaften dargestellten Publikationen zusammen. Jede Zeile entspricht einer (Unter-)Disziplin auf der Karte."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Positionstitel einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Referenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen <a href=\"{1}\">{0}</a>, die sich für dieses Forschungsgebiet interessieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AutorInnen mit Drag-and-Drop neu ordnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mitgliedschaft"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nicht abgebildete Publikationen speichern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telefonnummer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit werden keine Konzepte näher beschrieben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahre der Mitarbeit im Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gruppe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen <a href=\"{1}\">{0}</a>, die sich für dieses Forschungsgebiet interessieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen in VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Dokuments"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AutorIn hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erscheinungsdatum von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abteilungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseite hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Angaben in den folgenden Tabellen beziehen sich auf alle Jahre."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zur Profilseite"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlender Vortrag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Sie haben VIVO die Berechtigung verweigert, Ihren ORCID Eintrag auszulesen.</p> <p>Die Überprüfung kann nicht fortgesetzt werden.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte wählen Sie mindestens einen Begriff aus den Suchergebnissen aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fachbereich wird geladen. . ."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Person in dieser Position"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Information beruht einzig auf {0}, die in das VIVO-System geladen wurden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gilt nicht als wissenschaftliche Publikation."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Flash Player installieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie haben keine Berechtigung, für diese Benutzer Veröffentlichungen zu importieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseiten mit Drag-and-Drop neu ordnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Komplette Zeitleiste und KoautorInnen-Netzwerk anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verbindung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: HerausgeberIn wurde nicht gelöscht"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine übereinstimmenden Forschungsgebiete gefunden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Veranstaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehlermeldung: Es wurde kein Harvesting Auftrag oder ein unbekannter Auftrag angegeben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgabe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "waren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wählen Sie eine bestehende Organisation aus oder erstellen Sie eine neue."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erstellen Sie eine Capability Map durch Eingabe von Suchbegriffen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "weltweite Forschung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen pro Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: AutorIn wurde nicht gelöscht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte überprüfen Sie, ob dies die Veröffentlichungen sind, die Sie importieren wollen und geben Sie Ihre Beziehung zu dieser Veröffentlichung an."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Lehr-Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Importieren Sie Veröffentlichungen mittels"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Löschen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 1"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wenn Sie auf einen bestimmten Bereich klicken, werden Ihnen Personen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "von dieser Autorin/ diesem Autor"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Führung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Was beinhaltet der Vorgang zur Zwischenspeicherung?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO leitet Sie auf die  ORCID Seite um.</li> <li>Sie erlauben ORCID, dass VIVO eine \"external ID\" zu Ihrem ORCID Eintrag hinzufügt.</li> <li>VIVO ergänzt Ihren nORCID Eintrag.</li></ul>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle anzeigen ..."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faxnummer von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Land"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kapitel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mit dem gleichen Interessensgebiet angezeigt."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zu Ihrem ORCID Eintrag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 2"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lokaler Namensraum"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profiltyp"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Was möchten Sie vergleichen?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Referenz  der Basiskarte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberIn hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veröffentlicht in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisziplinen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fähigkeit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gilt als wissenschaftliche Publikation."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählter Verlag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Fachbereiche anzeigen, die sich für dieses Forschungsgebiet interessieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eine neue lokale Ontologie"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Link zu einer Webseite bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ihr ORCID Eintrag enthält bereits einen Verweis auf VIVO.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Rolle in der Lehre bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Auszeichnung oder des Preises"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsgebiete"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlendes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit gibt es keine laufenden Forschungsprojekte für diesen Fachbereich."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Karte kann auf zwei Ebenen erkundet werden - über 13 Disziplinen oder 554 Unterdisziplinen. Ein Klick auf einen Knoten in der Karte zeigt die Anzahl der teilweise assoziierten Zeitschriftenpublikationen und den Prozentsatz der Publikationen, die dieser (Teil-)Disziplin zugeordnet sind. Fahren Sie mit der Maus über eine Disziplin in der Tabelle links, um zu sehen, welchen Kreisen sie auf der Karte entspricht. Benutzen Sie den Schieberegler unter der Karte rechts, um die Anzahl der angezeigten Teildisziplinen zu verringern, um die Lesbarkeit zu verbessern."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Telefonnummer einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ende"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wenn Sie Herausgeber der Veröffentlichung sind, wählen Sie bitte \"Editor\" aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aktivitäten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgewählte Veranstaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ein Fehler ist aufgetreten und der Harvesting-Prozess kann nicht fortgeführt werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Stand des Wissenschaftsgebietes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lehr-Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Publikation wurde erfolgreich von der Profilseite ausgeschlossen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Links"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie müssen einen Wert in das Feld Vorname eingeben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen mit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 4"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rollentyp"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Begutachtungsrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ändern des Cutoff-Wertes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Fenster zeigt Informationen über einzelne Suchbegriffe und Gruppen an. Klicken Sie auf eine Gruppe, um Informationen über sie anzuzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fächer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Im Fall einer erstmalig zu importierenden Publikation wählen Sie bitte einen passenden Publikationstyp aus der Liste."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten eintragen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datei"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Spalte <b>% of activity</b> zeigt, welcher Anteil der Publikationen auf jede (Unter-)Disziplin abgebildet wurde."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag für die Positionenhistorie"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseite hinzufügen für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "präsentiert bei"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoforscherIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag der Co-Projektleitung für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loggen Sie sich ein, um auf Ihrer Profilseite zusätzliche Angaben zu Ihren Publikationen zu machen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hrsg."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Namenspräfix"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle ausgewählten Einträge löschen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: die Publikation kann nicht von der Profilseite ausgeschlossen werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letzte Seite"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kapitel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ihre Suchanfrage lieferte leider keine Treffer."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgewähltes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Der Abdeckungsgrad dieser Visualisierung kann durch die Aufnahme weiterer Publikationsdaten in das VIVO-System verbessert werden, und indem sichergestellt wird, dass jede Veröffentlichung im System mit einer Zeitschrift verknüpft ist, die die Map of Science erkennt (basierend auf den Beständen von Clarivates WoS-Datenbank und Elseviers Scopus-Datenbank). Zeitschriftentitel, die Tippfehler oder andere Eigenheiten enthalten, müssen möglicherweise bereinigt werden, bevor sie erkannt werden. Wenden Sie sich an einen Systemadministrator, wenn Sie Fragen zum Abdeckungsgrad haben."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hochgeladene Dateien"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte & Projekte verwalten für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: die nicht markierten Bezeichnungen konnten nicht gelöscht werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewähltes Konzept"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tagungsberichte von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nur Anzeige"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisziplinen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberInnen verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Klicken Sie auf den Button, um die Daten auszulesen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mehr erfahren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erweiterte Funktionen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Teilnehmerrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verwaltet von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Fenster zeigt eine Liste der Suchbegriffe an, die sich derzeit in der Grafik befinden. Um zu beginnen, bitte nach etwas suchen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualisierungs-Tools"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "betreute Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Zeitschrift"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wenn Sie diese Arbeit nicht für sich beanspruchen wollen, wählen Sie bitte \"Das ist nicht meine Veröffentlichung\"."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausg."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unbekannter Resource Typ"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Fachbereichs oder der Schule innerhalb"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Land/Bundesland/Bezirk"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speicherstelle des Harvesters"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mitautorschaft"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Stadt/ Ort einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Stadt/ Ort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hier klicken, um die Standard-Profilseite zu sehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseiten-URL"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Institution"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Journal Artikel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Forscherin/ des Forschers"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bevorzugter Titel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auf Ihrer Profilseite können Sie zusäztliche Angaben zu Ihren Publikationen machen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoforscherInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "werden aktualisiert. Die Visualisierung wird geladen, sobald die Berechnung abgeschlossen ist - Sie können VIVO durchstöbern oder nach anderen Daten suchen und in wenigen Minuten zurückkehren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahre der Mitarbeit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definition"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datei"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "abgebildet"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvest"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "von Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Spalte <b>% of activity</b> zeigt, welcher Anteil der Publikationen auf die einzelnen Teildisziplinen abgebildet wurde."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Geben Sie {0}(s) ein:"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anfangsjahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nach Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "jedes Wort mit einem Großbuchstaben beginnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Beschreibung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 5"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Angaben beruhen ausschließlich auf"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Beratungsbezeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle in der Präsentation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Land einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visuelle Hinweise"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Anzahl der gefundenen Forscher pro Suchbegriff ist durch den Cutoff-Wert im Suchformular begrenzt (standardmäßig 10). Eine Erhöhung dieses Grenzwertes erhöht die Wahrscheinlichkeit einer Überschneidung zwischen verschiedenen Suchbegriffen. Dies erhöht jedoch auch die Komplexität des Graphen und kann die Erkennung von Mustern erschweren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ausgewählte Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "die ab in das VIVO-System geladen wurden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eigenes Konzept erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der klinischen Tätigkeit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Sie haben VIVOs Anfrage eine ID zu Ihrem ORCID Eintrag hinzuzufügen abgelehnt.</p> <p>Die Verknüpfung konnte nicht erstellt werden.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bevorzugter Titel von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Person in dieser Rolle"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name der Referenz einen Wert eintragen oder auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "übergeordneter Eintrag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konferenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehlermeldung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte beachten Sie: Diese Information beruht ausschließlich auf Publikationen, die in das VIVO-System geladen wurden und die möglicherweise nur eine kleine Auswahl des Gesamtwerkes der Person darstellen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen mit dem Forschungsgebiet in dieser Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte einen Nachnamen für diese Person eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit werden DOIs unterstützt, die von Crossref, DataCite und mEDRA vergeben wurden.<br />Jeder DOI sollte durch Komma oder Zeilenumbruch getrennt werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eigenschaft aus Laufzeit.Eigenschaften ist nicht definiert.In order to use this feature, please define a value for this property that points to the Harvester installation directory before redeploying and restarting the application."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Vortrags"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Dienstleisterrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die zugeschriebene Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine übereinstimmenden Entitäten gefunden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legende"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte einen Wert im Feld Name des Forschungsprojektes eintragen oder auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "landesweite Forschung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es können höchstens 10 Entitäten verglichen werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die dargestellten Informationen wurden zuletzt aktualisiert am"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erscheinungsort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberInnen mit Drag-and-Drop neu ordnen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bestätigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es konnte keine URL zu dem Link gefunden werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen mit Interesse an <a href=\"{1}\">{0}</a>, die in dieser Organisation sind."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Autors"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interagieren mit der Visualisierung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Um die Visualisierung besser lesbar zu machen, werden Suchbegriffe und Gruppen entsprechend der Anzahl der zurückgegebenen Ergebnisse skaliert. Je nach Anzahl der verknüpften Suchbegriffe erhalten die Gruppen auch unterschiedliche Schattierungen. Je dunkler der Farbton, desto mehr Suchbegriffe sind mit einer Gruppe verbunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Position"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verliehen von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Forschungsaktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung (Alternativbezeichnungen)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unabhängiges URI-Modell"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "zweiter Vorname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tragen Sie Ihre Daten in das Template ein. Sie können mehrere Templates ausfüllen, falls Daten aus mehreren Dateien auf einmal gesammelt werden sollen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abteilung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pausieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mittlere Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Das Endjahr muss später als das Anfangsjahr liegen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Folgende Modelle im Zwischenspeicher werden wiederhergestellt."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "größte Übereinstimmung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faxnummer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie haben ausgewählt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "einschließlich der Jahre"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Template herunterladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Musical Score"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mitgliedschaft in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Linien oben zeigen Forschungsprojekte im Verlauf des gesamten letzten Kalenderjahres. In den folgenden Tabellen finden sich dagegen Angaben zu Forschungsprojekten aus allen Jahren, die auf den Informationen beruhen, die in das VIVO-System geladen wurden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postanschrift erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "E-Mail-Adresse von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 1: Hinzufügen Ihrer ORCID iD"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Referenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unbekanntes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vorträge"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vielen Dank."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Mitgliedschaft bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag einer Publikation für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(z. B. Titel der Doktorarbeit, Informationen zu Fachwechsel etc.)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontakt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Person einen bestehenden Wert auswählen oder einen neuen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Um diese Option zu aktivieren, müssen Sie zuerst eine Auswahl treffen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mehr über diese Aktivität erfahren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erste Schritte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Durch Anklicken eines beliebigen Knotens in der Visualisierung können zusätzliche Informationen in der Registerkarte \"Info\" auf der rechten Seite angezeigt werden. Für Personengruppen können die Angehörigen der Gruppe und Informationen über sie eingesehen sowie einzelne Forscher aus der Visualisierung entfernt werden. Wenn Sie einen Suchbegriff auswählen, werden alle angehängten Gruppen angezeigt. Unter jeder Gruppe werden alle Informationen für jede Person abgerufen und die Anzahl der passenden Stipendien und Publikationen für jeden Forscher innerhalb der abgebildeten Fähigkeiten angezeigt. Ein Klick auf den Namen eines Forschers führt zu den ursprünglichen Suchergebnissen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine der Publikationen im System konnte zugeordnet werden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Betreuungsverhältnis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Band"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten werden geladen für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr (oben nicht aufgeführt)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte beachten Sie, dass von Crossref übertragenen Metadaten benutzt werden wenn zur PubMed ID kein passender DOI gefunden wird."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art der Referenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Organisatorenrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(z. B. für mehrjährige Auszeichnungen  )"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "für Ihre Instanz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name der Organisation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte/r AutorIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte löschen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zahl der Forschungsprojekte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag _START_ - _END_ von _TOTAL_ "@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eine existierende Klasse einer lokalen Erweiterung auswählen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Report"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehlender Abschluss"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soll diese/r HerausgeberIn wirklich gelöscht werden?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lokale Forschung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Markieren Sie die Personen, die auf der Profilseite nicht berücksichtigt werden sollen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in den letzten 10 vollen Jahren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekt(e)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-Code exportieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hilfe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veranstaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorIn-Icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "benachbarte Abteilungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eine/n AutorIn hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Stichtag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "wiederaufnehmen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Straße einen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soll diese Autorin / dieser Autor wirklich gelöscht werden:"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "innerhalb der letzten 10 Jahre"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fachgebiet"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipp: Sie können einen groben Suchbegriff durch Klicken auf &lsquo;suchen und erweitern&rsquo; in speziellere Begriffe erweitern."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postanschrift für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name des Dokuments einen Wert eintragen oder auswählen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ergebnisse anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte wählen Sie die Art des Betreuungsverhältnisses aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drill-Down"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "haben keine Zeitschriftenangaben"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eigenschaft aus Laufzeit.Eigenschaften verweist auf das Harvester-Installations-Verzeichnis."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Link zu einer Webseite entfernen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Das Anfangsjahr muss vor dem Endjahr liegen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eigenes Konzept erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Möchten Sie eine ORCID iD hinzufügen?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "zeitlicher Graph Drill-up"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Personen anzeigen, die sich für dieses Forschungsgebiet interessieren."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Scopus-ID-Link"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "BeraterIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Namenssuffix"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konzept erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 3"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zur Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "veröffentlicht"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name des Preises oder der Auszeichnung einen bestehenden Wert auswählen oder einen neuen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fachbezeichnungen anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fehlende Informationsquelle"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zu Ihrem VIVO Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AutorIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konzept"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte geben Sie eine Rolle für diese Aktivität an."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profilseite"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anfangsbuchstabe genügt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Werkzeug kann nur von Administratoren benutzt werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr der Auszeichung erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Geben Sie ein Forschungsfeld in das Suchfeld oben ein und klicken Sie auf 'Suchen'. Das resultierende Diagramm zeigt den Suchbegriff in orange an, in Verbindung mit der blauen Gruppe von Forschenden, die in diesem Bereich tätig sind. Geben Sie einen anderen Suchbegriff ein, um zu sehen, wie die Forscher aus beiden Suchen zusammenhängen. Fügen Sie weitere Suchbegriffe hinzu, um eine Capability Map ('Fähigkeitskarte') zu erstellen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bei"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legal Case"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name des Auszeichnungsnachweises"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dokumentart"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty-of-1000-Link"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag eines Vortrags für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte/r HerausgeberIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Personen in dieser Organisation anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "im laufenden Jahr (oben nicht aufgeführt)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsnetz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nur (Teil-)Disziplinen auflisten, deren Namen diesen Text enthalten."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bestätigen Sie Ihre Arbeiten:"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bild"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "neuer Nachname erforderlich"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorIn(nen)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webseiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Organisatorenrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nachname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kein Anzeige-Link"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dachorganisation von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unvollständiges Datums-/ Uhrzeitintervall"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "finden Sie auf"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ihr ORCID Eintrag wurde mit VIVO verknüpft.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberIn hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Teilnehmerrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mit bekanntem Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suchdienst"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verlag"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Setzen Sie Schritt 2 fort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung der betreuten Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine Artikel von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoforscherIn(en)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verliehen von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primäre E-Mail-Adresse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Willkommen beim Capability-Mapping-Tool. Dieses Tool veranschaulicht die Beziehung zwischen verschiedenen Forschenden über Suchbegriffe."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualisierungsmodelle im Zwischenspeicher aktualisieren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verliehen von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schnellanzeige des Profils"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kein Forschungsinhalt gefunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "laufendes, unvollständiges Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Neue Webseite hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mit unbekanntem Jahr"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es konnten keine näheren Angaben zur Publikation ermittelt werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Letter"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fächer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "um einen vollständigeren Überblick zu erhalten."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten herunterladen als"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Karte zum Vergleich von Kompetenzprofilen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Das Auslesen Ihres ORCID Eintrags ist fehlgeschlagen.</p> <p>Die Überprüfung kann nicht fortgesetzt werden.</p>"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editoren"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Markieren Sie die Publikationen, die auf der Profilseite nicht berücksichtigt werden sollen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es können höchstens 3 Einheiten miteinander verglichen werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr der Auszeichnung bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Forscherrolle hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Setzen Sie Schritt 1 fort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titel der Präsentation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Name einen bestehenden Wert auswählen oder einen neuen Wert eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Standard-Ansicht des Profils"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koforscher-Netzwerk"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsaktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "BewerberIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Öffentlichkeitsarbeit und Community-Arbeit"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verwandte Forschungsgebiete"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sie können eine oder mehrere PubMed IDs eingeben. Jede PubMed ID sollte durch Komma oder Zeilenumbruch getrennt werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezeichnung des Betreuungsverhältnisses"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forscherrolle"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "beteiligte Personen an verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Diese Forscherrolle bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konzept (Typ)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schließen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konzepte verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Publikationstätigkeit einer Universität, Organisation oder Person kann auf der Karte überlagert werden, um Kompetenzprofile zu erstellen. Der Ablauf ist wie folgt: (1) Die Menge der einzelnen Zeitschriften wird identifiziert, (2) die Anzahl, die jede Zeitschrift als Veröffentlichungsort diente, wird berechnet, und (3) die Flächengröße der 13 Disziplinen und 554 Teildisziplinen wird auf der Grundlage dieser Zeitschriftenveröffentlichungsorte berechnet. Beachten Sie, dass einige Zeitschriften genau einer (Sub-)Disziplin zugeordnet sind, während andere, z.B. interdisziplinäre Zeitschriften wie <em>Science</em> oder <em>Nature</em>, mit mehreren (Sub-)Disziplinen verbunden sind. Unterdisziplinen erben die Farben ihrer übergeordneten Disziplinen. (Teil-)Disziplinen ohne zugehörige Publikationen sind grau dargestellt."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle in der Institution"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "der Aktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aus einer Gesamtmenge"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue Mitgliedschaft hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte besuchen Sie das Portal,"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Das ist nicht meine Veröffentlichung."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahr der Auszeichung von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Betreuungsverhältnis zu"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koforscher-Netzwerk"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Spalte <b># of pubs.</b> zeigt, wie viele der Publikationen auf jede (Unter-)Disziplin abgebildet wurden. Diese Zählung kann aufgeteilt sein, da einige enthaltenden Sammelwerke mit mehr als einer (Unter-)Disziplin verbunden sind. Jede Publikation an einem solchen Ort trägt nach einem Gewichtungsschema zu allen zugehörigen (Teil-)Disziplinen bei."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URI teilen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Icon der Wissenschaftslandkarte"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "HerausgeberInnen-Link entfernen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "E-Mail"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fachbereich"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoforscherIn-Icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dieser Forscherin/ dieses Forschers."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zu Konzepte verwalten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Referenzen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "verliehen an"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Änderungen speichern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "richtig mit Ihren Datenbank-Informationen und dem Namensraum konfiguriert."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es stehen keine weiteren Veröffentlichungen zum Importieren zur Verfügung.<br />Sie können weitere IDs eingeben oder zu Ihrer Profilseite wechseln."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "laufende Forschungsprojekte für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abschluss"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Zahlen beruhen ausschließlich auf Publikationen, die in diese VIVO-Anwendung geladen wurden. Falls es sich um Ihr Profil handelt, können Sie unten weitere Publikationen eintragen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay  und Prüfung von Kompetenzprofilen für eine oder mehrere Organisationen. Farbcodierung nach Organisation."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Die Modelle werden bei jedem Neustart des Servers aktualisiert. Da dies auf der Produktionsinstanz  allgemein unpraktisch ist, können AdministratorInnen stattdessen den “Zwischenspeicher aktualisieren”-Link oben verwenden, um ohne einen Neustart eine Aktualisierung durchzuführen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte wählen Sie einen Typ aus der Dropdown-Liste aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoautorInnen-Netzwerk"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schnellanzeige-Icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zum Data Ingest Tools-Menü"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Für diese Kategorie sind zur Zeit keine Webseiten definiert. Fügen Sie eine neue Webseite durch einen Klick auf den Button unten hinzu."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikationen des heutigen Tages"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Neue klinische Position hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download-Link"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Es können höchstens 10 Entitäten verglichen werden. Bitte löschen Sie eine Auswahl und versuchen Sie es dann erneut."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualisierungen im großen Rahmen wie der zeitliche Graph oder die Wissenschaftslandkarte beinhalten die Berechnung der Gesamtzahl von Publikationen oder Forschungsprojekten für eine bestimmte Einheit. Da dies auch die Überprüfung aller Untereinheiten bedeutet, können die zugrundeliegenden Suchanfragen sowohl speicherintensiv als auch zeitaufwändig sein. Um die Anwendererfahrung zu beschleunigen, möchten wir die Ergebnisse dieser Suchanfragen zur späteren Wiederverwendung speichern."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schritt 1: Hinzufügen Ihrer ORCID iD"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "im System."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten-Overlay"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Profilseite gehen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tabellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kartendaten werden geladen..."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gesamte Forschung anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interaktivität"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abschicken"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "KoforscherInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "interne Klasse für die Institution"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsgebiete der Fachbereiche"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zu diesem Zweck haben wir eine Zwischenspeicherungslösung entwickelt, die durch die Speicherung des RDF-Modells Informationen über die Hierarchie der Organisationen speichert -- d. h. welche Publikationen welchen Organisationen zugerechnet werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vollansicht-Icon"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wenn Sie ein Autor der Arbeit sind, wählen Sie bitte Ihren Namen aus der Liste aus."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letztes Ergebnis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "keine Verknüpfung zu einer/einem AutorIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte warten Sie, der Harvesting-Prozess Ihrer Daten läuft."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fehler bei der Bearbeitung des Auftrags: der Eintrag kann nicht von der Profilseite ausgeschlossen werden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Was ist das?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(Vorgang abgeschlossen)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Im VIVO-Harvester existiert das"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hier klicken, um zur"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Referenz"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telefonnummer von"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Permalink zur aktuellen Visualisierung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digital Object Identifier (DOI)"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zahl der Publikationen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soll diese Webseite wirklich gelöscht werden?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Möchten Sie eine ORCID iD hinzufügen?"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Wortschatzquelle"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscript"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Schnellanzeige des Profils zu gelangen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bewilligt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Person"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "BachelorandIn/ MasterandIn/ DoktorandIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menü"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nutzungsbedingungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Formular kann die Bearbeitung dieser Position nicht ausführen, da es mit mehreren Einzelpositionen verbunden ist."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nachname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vorname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Mitglieder dieser Organisation anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "weitere Ergebnisse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postanschrift bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erste Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine ProfessorInnen gefunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mein Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieser Teil stammt aus der Template-Datei vivo/productMods/templates/freemarker/body/menupage/grants.ftl. In der Bildschirmanzeige hat die Seite Forschungsprojekte eine display:requiresBodyTemplate Eigenschaft, die definiert, dass die Seite Forschungsprojekte das Standard-Template aufhebt. Das Standard-Template für diese Seiten findet sich auf /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | verbinden teilen entdecken"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO-Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abmelden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Platzhalter-Bild"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erstes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "TeilnehmerIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Land."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impressum"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Technik könnte dazu benutzt werden, Seiten ohne Menüpunkte mit Inhalten aus einem Freemarker-Template zu definieren. Ein Beispiel hierfür wäre die Impressum-Seite."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle des Dienstleistungsanbieters"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "E-Mail-Adresse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "landesweite Standorte."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suche einschränken"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bundesland oder Bezirk "@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Copyright"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ort des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seite bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Rolle einen neuen Wert eintragen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letztes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine Forschungsprojekte für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Straße und Hausnummer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bild wird geladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suche filtern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "BenutzerIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Formular kann die Bearbeitung dieses Forschungsprojektes nicht ausführen, da es mit mehreren einzelnen Forschungsprojekten verbunden ist."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit gibt es keine ForscherInnen mit einem bestimmten Ort."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Abteilungen anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ansicht"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezirke"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle des Organisators/ der Organisatorin"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seitenverwaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hilfe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherInnen in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ProfessorInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letzte Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menüpunkt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrationszugang - Anmeldung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder und Bezirke"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle der GutachterIn/ des Gutachters"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine Abteilungen gefunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zum Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag eines Forschungsprojektes für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO durchsuchen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adresszusatz 2"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adressbezeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auswahl ändern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ProfessorInnen des {0} Fachbereichs, die Mitglieder dieser Organisation sind."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte in VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Führungsposition"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine {0} Artikel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Willkommen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Willkommen bei VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dadurch würde eine Seite entstehen, die about.ftl als Hauptteil benutzt. Die Seite wäre zugänglich über /about und würde alle servlet mappings in web.xml außer Kraft setzen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen in dem Fachbereich mit diesem Forschungsgebiet"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontakt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passwort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO ist ein forschungsorientiertes Recherchewerkzeug, das die Zusammenarbeit zwischen Wissenschaftlern quer durch alle Fachbereiche ermöglicht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sammlung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adresszusatz 1"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Auszeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten werden geladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anmelden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Startdatum des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Durchstöbern Sie die Kategorien oder suchen Sie gezielt Informationen zu Personen, Fachbereichen, Seminaren, Forschungsprojekten und Veranstaltungen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mein Account"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vollständiger Name"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahre der Mitarbeit in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gesamten Fachbereich anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suche filtern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Führungsposition"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ansicht"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ort des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ausgewählte Auszeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle des Dienstleistungsanbieters"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vorname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontakt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adresszusatz 2"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle der GutachterIn/ des Gutachters"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nutzungsbedingungen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Formular kann die Bearbeitung dieser Position nicht ausführen, da es mit mehreren Einzelpositionen verbunden ist."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "TeilnehmerIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Platzhalter-Bild"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "BenutzerIn"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letzte Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passwort"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieses Formular kann die Bearbeitung dieses Forschungsprojektes nicht ausführen, da es mit mehreren einzelnen Forschungsprojekten verbunden ist."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder und Bezirke"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Abmelden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seite bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "bis"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Art des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mein Account"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine ProfessorInnen gefunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "landesweite Standorte."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bundesland oder Bezirk "@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hilfe"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherInnen in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nachname"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hinzufügen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Durchstöbern Sie die Kategorien oder suchen Sie gezielt Informationen zu Personen, Fachbereichen, Seminaren, Forschungsprojekten und Veranstaltungen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag eines Forschungsprojektes für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | verbinden teilen entdecken"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auswahl ändern"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ProfessorInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seitenverwaltung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sammlung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrationszugang - Anmeldung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Abteilungen anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mein Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Land."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dadurch würde eine Seite entstehen, die about.ftl als Hauptteil benutzt. Die Seite wäre zugänglich über /about und würde alle servlet mappings in web.xml außer Kraft setzen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alle Mitglieder dieser Organisation anzeigen."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "E-Mail-Adresse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gesamten Fachbereich anzeigen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bitte im Feld Rolle einen neuen Wert eintragen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postanschrift bearbeiten"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jahre der Mitarbeit in"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Willkommen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Startdatum des Forschungsprojektes"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adressbezeichnung"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erste Publikation"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ProfessorInnen des {0} Fachbereichs, die Mitglieder dieser Organisation sind."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suche einschränken"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vollständiger Name"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zur Zeit gibt es keine ForscherInnen mit einem bestimmten Ort."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO durchsuchen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Copyright"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Keine Abteilungen gefunden."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bild wird geladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "letztes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dieser Teil stammt aus der Template-Datei vivo/productMods/templates/freemarker/body/menupage/grants.ftl. In der Bildschirmanzeige hat die Seite Forschungsprojekte eine display:requiresBodyTemplate Eigenschaft, die definiert, dass die Seite Forschungsprojekte das Standard-Template aufhebt. Das Standard-Template für diese Seiten findet sich auf /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine Forschungsprojekte für"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Länder."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "erstes Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Forschungsprojekte in VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bezirke"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "weitere Ergebnisse"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Daten werden geladen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diese Technik könnte dazu benutzt werden, Seiten ohne Menüpunkte mit Inhalten aus einem Freemarker-Template zu definieren. Ein Beispiel hierfür wäre die Impressum-Seite."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eintrag erstellen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rolle des Organisators/ der Organisatorin"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Straße und Hausnummer"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO ist ein forschungsorientiertes Recherchewerkzeug, das die Zusammenarbeit zwischen Wissenschaftlern quer durch alle Fachbereiche ermöglicht."@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impressum"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adresszusatz 1"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO-Profil"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personen in dem Fachbereich mit diesem Forschungsgebiet"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurzeit gibt es keine {0} Artikel"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ForscherInnen"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anmelden"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Willkommen bei VIVO"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zurück zum Forschungsprojekt"@de-DE ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the person cannot be excluded from the organization page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Conference"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This organization has neither sub-organizations nor people with"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only organizations whose name contains this text."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type of Educational Training"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the last 10 full"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reset"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webpage Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants per year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "directory and all of its children."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service to the profession"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no constructed models for use by visualization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in a completed year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Authors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Position Type field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compare organizations"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "full name for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Additional Emails"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In order for a local ontology to be recognized here, its namespace URI must follow this pattern"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Claiming works for<br />{0}"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Count"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "incomplete date/time value"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service to the profession in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Next"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resource name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those grants and projects you want to <em>exclude</em> from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Postal Code field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the file"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "How do you want to compare?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Major Field of Degree"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to enter additional details about your grants on your profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutions"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all grants"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "More info on QR codes"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Position Title"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "click webpage icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Type of Educational Training field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e.g., Instructor, Facilitator, Assistant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concept name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advisee"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR Code"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigator"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For more information on the UCSD map of science and classification system, see"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvest complete.  For another, please refresh the page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You may enter one or more DOIs to match, and can be entered either as an ID or URL:<br /><br />e.g."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Email Address field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This is most likely due to an improper Harvester configuration. Please ensure the following:"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no linked editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ENTITY LEVEL UNDEFINED ERROR"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this editor role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Can't find an appropriate class?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique co-investigators"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: the organizations or people listed below are only those which are directly beneath {0} in the organization hierarchy. You may 'drill down' to see the organizations or people below a given sub-organization by selecting the chart icon next to a selected sub-organization's name below the graph on the right."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remove group"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Web Pages"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unknown Profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The end user should not see this error under normal circumstances, so this is probably a bug and should be reported."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID iD is confirmed as {0}</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Harvester is installed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remove capability"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "across 554 scientific subdisciplines"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View full timeline and co-investigator network."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to your profile page to enter additional details about your grants."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clinical activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About VIVO's Map of Science Visualization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-authors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presentation Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "External Vocabulary Services"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO failed to add an External ID to your ORCID record.</p> <p>Linking can't continue.</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: term not removed"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For other maps of science, see"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this \"head of\" role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Temporal Graph"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Total Number of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The item has been successfully excluded from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-authors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patent"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "hide group labels"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each subdiscipline. This count can be fractional because some publication venues are associated with more than one subdiscipline. Each publication in such a venue contributes fractionally to all associated subdisciplines according to a weighting scheme."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dataset"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "phone"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new service provider role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the web server user (typically tomcat6) has read and write access to the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisor label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Book"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR Code"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Title not found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Supplemental Information"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "additional emails"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Geographic Focus"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: This information is based solely on grants that have been loaded into the VIVO system. This may only be a small sample of the person's total work."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This visualization is based on the publications we were able to 'science locate' for {0}, and therefore it may not be fully representative of the overall publication activity for {0}."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have already claimed this work."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Conferrer"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "reviewer of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload your completed template(s)."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: problematic section as above should all have been handled."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Review"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all active grants"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "screenshot of webpage {0}"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Script being executed"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unlisted Author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "attended"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must enter a value in the Last Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "qr icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Label (Type)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "and then return here to define the institutional internal class."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique Co-Investigators per year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create a new one"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Organization Type field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ingest Menu"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Progress"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of up to three organizations or persons can be compared via \"Compare organizations.\" In the table on the left, select up to three organizations. The expertise profile of each organizations will be represented as data overlay. Each organizations is represented in a distinct color and a top-10 list of subdisciplines with the highest number of publications is given below the comparison map. Data can be saved as CSV file."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organization type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advising Relationship Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webpage"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Info"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant being administered by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor role in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Presentation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This class will be used to designate those individuals internal to your institution."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "schools"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of web pages failed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The last name field may not contain a comma. Please enter first name in First Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redirects you to ORCID's web site.</li> <li>You log in to your ORCID account. <ul class=\"inner\"><li>If you don't have an account, you can create one.</li></ul></li> <li>You tell ORCID that VIVO may read your ORCID record.</li> <li>VIVO reads your ORCID record.</li> <li>VIVO notes that your ORCID iD is confirmed.</li></ul>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This will allow you to limit the individuals displayed on your menu pages (People, Research, etc.) to only those within your institution."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "collection or series editor role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thesis"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "from"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "educational training entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all VIVO grants and corresponding co-investigator network."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique Co-Authors per year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is now being refreshed. The visualization will load as soon as we are done computing, or you can search or browse other data in VIVO and come back in a few minutes."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new reviewer role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link text"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Advisor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the VIVO database."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Term"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Networks"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "by Grants"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: web page not removed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entity Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legislation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conference Paper"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "temporal graph"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entity Label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an iD"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The VIVO Map of Science visualization uses the UCSD map of science and classification system that was computed using paper-level data from about 25,000 journals from Elsevier's Scopus and Clarivate Analytics' Web of Science (WoS) for the years 2001-2010. The UCSD map of science assigns the 25,000 journals to 554 subdisciplines that are further aggregated into 13 main disciplines of science. In the map, each discipline has a distinct color (green for 'Biology', brown for 'Earth Sciences', etc.) and a label. (Sub)disciplines that are similar closer to one another on the map. (Sub)disciplines that are especially similar are connected by grey lines."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for a organization. Color coding by discipline."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizer of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit publication date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This content requires the Adobe Flash Player."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The person has been successfully excluded from the organization page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have passed an invalid value for the qrCode display parameter."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "We're currently caching these models in memory.  The cache is built (only once) on the first user request after a server restart.  Because of this, the same model will be served until the next restart. This means that the data in these models may become stale depending upon when it was last created. This works well enough for now. In future releases we will improve this solution so that models are stored on disk and periodically updated."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year Awarded"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create publication date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "total"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speech"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Organization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "map of science"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PubMed ID"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor of entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "principal investigator entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "outreach & community service in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Publications for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants with"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 links"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No publications in the system have been attributed to this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparing"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Book"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "YYYY"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a First name for this person."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizations and People"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "within my institution"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select at least one external vocabulary source to search."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 2 (recommended): Linking your ORCID record to VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award or honor for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Learn more about VIVO's Map of Science visualization?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researcher"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of editors failed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "None of the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advising"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Why is it needed?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this outreach provider role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please visit the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Number of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this clinical activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primary email"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this term?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URL Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new editor role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create a new class"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Document Type field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of authors failed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove author link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidacy"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Theses"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "background top image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Authors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "series"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administering organization for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "An error was encountered in executing this search."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Selected Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Current search terms"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "position entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 links"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutional Internal Class"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty members in the {0} department who have an interest in this research area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Street Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The listed organizations are children of the {0} node in the organizational hierarchy. You may 'drill down' to see the organizations below a given sub-organization by selecting the chart icon next to a selected sub-organization's name below the graph on the right."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In order to use this feature, please define a value for this property that points to the Harvester installation directory before redeploying and restarting the application."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clear search query"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hyperlink"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map of Science"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "directory exists and the web server user has read and write access to it."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "or add a new one."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Map of Science visualization depicts the topical expertise a university, organization, or person has based on past publications loaded into VIVO. The {0} expertise profile is shown here -- larger circle sizes denote more publications per topic area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to view the {0} web page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postal Code"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new \"head of\" role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e.g., Moderator, Speaker, Panelist"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verify this match"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Article"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expand"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Fax Number field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Document"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} grants for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit webpage of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are {0} ids remaining"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "could not be matched with a map location using their journal information."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications (pubs.)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Info"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View this person's profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Number"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Preferred Title field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no recognized local ontologies."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End Year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save All as CSV"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants per year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 links"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications attributed to this"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new outreach provider role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Subject Area"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search terms"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activity name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigator entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload file(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search and Expand"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing publication in the Title field or enter a new one."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map of Science Visualization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "show group labels"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Export QR code"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Links"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Can't find the concept you want? Select or create a VIVO-defined concept."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "new local ontology"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year Issued"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new teaching role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection or series"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The table below summarizes the publications plotted on the Map of Science. Each row corresponds to a (sub)discipline on the map"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Position Title field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing credential"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals in <a href=\"{1}\">{0}</a> who have an interest in this research area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder authors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizations"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membership"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save Unmapped Publications"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telephone Number"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no concepts specified."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "group"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals in the <a href=\"{1}\">{0}</a> who have an interest in this research area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications in VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication date for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departments"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Web Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The information in the following tables is for all years."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to Profile Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing presentation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>You denied VIVO's request to read your ORCID record.</p> <p>Confirmation can't continue.</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select at least one term from the search search results."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading faculty . . ."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing person in this position"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This information is based solely on {0} which have been loaded into the VIVO system."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "has not been \"science-located.\""@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Get Flash"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You do not have permissions to claim for this user"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder web pages"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View full timeline and co-author network."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: editor not removed"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No matching science areas found"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "person name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing event"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: No file harvest job was specified, or an unknown job was specified."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Issue"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "were"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select an existing Organization or create a new one."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Build a &lsquo;first pass&rsquo; capability map by typing in a<!-- set of--> search term<!--s--> that could be said to represent a broad research capability."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Global Research"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications per year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: author not removed"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please check that these are the work(s) that you wish to claim, and indicate your relationship with them."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teaching activity type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Claim publications by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clear"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click an area to view others"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "this author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "leadership"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What's involved in the caching process?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redirects you to ORCID's web site</li> <li>You tell ORCID that VIVO may add an \"external ID\" to your ORCID record.</li> <li>VIVO adds the external ID.</li></ul>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all ..."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fax number for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Country"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapter"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with the same interest."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View your ORCID record."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 2"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local Namespace"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Research"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What do you want to compare?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing organization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reference Basemap"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Published in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subdisciplines"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capability"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have been \"science-located.\""@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Publisher"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all faculty with an interest in this area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a new local ontology"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "edit web page link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID record already includes a link to VIVO.</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this teaching role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Award or Honor Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research areas"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no active grants for this department."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "People"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The map can be explored at two levels-by 13 disciplines or 554 subdisciplines. Clicking on a node in the map brings up the number of fractionally associated journal publications and the percentage of publications mapped to this (sub)discipline. Hover over a discipline in the table on the left to see what circles it corresponds to on the map. Use slider below map, on the right to reduce number of subdisciplines shown to improve legibility. "@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Telephone Number field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you edited the work, please select \"Editor\"."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activities"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Event"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "An error has occurred and the file harvest cannot continue."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Level of Science Area"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teaching activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication will has been successfully excluded from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must enter a value in the First Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications with"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 4"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this reviewer role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Changing the cutoff value"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This panel displays information about individual search terms and groups. Click on a group to display its information."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "disciplines"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fill in data"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "File"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each (sub)discipline."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "position history entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add webpage for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presented At"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-principal investigator entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to enter additional details about your publications on your profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name Prefix"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clear all selected entities."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the publication cannot be excluded from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapter"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No search results were found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication coverage of this visualization can be improved by including more publication data in the VIVO system, and by ensuring that each publication in the VIVO system is associated with a journal that the Map of Science recognizes (based on the holdings of Clarivate Analytics' Web of Science database and Elsevier's Scopus database). Journal names containing typos or other idiosyncrasies may need to be cleaned up before they are recognized. You may contact a VIVO system administrator if publication coverage is a concern."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uploaded files"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Grants & Projects for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the unchecked labels could not be deleted."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Proceedings of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Only display"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisciplines"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Editors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click the button to harvest your file(s)."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advanced features"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this participation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administered by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This panel displays a list of the search terms currently on the graph. Search for something to begin."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualization Tools"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Advisee"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Journal"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you do not wish to claim a work, select \"This is not my work\"."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unknown Resource Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Department or School Name within the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "State/Province/Region"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-authorship"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the City/Locality field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "City/Locality"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to view the standard profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "webpage url"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name of Institution"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Journal Article"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigator name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preferred Title"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to your profile page to enter additional details about your publications."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigators"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is now being refreshed. The visualization will load as soon as we are done computing, or you can search or browse other data in VIVO and come back in a few minutes."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definition"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "file"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapped"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvest"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of pubs."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each subdiscipline."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enter {0}:"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start Year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "by Publications"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "use capitals for the first letter of each word"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Description"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 5"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This information is based solely on"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisory label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in Presentation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Country field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visual cues"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The amount of researchers retrieved for each search term for is limited by the cutoff value in the search form (10 by default). Increasing this cutoff will increase the likelihood of an intersection between different search terms. This will also increase the complexity of the graph, however, and may make it difficult to identify patterns."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "which have been loaded into the VIVO system as of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select or create a VIVO-defined concept."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clinical activity type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>You denied VIVO's request to add an External ID to your ORCID record.</p> <p>Linking can't continue.</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "preferred title for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing person in this role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Credential Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "parent entity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conference"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "error notification"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: This information is based solely on publications that have been loaded into the VIVO system. This may only be a small sample of the person's total work."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals with the research area in this organization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a Last name for this person."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently, DOIs issued by Crossref, DataCite and mEDRA are supported.<br />Each DOI should be separated by a comma or new line."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property in runtime.properties is undefined."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "presentation name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this service provider role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication attributed to this"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No matching entities found"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legend"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Grant Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Country-wide Research"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A Maximum of 10 entities can be compared."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Using information cached at"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of Publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder editors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirm"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no url provided for link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals with an interest in <a href=\"{1}\">{0}</a> who are in this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "author name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interacting with the visualisation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To make the visualisation easier to read, search terms and groups are scaled according to the number of results returned. Groups are also given different shades according to the number of connected search terms. The darker the shade, the more search terms a group is connected to."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Position Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferred by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research activity type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Label (Alternate Labels)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URI Independent Model"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Middle name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fill in the template with your data.  You may fill in multiple templates if you wish to harvest multiple files at once."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "department"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pause"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "middle organization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The End Year must be later than the Start Year."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The following cached models will be regenerated."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Best Match"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prev"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fax Number"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have selected"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years Inclusive"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download template"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Musical Score"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membership in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The spark lines shown above reflect grants through the last complete calendar year. These tables, however, show the grant information for all years, based on the information loaded in the VIVO system."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Mailing Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email address for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1: Adding your ORCID iD"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Credential Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have an unknown"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speeches"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thank you"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this membership"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(e.g., Thesis title, Transfer info, etc.)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Person field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To enable this option, you must first select an"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Getting Started"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "By clicking on any node in the visualisation, additional information can be viewed in the 'Info' tab on the right-hand side. For groups of people, the participants in the group and their information can be viewed, and individual researchers can be removed from the graph. Selecting a search term will display all attached groups. Under each group full information for each person is retrieved, and the number of matching grants and publications for each researcher within the mapped capabilities is shown. Clicking on a researcher's name will lead to the original search results."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No publications in the system have been attributed to this"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advising relationship"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volume"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading data for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "year (not charted above)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note that metadata will be retrieved from Crossref, if the PubMed ID can be resolved to a DOI."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type of Credential"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new Organizer role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(e.g., for multi-year awards)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for your instance"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organization name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Delete selected"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant Count"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Records _START_ - _END_ of _TOTAL_ "@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select an existing class from a local extension"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Report"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing degree"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this editor:"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local Research"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those people you want to <em>exclude</em> from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the last 10 full years"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Export QR codes"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Help"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Event"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "years"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-author icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Associated Departments"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an Author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close Date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resume"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Street Address field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this author:"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "within the last 10 years"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subject Area"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip: you can expand a broad search term into smaller concepts by clicking &lsquo;search and expand&rsquo;."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mailing address for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Document Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View results"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an Advising Relationship Type."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "drill down"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have no journal information."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property in runtime.properties is pointed to the Harvester installation directory."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "delete web page link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The Start Year must be earlier than the End Year."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Your Own Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Do you want to add an ORCID iD?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "temporal graph drill up"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all individuals with an interest in this area."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Scopus ID Link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advisor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name Suffix"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 3"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "published"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Award or Honor Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Show discipline labels"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Person"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing information resource"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to your VIVO profile page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please specify a role for this activity."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profile page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "initial okay"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Item"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must be an administrator to use this tool."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create year awarded"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enter a research area into the search field above and press 'Search'. The resulting diagram displays the search term, rendered in orange, connected to the blue group of researchers that are active in that area. Enter another search term to see how researchers from both searches relate. Keep adding search terms to build a capability map."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "at"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legal Case"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award receipt name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty of 1000 Link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "presentation entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all individuals in this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the current incomplete year (not charted above)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capability Map"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only (sub)disciplines whose names contain this text."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirm your work(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "required with new Last name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-author(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Websites"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this organizer role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no view link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Parent organization of"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "incomplete date/time interval"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for a complete overview."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID record is linked to VIVO</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an Editor"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new participation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with known year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search Service"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publisher"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue Step 2"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisee label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no papers for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigator(s)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "awarded by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primary Email"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to the Capability Mapping tool. This tool visualises how researchers relate to other researchers via search terms."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Refresh Cached Models for Visualization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conferred by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Quick profile view"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No research content found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "from current incomplete year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add New Web Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with unknown year"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unable to retrieve citation details"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Letter"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Disciplines"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for a more complete overview."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizations"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download data as"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expertise Profile Comparison Map"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO failed to read your ORCID record.</p> <p>Confirmation can't continue.</p>"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editors"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those publications you want to <em>exclude</em> from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The maximum number of items for comparison is 3."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit year awarded"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new researcher role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue Step 1"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Title of Presentation"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Name field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Standard profile view"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator network"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidate"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "outreach & community service"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Affiliated Research Areas"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You may enter one or more PubMed IDs to match. Each ID should be separated by a comma or new line."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisor relationship entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Researcher Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage People Affiliated with"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this researcher role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept (Type)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close Me"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Concepts"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of a university, organization, or person can be overlaid on the map to generate expertise profiles. The process is as follows: (1) The set of unique journals is identified, (2) the number of times each journal served as a publication venue is calculated, and (3) the area size of the 13 disciplines and 554 subdisciplines is calculated based on these journal publication venue counts. Note that some journals are associated with exactly one (sub)discipline while others, e.g., interdisciplinary ones like <em>Science</em> or <em>Nature</em>, are fractionally associated with multiple (sub)disciplines. Subdisciplines inherit the colors of their parent disciplines. (Sub)disciplines without any associated publications are given in gray.Publication activity of a university, organization, or person can be overlaid on the map to generate expertise profiles. The process is as follows: (1) The set of unique journals is identified, (2) the number of times each journal served as a publication venue is calculated, and (3) the area size of the 13 disciplines and 554 subdisciplines is calculated based on these journal publication venue counts. Note that some journals are associated with exactly one (sub)discipline while others, e.g., interdisciplinary ones like <em>Science</em> or <em>Nature</em>, are fractionally associated with multiple (sub)disciplines. Subdisciplines inherit the colors of their parent disciplines. (Sub)disciplines without any associated publications are given in gray. "@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in Institution"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of a maximum"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new membership"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please visit the full"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This is not my work"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "year awarded for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisee relationship entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigator Network"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each (sub)discipline. This count can be fractional because some publication venues are associated with more than one (sub)discipline. Each publication in such a venue contributes fractionally to all associated (sub)disciplines according to a weighting scheme."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "share the uri"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "map of science icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove editor link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "this investigator"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to Manage Concepts"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "credentials"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferred on"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is properly configured with your database information and namespace."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are no more works left to claim.<br />You may enter more IDs below, or view your profile."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Active Grants for the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Degree"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "These numbers are based solely on publications that have been loaded into this VIVO application. If this is your profile, you can enter additional publications below."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for one or more organizations. Color coding by organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the \"refresh cache\" link above to do this without a restart."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a type from the drop-down list."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-author Network"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "quick view icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to the Data Ingest Tools menu"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This individual currently has no web pages specified. Add a new web page by clicking on the button below."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications through today's date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new clinical activity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "download link"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A Maximum 10 entities can be compared. Please remove some & try again."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Large-scale visualizations like the Temporal Graph or the Map of Science involve calculating total counts of publications or of grants for some entity. Since this also means checking through all of its sub-entities, the underlying queries can be both memory-intensive and time-consuming. For a faster user experience, we wish to save the results of these queries for later re-use."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1: Adding your ORCID iD"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the system."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data Overlay"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tables"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading map information . . ."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all research"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interactivity"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Submit IDs"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigators"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "institutional internal class"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Research Areas"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To this end we have devised a caching solution which will retain information about the hierarchy of organizations -- namely, which publications are attributed to which organizations -- by storing the RDF model."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "full view icon"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you are an author of a work, please select your name in the author list.<br />Retrieved metadata may be incomplete. If you can not see your name listed, select \"Unlisted Author\"."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no linked author"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please wait while your data is harvested."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the item cannot be excluded from the profile page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What is this?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(step completed)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to display the"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Credential"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "telephone number for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Persistent link to current visualization"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digital Object Identifier (DOI)"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Count"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this web page?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Do you want to add an ORCID iD?"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vocabulary Source"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscript"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profile quick view."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "granted"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Person"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Degree Candidacy"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Terms of Use"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this position because it is associated with multiple Position individuals."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all the members of this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "more"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Mailing Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No faculty members found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | connect share discover"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log out"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Entry"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "placeholder image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attendee"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Service Provider Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state-wide locations."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limit search"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province or Region"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "to"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a new value in the Role field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no grants for "@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street one"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "states."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading website image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filter search"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "user"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this grant because it is associated with multiple grant individuals."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no researchers with a defined geographic focus."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all academic departments"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regions"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizer Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Support"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Memberships"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "menu item"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to manage this site"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries and regions."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reviewer Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No academic departments found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street three"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "change selection"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty in the {0} department who are members of this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants in VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Leadership Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} papers for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals in the department with this research area"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Us"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "password"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO is a research-focused discovery tool that enables collaboration among scientists across all disciplines."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street two"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "loading data"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "return to"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Browse or search information on people, departments, courses, grants, and publications."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My account"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Full name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all faculty"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filter search"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Leadership Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Service Provider Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Us"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street three"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reviewer Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Terms of Use"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this position because it is associated with multiple Position individuals."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attendee"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "placeholder image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "user"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "password"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this grant because it is associated with multiple grant individuals."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries and regions."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log out"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Page"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "to"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Type"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My account"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No faculty members found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state-wide locations."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province or Region"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Support"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Browse or search information on people, departments, courses, grants, and publications."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant entry for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | connect share discover"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "change selection"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Memberships"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to manage this site"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all academic departments"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all the members of this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all faculty"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a new value in the Role field."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "return to"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Mailing Address"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Date"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address label"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First publication"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty in the {0} department who are members of this organization."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limit search"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Full name"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no researchers with a defined geographic focus."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No academic departments found."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading website image"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no grants for "@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "states."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants in VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regions"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "more"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "loading data"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Entry"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizer Role"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street one"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO is a research-focused discovery tool that enables collaboration among scientists across all disciplines."@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street two"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profile"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals in the department with this research area"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} papers for"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to VIVO"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to grant"@en-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the person cannot be excluded from the organization page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Conference"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This organization has neither sub-organizations nor people with"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only organizations whose name contains this text."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type of Educational Training"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the last 10 full"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reset"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webpage Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants per year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "directory and all of its children."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service to the profession"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no constructed models for use by visualization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in a completed year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Authors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Position Type field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compare organizations"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "full name for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Additional Emails"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In order for a local ontology to be recognized here, its namespace URI must follow this pattern"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Claiming works for<br />{0}"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Count"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "incomplete date/time value"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service to the profession in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Next"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resource name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those grants and projects you want to <em>exclude</em> from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Postal Code field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the file"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "How do you want to compare?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Major Field of Degree"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to enter additional details about your grants on your profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutions"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all grants"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "More info on QR codes"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Position Title"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "click webpage icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Type of Educational Training field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e.g., Instructor, Facilitator, Assistant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concept name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advisee"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR Code"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigator"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For more information on the UCSD map of science and classification system, see"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvest complete.  For another, please refresh the page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You may enter one or more DOIs to match, and can be entered either as an ID or URL:<br /><br />e.g."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Email Address field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This is most likely due to an improper Harvester configuration. Please ensure the following:"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no linked editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ENTITY LEVEL UNDEFINED ERROR"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this editor role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Can't find an appropriate class?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique co-investigators"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: the organizations or people listed below are only those which are directly beneath {0} in the organization hierarchy. You may 'drill down' to see the organizations or people below a given sub-organization by selecting the chart icon next to a selected sub-organization's name below the graph on the right."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remove group"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Web Pages"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unknown Profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The end user should not see this error under normal circumstances, so this is probably a bug and should be reported."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID iD is confirmed as {0}</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Harvester is installed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remove capability"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "across 554 scientific subdisciplines"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View full timeline and co-investigator network."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to your profile page to enter additional details about your grants."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clinical activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About VIVO's Map of Science Visualization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-authors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presentation Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "External Vocabulary Services"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO failed to add an External ID to your ORCID record.</p> <p>Linking can't continue.</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: term not removed"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For other maps of science, see"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this \"head of\" role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Temporal Graph"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Total Number of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The item has been successfully excluded from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-authors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patent"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "hide group labels"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each subdiscipline. This count can be fractional because some publication venues are associated with more than one subdiscipline. Each publication in such a venue contributes fractionally to all associated subdisciplines according to a weighting scheme."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dataset"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "phone"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new service provider role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the web server user (typically tomcat6) has read and write access to the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisor label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Book"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR Code"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Title not found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Supplemental Information"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "additional emails"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Geographic Focus"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: This information is based solely on grants that have been loaded into the VIVO system. This may only be a small sample of the person's total work."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This visualization is based on the publications we were able to 'science locate' for {0}, and therefore it may not be fully representative of the overall publication activity for {0}."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have already claimed this work."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Conferrer"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "reviewer of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload your completed template(s)."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: problematic section as above should all have been handled."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Review"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all active grants"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "screenshot of webpage {0}"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Script being executed"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unlisted Author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "attended"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must enter a value in the Last Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "qr icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Label (Type)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "and then return here to define the institutional internal class."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique Co-Investigators per year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create a new one"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Organization Type field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ingest Menu"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Progress"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of up to three organizations or persons can be compared via \"Compare organizations.\" In the table on the left, select up to three organizations. The expertise profile of each organizations will be represented as data overlay. Each organizations is represented in a distinct color and a top-10 list of subdisciplines with the highest number of publications is given below the comparison map. Data can be saved as CSV file."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organization type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advising Relationship Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Webpage"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Info"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant being administered by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor role in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Presentation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This class will be used to designate those individuals internal to your institution."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "schools"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of web pages failed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The last name field may not contain a comma. Please enter first name in First Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redirects you to ORCID's web site.</li> <li>You log in to your ORCID account. <ul class=\"inner\"><li>If you don't have an account, you can create one.</li></ul></li> <li>You tell ORCID that VIVO may read your ORCID record.</li> <li>VIVO reads your ORCID record.</li> <li>VIVO notes that your ORCID iD is confirmed.</li></ul>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This will allow you to limit the individuals displayed on your menu pages (People, Research, etc.) to only those within your institution."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "collection or series editor role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thesis"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "from"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "educational training entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all VIVO grants and corresponding co-investigator network."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unique Co-Authors per year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is now being refreshed. The visualization will load as soon as we are done computing, or you can search or browse other data in VIVO and come back in a few minutes."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new reviewer role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link text"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Advisor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the VIVO database."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Term"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "event label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Networks"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "by Grants"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: web page not removed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entity Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legislation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conference Paper"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "temporal graph"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entity Label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an iD"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The VIVO Map of Science visualization uses the UCSD map of science and classification system that was computed using paper-level data from about 25,000 journals from Elsevier's Scopus and Clarivate Analytics' Web of Science (WoS) for the years 2001-2010. The UCSD map of science assigns the 25,000 journals to 554 subdisciplines that are further aggregated into 13 main disciplines of science. In the map, each discipline has a distinct color (green for 'Biology', brown for 'Earth Sciences', etc.) and a label. (Sub)disciplines that are similar closer to one another on the map. (Sub)disciplines that are especially similar are connected by grey lines."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for a organization. Color coding by discipline."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizer of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit publication date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This content requires the Adobe Flash Player."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The person has been successfully excluded from the organization page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have passed an invalid value for the qrCode display parameter."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "We're currently caching these models in memory.  The cache is built (only once) on the first user request after a server restart.  Because of this, the same model will be served until the next restart. This means that the data in these models may become stale depending upon when it was last created. This works well enough for now. In future releases we will improve this solution so that models are stored on disk and periodically updated."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year Awarded"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create publication date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "total"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speech"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Organization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "map of science"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PubMed ID"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor of entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "principal investigator entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "outreach & community service in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Publications for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants with"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 links"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No publications in the system have been attributed to this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparing"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Book"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "YYYY"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a First name for this person."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizations and People"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "within my institution"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select at least one external vocabulary source to search."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 2 (recommended): Linking your ORCID record to VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award or honor for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Learn more about VIVO's Map of Science visualization?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researcher"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of editors failed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "None of the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advising"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Why is it needed?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this outreach provider role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please visit the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Number of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this clinical activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primary email"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this term?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URL Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new editor role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create a new class"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a value in the Document Type field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordering of authors failed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove author link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidacy"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Theses"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "background top image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Authors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "series"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administering organization for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "An error was encountered in executing this search."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Selected Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Current search terms"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "position entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 links"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutional Internal Class"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty members in the {0} department who have an interest in this research area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Street Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The listed organizations are children of the {0} node in the organizational hierarchy. You may 'drill down' to see the organizations below a given sub-organization by selecting the chart icon next to a selected sub-organization's name below the graph on the right."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In order to use this feature, please define a value for this property that points to the Harvester installation directory before redeploying and restarting the application."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clear search query"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hyperlink"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map of Science"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "directory exists and the web server user has read and write access to it."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "or add a new one."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Map of Science visualization depicts the topical expertise a university, organization, or person has based on past publications loaded into VIVO. The {0} expertise profile is shown here -- larger circle sizes denote more publications per topic area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to view the {0} web page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Postal Code"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new \"head of\" role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e.g., Moderator, Speaker, Panelist"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verify this match"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Article"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expand"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Fax Number field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Document"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} grants for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit webpage of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are {0} ids remaining"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "could not be matched with a map location using their journal information."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications (pubs.)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Info"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View this person's profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Number"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Preferred Title field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no recognized local ontologies."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End Year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save All as CSV"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants per year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organization Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 links"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications attributed to this"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new outreach provider role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Subject Area"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search terms"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activity name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigator entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload file(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search and Expand"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing publication in the Title field or enter a new one."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map of Science Visualization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "show group labels"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Export QR code"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Links"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Can't find the concept you want? Select or create a VIVO-defined concept."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "new local ontology"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year Issued"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new teaching role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection or series"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The table below summarizes the publications plotted on the Map of Science. Each row corresponds to a (sub)discipline on the map."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Position Title field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing credential"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals in <a href=\"{1}\">{0}</a> who have an interest in this research area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder authors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizations"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membership"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save Unmapped Publications"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telephone Number"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no concepts specified."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "group"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals in the <a href=\"{1}\">{0}</a> who have an interest in this research area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications in VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication date for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departments"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Web Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The information in the following tables is for all years."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to Profile Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing presentation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>You denied VIVO's request to read your ORCID record.</p> <p>Confirmation can't continue.</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select at least one term from the search search results."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading faculty . . ."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing person in this position"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This information is based solely on {0} which have been loaded into the VIVO system."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "has not been \"science-located.\""@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Get Flash"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You do not have permissions to claim for this user"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder web pages"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View full timeline and co-author network."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: editor not removed"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No matching science areas found"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "person name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing event"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: No file harvest job was specified, or an unknown job was specified."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Issue"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "were"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select an existing Organization or create a new one."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Build a &lsquo;first pass&rsquo; capability map by typing in a<!-- set of--> search term<!--s--> that could be said to represent a broad research capability."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Global Research"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications per year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: author not removed"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please check that these are the work(s) that you wish to claim, and indicate your relationship with them."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teaching activity type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Claim publications by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clear"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click an area to view others"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "this author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "leadership"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What's involved in the caching process?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redirects you to ORCID's web site</li> <li>You tell ORCID that VIVO may add an \"external ID\" to your ORCID record.</li> <li>VIVO adds the external ID.</li></ul>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all ..."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fax number for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Country"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapter"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with the same interest."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View your ORCID record."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 2"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local Namespace"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Research"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What do you want to compare?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing organization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reference Basemap"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add Editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Published in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subdisciplines"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capability"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have been \"science-located.\""@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Publisher"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all faculty with an interest in this area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a new local ontology"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "edit web page link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID record already includes a link to VIVO.</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this teaching role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Award or Honor Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research areas"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no active grants for this department."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "People"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The map can be explored at two levels-by 13 disciplines or 554 subdisciplines. Clicking on a node in the map brings up the number of fractionally associated journal publications and the percentage of publications mapped to this (sub)discipline. Hover over a discipline in the table on the left to see what circles it corresponds to on the map. Use slider below map, on the right to reduce number of subdisciplines shown to improve legibility."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Telephone Number field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you edited the work, please select \"Editor\"."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activities"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Event"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "An error has occurred and the file harvest cannot continue."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Level of Science Area"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teaching activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication will has been successfully excluded from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must enter a value in the First Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications with"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 4"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this reviewer role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Changing the cutoff value"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This panel displays information about individual search terms and groups. Click on a group to display its information."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "disciplines"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fill in data"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "File"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each (sub)discipline."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "position history entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add webpage for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presented At"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-principal investigator entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to enter additional details about your publications on your profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name Prefix"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clear all selected entities."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the publication cannot be excluded from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "End Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapter"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No search results were found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication coverage of this visualization can be improved by including more publication data in the VIVO system, and by ensuring that each publication in the VIVO system is associated with a journal that the Map of Science recognizes (based on the holdings of Clarivate Analytics' Web of Science database and Elsevier's Scopus database). Journal names containing typos or other idiosyncrasies may need to be cleaned up before they are recognized. You may contact a VIVO system administrator if publication coverage is a concern."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uploaded files"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Grants & Projects for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the unchecked labels could not be deleted."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Proceedings of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Only display"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisciplines"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Editors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click the button to harvest your file(s)."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advanced features"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this participation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administered by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This panel displays a list of the search terms currently on the graph. Search for something to begin."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualization Tools"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Map"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Advisee"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Journal"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you do not wish to claim a work, select \"This is not my work\"."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unknown Resource Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Department or School Name within the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "State/Province/Region"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-authorship"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the City/Locality field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "City/Locality"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to view the standard profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "webpage url"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name of Institution"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Journal Article"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigator name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preferred Title"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to your profile page to enter additional details about your publications."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigators"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is now being refreshed. The visualization will load as soon as we are done computing, or you can search or browse other data in VIVO and come back in a few minutes."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definition"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "file"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapped"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Harvest"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of pubs."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each subdiscipline."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enter {0}:"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Start Year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "by Publications"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "use capitals for the first letter of each word"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Description"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 5"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This information is based solely on"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisory label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in Presentation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Country field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visual cues"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The amount of researchers retrieved for each search term for is limited by the cutoff value in the search form (10 by default). Increasing this cutoff will increase the likelihood of an intersection between different search terms. This will also increase the complexity of the graph, however, and may make it difficult to identify patterns."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "which have been loaded into the VIVO system as of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select or create a VIVO-defined concept."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "clinical activity type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>You denied VIVO's request to add an External ID to your ORCID record.</p> <p>Linking can't continue.</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "preferred title for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing person in this role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Credential Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "parent entity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conference"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "error notification"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: This information is based solely on publications that have been loaded into the VIVO system. This may only be a small sample of the person's total work."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals with the research area in this organization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a Last name for this person."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently, DOIs issued by Crossref, DataCite and mEDRA are supported.<br />Each DOI should be separated by a comma or new line."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property in runtime.properties is undefined."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "presentation name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this service provider role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication attributed to this"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No matching entities found"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legend"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Grant Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Country-wide Research"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A Maximum of 10 entities can be compared."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Using information cached at"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of Publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Drag and drop to reorder editors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirm"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no url provided for link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the individuals with an interest in <a href=\"{1}\">{0}</a> who are in this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "author name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interacting with the visualisation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To make the visualisation easier to read, search terms and groups are scaled according to the number of results returned. Groups are also given different shades according to the number of connected search terms. The darker the shade, the more search terms a group is connected to."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Position Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferred by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research activity type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Label (Alternate Labels)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URI Independent Model"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Middle name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fill in the template with your data.  You may fill in multiple templates if you wish to harvest multiple files at once."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "department"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pause"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "middle organization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The End Year must be later than the Start Year."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The following cached models will be regenerated."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Best Match"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prev"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fax Number"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You have selected"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years Inclusive"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download template"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Musical Score"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membership in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The spark lines shown above reflect grants through the last complete calendar year. These tables, however, show the grant information for all years, based on the information loaded in the VIVO system."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Mailing Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email address for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1: Adding your ORCID iD"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Credential Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have an unknown"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speeches"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thank you"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this membership"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(e.g., Thesis title, Transfer info, etc.)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Person field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To enable this option, you must first select an"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Getting Started"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "By clicking on any node in the visualisation, additional information can be viewed in the 'Info' tab on the right-hand side. For groups of people, the participants in the group and their information can be viewed, and individual researchers can be removed from the graph. Selecting a search term will display all attached groups. Under each group full information for each person is retrieved, and the number of matching grants and publications for each researcher within the mapped capabilities is shown. Clicking on a researcher's name will lead to the original search results."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No publications in the system have been attributed to this"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advising relationship"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volume"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading data for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "year (not charted above)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note that metadata will be retrieved from Crossref, if the PubMed ID can be resolved to a DOI."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type of Credential"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new Organizer role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(e.g., for multi-year awards)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for your instance"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organization name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Delete selected"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant Count"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Records _START_ - _END_ of _TOTAL_ "@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Select an existing class from a local extension"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Report"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing degree"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this editor:"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local Research"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those people you want to <em>exclude</em> from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the last 10 full years"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Export QR codes"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Help"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Event"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "years"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-author icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Associated Departments"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an Author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close Date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resume"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a value in the Street Address field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this author:"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "within the last 10 years"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subject Area"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip: you can expand a broad search term into smaller concepts by clicking &lsquo;search and expand&rsquo;."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mailing address for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter or select a value in the Document Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View results"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an Advising Relationship Type."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "drill down"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "have no journal information."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property in runtime.properties is pointed to the Harvester installation directory."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "delete web page link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The Start Year must be earlier than the End Year."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Your Own Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Do you want to add an ORCID iD?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "temporal graph drill up"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all individuals with an interest in this area."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Scopus ID Link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advisor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Name Suffix"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 3"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "published"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Award or Honor Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Show discipline labels"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Person"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "missing information resource"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to your VIVO profile page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please specify a role for this activity."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profile page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "initial okay"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Item"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You must be an administrator to use this tool."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create year awarded"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enter a research area into the search field above and press 'Search'. The resulting diagram displays the search term, rendered in orange, connected to the blue group of researchers that are active in that area. Enter another search term to see how researchers from both searches relate. Keep adding search terms to build a capability map."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "at"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legal Case"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "award receipt name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty of 1000 Link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "presentation entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all individuals in this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the current incomplete year (not charted above)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capability Map"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only (sub)disciplines whose names contain this text."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirm your work(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "required with new Last name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-author(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Websites"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this organizer role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no view link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Parent organization of"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "incomplete date/time interval"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for a complete overview."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Your ORCID record is linked to VIVO</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add an Editor"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new participation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with known year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search Service"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publisher"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue Step 2"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisee label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no papers for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigator(s)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "awarded by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primary Email"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to the Capability Mapping tool. This tool visualises how researchers relate to other researchers via search terms."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Refresh Cached Models for Visualization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conferred by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Quick profile view"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No research content found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "from current incomplete year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add New Web Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "with unknown year"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unable to retrieve citation details"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Letter"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Disciplines"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for a more complete overview."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizations"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download data as"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expertise Profile Comparison Map"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO failed to read your ORCID record.</p> <p>Confirmation can't continue.</p>"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editors"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Check those publications you want to <em>exclude</em> from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The maximum number of items for comparison is 3."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit year awarded"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new researcher role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue Step 1"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Title of Presentation"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select an existing value or enter a new value in the Name field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Standard profile view"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator network"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "research activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidate"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "outreach & community service"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Affiliated Research Areas"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "You may enter one or more PubMed IDs to match. Each ID should be separated by a comma or new line."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisor relationship entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Researcher Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage People Affiliated with"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edit this researcher role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept (Type)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Close Me"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manage Concepts"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of a university, organization, or person can be overlaid on the map to generate expertise profiles. The process is as follows: (1) The set of unique journals is identified, (2) the number of times each journal served as a publication venue is calculated, and (3) the area size of the 13 disciplines and 554 subdisciplines is calculated based on these journal publication venue counts. Note that some journals are associated with exactly one (sub)discipline while others, e.g., interdisciplinary ones like <em>Science</em> or <em>Nature</em>, are fractionally associated with multiple (sub)disciplines. Subdisciplines inherit the colors of their parent disciplines. (Sub)disciplines without any associated publications are given in gray."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Role in Institution"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "of a maximum"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new membership"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please visit the full"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This is not my work"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "year awarded for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "advisee relationship entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigator Network"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each (sub)discipline. This count can be fractional because some publication venues are associated with more than one (sub)discipline. Each publication in such a venue contributes fractionally to all associated (sub)disciplines according to a weighting scheme."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "share the uri"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "map of science icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove editor link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigator icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "this investigator"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to Manage Concepts"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "credentials"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferred on"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Save"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "is properly configured with your database information and namespace."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upload"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are no more works left to claim.<br />You may enter more IDs below, or view your profile."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Active Grants for the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Degree"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "These numbers are based solely on publications that have been loaded into this VIVO application. If this is your profile, you can enter additional publications below."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for one or more organizations. Color coding by organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the \"refresh cache\" link above to do this without a restart."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please select a type from the drop-down list."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-author Network"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "quick view icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to the Data Ingest Tools menu"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This individual currently has no web pages specified. Add a new web page by clicking on the button below."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications through today's date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Add a new clinical activity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "download link"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A Maximum 10 entities can be compared. Please remove some & try again."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Large-scale visualizations like the Temporal Graph or the Map of Science involve calculating total counts of publications or of grants for some entity. Since this also means checking through all of its sub-entities, the underlying queries can be both memory-intensive and time-consuming. For a faster user experience, we wish to save the results of these queries for later re-use."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Step 1: Adding your ORCID iD"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in the system."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data Overlay"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Go to profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tables"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading map information . . ."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all research"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interactivity"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Submit IDs"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigators"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "institutional internal class"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Research Areas"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "To this end we have devised a caching solution which will retain information about the hierarchy of organizations -- namely, which publications are attributed to which organizations -- by storing the RDF model."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "full view icon"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "If you are an author of a work, please select your name in the author list.<br />Retrieved metadata may be incomplete. If you can not see your name listed, select \"Unlisted Author\"."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no linked author"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please wait while your data is harvested."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error processing request: the item cannot be excluded from the profile page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "What is this?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(step completed)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "In VIVO Harvester, the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Click to display the"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Credential"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "telephone number for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Persistent link to current visualization"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digital Object Identifier (DOI)"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication Count"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Are you sure you want to remove this web page?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Do you want to add an ORCID iD?"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vocabulary Source"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscript"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profile quick view."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "granted"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Person"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Degree Candidacy"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Terms of Use"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this position because it is associated with multiple Position individuals."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all the members of this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "more"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Mailing Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No faculty members found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | connect share discover"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log out"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Entry"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "placeholder image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attendee"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Service Provider Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state-wide locations."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limit search"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province or Region"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "to"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a new value in the Role field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no grants for "@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street one"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "states."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading website image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filter search"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "user"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this grant because it is associated with multiple grant individuals."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no researchers with a defined geographic focus."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all academic departments"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regions"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizer Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Support"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Memberships"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "menu item"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to manage this site"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries and regions."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reviewer Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No academic departments found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street three"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "change selection"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty in the {0} department who are members of this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants in VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Leadership Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} papers for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals in the department with this research area"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Us"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "password"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO is a research-focused discovery tool that enables collaboration among scientists across all disciplines."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street two"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "loading data"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "return to"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Browse or search information on people, departments, courses, grants, and publications."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My account"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Full name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all faculty"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filter search"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Leadership Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Place of grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selected Award"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Service Provider Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contact Us"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street three"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reviewer Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Terms of Use"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this position because it is associated with multiple Position individuals."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attendee"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "placeholder image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "user"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "password"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this grant because it is associated with multiple grant individuals."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries and regions."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log out"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Page"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "to"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Type"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My account"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No faculty members found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state-wide locations."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province or Region"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Support"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Add"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Browse or search information on people, departments, courses, grants, and publications."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant entry for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | connect share discover"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "change selection"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculty Memberships"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "countries"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in to manage this site"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all academic departments"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "My profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "state."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Powered by"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "View all the members of this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "view all faculty"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Please enter a new value in the Role field."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "return to"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit Mailing Address"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Years of Participation in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant Date"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address label"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First publication"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty in the {0} department who are members of this organization."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limit search"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Full name"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "There are currently no researchers with a defined geographic focus."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Search VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No academic departments found."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Loading website image"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Last Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no grants for "@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "states."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "First Grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grants in VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regions"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "more"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "loading data"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Create Entry"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizer Role"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street one"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO is a research-focused discovery tool that enables collaboration among scientists across all disciplines."@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "address street two"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profile"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "individuals in the department with this research area"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Currently there are no {0} papers for"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "researchers"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Log in"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Welcome to VIVO"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Return to grant"@en-US ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: la persona no puede ser excluida de la página de la organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conferencia seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta organización no tiene suborganizaciones ni personas con"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Listar sólo las organizaciones cuyo nombre contenga el texto."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Formación Educativa"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en los últimos 10"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resetear"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Donaciones por año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "directorio y todos sus hijos."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "servicio a la profesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay modelos construidos para el uso de la visualización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en un año completo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor en el campo Tipo de Posición."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparar organizaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nombre completo para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Correos electrónicos adicionales"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A fin de que una ontología local pueda ser reconocida aquí, su URI de espacio de nombres debe seguir este patrón"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reclamando obras para<br />{0}"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fecha incompleta / valor de tiempo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "servicio a la profesión en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Siguiente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del recurso"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compruebe las subvenciones y proyectos que desea excluir de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo Código Postal."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "En el cosechador de VIVO, el archivo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Cómo le gustaría comparar?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Campo principal de grado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión para entrar en detalles acerca de sus donaciones en la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Instituciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todas las subvenciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Más información sobre los códigos QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título del Puesto:"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "haga clic en el icono de la página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor en el campo Tipo de Formación Educativa."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por ejemplo, instructor, facilitador, Asistente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del concepto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asesorado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coautor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del premio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Código vCard QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para obtener más información sobre el mapa UCSD de la ciencia y el sistema de clasificación, véase"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cosecha completa. Para realizar otra, por favor, actualice la página."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de evento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Puede agregar uno o más DOIs para que coincidan, y pueden agregarse como ID o como URL<br /><br />p.ej."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo dirección de correo electrónico."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esto es debido a una configuración incorrecta del Cosechador. Por favor, asegúrese de lo siguiente:"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ningún editor vinculado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ERROR INDEFINIDO EN EL NIVEL DE ENTIDAD"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no puede encontrar una clase apropiada?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coinvestigadores únicos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: las organizaciones o personas que se indican a continuación son las que están directamente debajo de {0} en la jerarquía de la organización. Es posible 'profundizar' para ver las organizaciones o personas por debajo de una determinada suborganización, seleccione el icono de gráfica junto al nombre de suborganización seleccionada por debajo de la gráfica de la derecha."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Quitar el grupo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar páginas Web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Descargar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil desconocido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El usuario final no debería ver este error en circunstancias normales, por lo que este es probablemente un error y se debe informar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Su ORCID iD se confirmó como {0}</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se ha instalado el cosechador de VIVO."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eliminar capacidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tras 554 subdisciplinas científicas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver línea de tiempo completa y la red coinvestigador."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ir a la página de su perfil para entrar en detalles acerca de sus donaciones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "actividad clínica"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Acerca del Mapa de Visualización de la Ciencia VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coautores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de presentación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Servicios de vocabulario externos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO no pudo añadir un ID externo a su registro ORCID.</p> <p>La vinculación no puede continuar.</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: El término no se ha eliminado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para otros mapas de la ciencia, ver"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol \"jefe de\""@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gráfico temporal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número total de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El artículo ha sido excluido correctamente de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coautores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ocultar las etiquetas de los grupos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La columna número de publicaciones  muestra la cantidad de publicaciones que fueron asignadas a cada especialidad. Esta cuenta puede ser fraccionaria ya que algunos lugares de publicación están asociados con más de una especialidad. Cada publicación de tal lugar contribuye fraccionadamente a todas las subdisciplinas asociadas de acuerdo con un esquema de ponderación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conjunto de datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "teléfono"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de proveedor de servicios"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "En el cosechador de VIVO, el usuario del servidor web (por lo general tomcat6) ha leido y escrito el acceso a el"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta asesor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Libro"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Código QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título no encontrado."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Información Complementaria"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "correos electrónicos adicionales"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enfoque Geográfico"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: Esta información está basada únicamente en las subvenciones que se han cargado en el sistema VIVO. Esto sólo puede ser una pequeña muestra del trabajo total de la persona."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca o seleccione un valor en el campo Nombre."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta visualización se basa en las publicaciones que pudimos 'localizar a ciencia' para {0}, y por lo tanto, puede que no sea plenamente representativo de la actividad general de publicaciones de {0}."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ya ha reclamado esta obra."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otorgador seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revisor de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otorgar Nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sube tu plantilla completa(s)."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: la sección problemática que se ha indicado anteriormente han sido tratada."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revisión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todas las subvenciones activas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "captura de pantalla de la página web {0}"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Script ejecutado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor no enlistado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "asistido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Debe ingresar un valor en el campo Apellido."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icono qr"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Etiqueta (Tipo)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "y luego regrese aquí para definir la clase interna institucional."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coinvestigadores únicos por año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crea uno nuevo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor en el campo Tipo de Organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu procesamiento de datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Progreso"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La actividad de publicación de hasta tres personas u organizaciones pueden compararse a través de \"Comparar organizaciones. \"en la tabla de la izquierda, seleccione hasta tres organizaciones. El perfil de conocimientos de cada organizaciones se representará como superposición de datos. Cada organización es representada en un color distinto y una lista de 10 subdisciplinas con el mayor número de las publicaciones se expone a continuación en el mapa de comparación. Los datos pueden ser guardados como archivos CSV."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fecha de publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de relación de asesoramiento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pagina web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Información de Contacto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Imagen"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concesión administrado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol de editor en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presentación seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta clase se utilizará para designar a las personas \"internas\" de su institución."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "escuelas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primero"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ha fallado el reordenamiento de las páginas web."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El campo de apellido no puede contener una coma. Ingrese el nombre en el campo Nombre."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO le redirigirá a la pagina web de ORCID.</li> <li>Inicie sesión con su cuenta ORCID. <ul class=\"inner\"><li>Si no tiene una cuenta de ORCID, puede crearla.</li></ul></li> <li>Autorizar a ORCID que VIVO puede leer su registro ORCID.</li> <li>VIVO lee su registro ORCID.</li> <li>VIVO nota que su ORCID iD está confirmado.</li></ul>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esto le permitirá limitar las personas que aparecen en las páginas del menú  principal (Personas, Investigación, etc.) a sólo aquellos dentro de su institución."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rol de editor de colección o serie"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tesis"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de formación educativa para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vea todas las subvenciones de VIVO y la red de coinvestigador correspondiente."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coautores únicos por año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ahora está siendo actualizado. La visualización se cargará tan pronto como hayamos terminado de calcular, o puede buscar o navegar por otros datos en VIVO y regresar en unos minutos."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicación (es)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del evento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de revisor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "texto del enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asesor seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en la base de datos vivo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Término"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de evento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Redes"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cerrar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por subvenciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: la página web no se puede eliminar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de entidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legislación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conceder"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Documento de conferencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gráfico temporal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de entidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar un ID"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El mapa VIVO de la visualización de la ciencia utiliza el mapa UCSD de la ciencia y clasificación, sistema que se calcula a partir de datos de papel a nivel de alrededor de 25 000 revistas de Elsevier Scopus y Clarivate Analytics Web of Science (WoS) para los años 2001-2010. El mapa UCSD de la ciencia se encarga de los 25.000 diarios a 554 subdisciplinas que se agregan más en 13 disciplinas principales de la ciencia. En el mapa, cada disciplina tiene un color distinto (verde para 'Biología', marrón de 'Ciencias de la Tierra', etc) y una etiqueta. (Sub) disciplinas que son similares más cerca el uno al otro en el mapa. (Sub) disciplinas que son especialmente similares están conectados por líneas grises."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Superponer y examinar los perfiles de competencias para una o más organizaciones. El código de colores es por disciplina."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizador de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar fecha de publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este contenido requiere Adobe Flash Player."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La persona se ha excluido con éxito desde la página de la organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ha pasado un valor no válido para el parámetro de visualización qrCode."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente el cache de estos modelos estan en la memoria. La caché se construye (sólo una vez) en la primera solicitud de un usuario después de un reinicio del servidor. Debido a esto, el mismo modelo sirve hasta el siguiente reinicio. Esto significa que los datos de estos modelos pueden convertirse en obsoletos dependiendo de cuando fueron creados. Esto funciona bastante bien por ahora. En futuras versiones, mejoraremos esta solución para que los modelos se almacenan en el disco y se actualizan periódicamente."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Año otorgado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear fecha de publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "total"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discurso"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Página inicial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organización seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapa de la ciencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PubMed ID"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor de entrada para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de investigador principal para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "servicio de extensión a la comunidad en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar Publicaciones para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvenciones con"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">= 4 enlaces"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No hay publicaciones en el sistema atribuídas a esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparando"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Libro seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "YYYY"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un Nombre para esta persona."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizaciones y Personas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dentro de mi institución"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione al menos una fuente del vocabulario externo para buscar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta el autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 2 (recomendado): Conecte su registro ORCID a VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "premio u honor para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Obtenga más información sobre mapas de visualización Ciencias de VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al reordenar los editores."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ninguno de los"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "asesoramiento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Por qué es necesario?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de proveedor de difusión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, visite el"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta actividad clínica"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "correo electrónico principal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Está seguro que desea eliminar este término?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de URL"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri del icono"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear una nueva clase"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor en el campo tipo de documento."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Falló el reordenamiento de los autores."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "quitar enlace de autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidatura"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tesis"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagen superior de fondo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar autores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "serie"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administración de la organización para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se ha encontrado un error en la ejecución de esta búsqueda."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar concepto seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Términos de búsqueda actuales"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Posición de entrada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 enlaces"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clase interna institucional"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estos son los miembros de la facultad en el departamento de {0} que tienen un interés en el área de investigación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dirección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Las organizaciones mencionadas son hijos del nodo de {0} en la jerarquía organizacional. Es posible 'desglozar' para ver las organizaciones por debajo de una determinada suborganización, seleccione el icono de gráfica junto al nombre de una suborganización seleccionada por debajo de la gráfica de la derecha."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para utilizar esta función, defina un valor para esta propiedad que apunta al directorio de instalación del cosechador antes de volver a redistribuir y reiniciar la aplicación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limpiar los resultados de consulta"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hipervínculo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa de la ciencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El directorio existe y el usuario del servidor web ha leido y escrito el acceso a esto."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "o añadir uno nuevo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El Mapa la visualización de la Ciencia en VIVO representa la experiencia actual que una universidad, organización o persona tiene sobre la base de las publicaciones anteriores cargadas en VIVO. Aquí se muestra el perfil de especialización de la {0} -- los círculos más grandes denotan más publicaciones por área temática."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Haga clic para ver la {0} página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Código postal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de \"jefe de\""@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "busca"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por ejemplo, Asesor, orador, participante"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verifique esta equivalencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artículo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expande"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo número de fax."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Documento seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay {0} subvenciones para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar página de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aún hay {0} pendientes"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no se podría combinar con una posición del mapa usando su información de revista."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicaciones (pubs.)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Información"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver perfil de esta persona"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo título preferido."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hay actualmente ontologías locales no reconocidas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Año final"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Falta editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Guardar todo como CSV"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Donaciones por año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 enlaces"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicaciones atribuidas a esta"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de proveedor de difusión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asignatura seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Términos de búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "una entrada de investigador para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargar archivo(s)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Busca y expande"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "registro/"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione una publicación existente en el campo Título o introduzca uno nuevo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualización del Mapa de la Ciencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar concepto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mostrar las etiquetas de los grupos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Exportar código QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enlaces"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se puede encontrar el concepto que desea? Cree uno propio."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nueva ontología local"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Año de emisión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de enseñanza"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Colección o serie"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta la actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La siguiente tabla resume las publicaciones que se representan en el mapa de la Ciencia. Cada fila corresponde a una (sub) disciplina en el mapa."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo Título de Posición."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta credencial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aquí están las personas en <a href=\"{1}\"> {0} </a> que tienen un interés en esta área de investigación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastrar y soltar para cambiar el orden de los autores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "afiliación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Guardar publicaciones no mapeadas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número de teléfono"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente no hay conceptos especificados."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Años de participación en la subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grupo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aquí están las personas en el <a href=\"{1}\"> {0} </a> que tienen un interés en esta área de investigación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicaciones en VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del documento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar Autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fecha de publicación de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departamentos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar página Web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La información de las siguientes tablas es para todos los años."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volver a la página de perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta la presentación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ha denegado la solicitud de VIVO de leer su registro ORCID.</p> <p>La confirmación no puede continuar.</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, seleccione al menos un término de los resultados de búsqueda."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargando profesorado..."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta la persona en esta posición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta información se basa únicamente en {0} lo que se han cargado en el sistema VIVO."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no se han 'localizado por la ciencia.'"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Obtener Flash"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No tiene permiso para reclamar para este usuario"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastrar y soltar para cambiar el orden de las páginas web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver la línea de tiempo completa y la red de coautor."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la solicitud: el editor no se puede eliminar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado áreas de la ciencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la persona"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta de eventos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: No se especificó ningún archivo de trabajo de cosecha, o se ha especificado un trabajo desconocido."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eran"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol en la"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seleccione una organización existente o cree una nueva."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cree un 'primer pase' mapa de capacidades escribiendo un término de búsqueda que podría decirse que representa una amplia capacidad de investigación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigación global"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicaciones por año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: el autor no se ha eliminado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor compruebe las obras que desea reclamar e indique su relación con ellas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de actividad docente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reclame publicaciones de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Borrar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 1"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Haga clic en el area para ver otros"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "este autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "liderazgo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Qué implica el proceso de almacenamiento en caché?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO le redirigirá a la pagina web de ORCID</li> <li>Autorice a ORCID que VIVO permita añadir su ID externo a su registro ORCID.</li> <li>VIVO añade el ID externo.</li></ul>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todo ..."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "número de fax para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "País"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capítulo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "con el mismo interés."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vea su registro ORCID."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 2"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Espacio de nombres local"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Qué es lo que quiere comparar?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta la organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa base de referencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% de actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicado en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subdisciplinas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capacidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "se han 'localizado por la ciencia.'"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editorial seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos los profesores interesados ​​en esta área."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "una nueva ontología local"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editar el enlace de la página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Su registro ORCID ya incluye un vínculo a VIVO.</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de enseñanza"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del Premio u Honor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "áreas de investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente no hay concesiones activas para este departamento."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El mapa puede ser explorado en dos niveles por 13 disciplinas o 554 subdisciplinas. Al hacer clic en en un nodo en el mapa aparece el número de publicaciones en revistas asociada y el porcentaje de publicaciones asignadas a esta (sub)disciplina. Pase el ratón sobre una disciplina en la tabla de la izquierda para ver que círculos corresponde en el mapa. Usar control deslizante situado debajo del mapa, sobre la derecha a reducir el número de subdisciplinas mostrando mejorar la legibilidad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo número de teléfono."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fin"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si ha editado la obra, seleccione \"Editor\"."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "actividades"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Evento seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se ha producido un error y el archivo de la cosecha no puede continuar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nivel del área de ciencias"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actividad docente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La publicación se ha excluido con éxito de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nombre del enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Debe ingresar un valor en el campo Nombre."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicaciones con"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 4"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de rol"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de revisor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cambiar el valor de corte"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este panel muestra información sobre el individuo términos y grupos de búsqueda. Haga clic en un grupo para mostrar su información."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "disciplinas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rellene los datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Archivo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El porcentaje de la columna actividad muestra qué proporción de las publicaciones se asigna a cada (sub)disciplina."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada historial de posición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar página web para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Presentado en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coinvestigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de co-investigador principal para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión para entrar en detalles acerca de sus publicaciones en la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prefijo de nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Borrar todas las entidades seleccionadas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: la publicación no puede ser excluida de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Página final"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capitulo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado resultados de búsqueda."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvención Seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La cobertura de publicación de esta visualización se puede mejorar mediante la inclusión de más datos de publicación en el sistema VIVO, y garantizando que cada publicación en el sistema VIVO se asocia a una revista que el Mapa de La ciencia reconoce (basado en la participación de la base de datos Web of Science de Clarivate Analytics y de la base de datos Scopus de Elsevier). Los nombres de revistas que contengan errores tipográficos u otras idiosincrasias pueden necesitar ser limpiado antes de ser reconocidos. Usted puede ponerse en contacto con un administrador de sistema VIVO si la cobertura publicación es una preocupación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Archivos cargados"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar Becas y Proyectos para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la solicitud: las etiquetas sin control no pueden ser eliminadas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concepto seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actas de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sólo mostrar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisciplinas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar editores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Haga clic en el botón para cosechar su archivo(s)."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Características avanzadas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta participación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administrado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este panel muestra una lista de los términos de búsqueda actualmente en el gráfico. Busque algo para comenzar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Herramientas de visualización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asesorado seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revista seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si no desea reclamar una obra, seleccione “Esta no es mi obra\""@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Inicio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de recurso desconocido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departamento o nombre de la escuela dentro del"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estado/provincia/Región"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coautoría"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo ciudad/localidad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ciudad/localidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Haga clic aquí para ver la página de perfil estándar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Url de la página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la institución"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artículo de revista"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título preferido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ir a la página de su perfil para entrar en detalles acerca de sus publicaciones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coinvestigadores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ahora está siendo actualizada. La visualización se cargará tan pronto como hayamos terminado de calcular, o puede buscar o navegar por otros datos en VIVO y regresar en unos minutos."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Años de participación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "archivo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapeado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cosecha"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de pubs."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El porcentaje de la columna actividad muestra qué proporción de las publicaciones se han asignado a cada especialidad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entre {0}:"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Año inicial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por publicaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "utilice mayúsculas para la primera letra de cada palabra"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Descripción"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 5"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta información se basa únicamente en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Etiqueta de advertencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol en la presentación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvenciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo País."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Señales visuales"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La cantidad de investigadores recuperados para cada término de búsqueda para está limitado por el valor de corte en el formulario de búsqueda (10 por defecto). Aumentar este límite aumentará la probabilidad de una intersección entre diferentes términos de búsqueda. Esto también aumentará la complejidad del gráfico, sin embargo, y puede dificultar la identificación de patrones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicación seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "que hayan sido cargados en el sistema VIVO como"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear su propio concepto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de actividad clínica"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ha denegado la solicitud de VIVO de añadir un ID externo a su registro ORCID.</p> <p>La vinculación no puede continuar.</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título preferido para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta la persona en este rol"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca o seleccione un valor en el campo Nombre de Credencial."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entidad principal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "notificación de error"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: Esta información está basada únicamente en las publicaciones que se han cargado en el sistema VIVO. Esto sólo puede ser una pequeña muestra del trabajo total de la persona."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "personas con el área de investigación en esta organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un apellido para esta persona."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente, se soportan los DOIs emitidos por Crossref, DataCite y mEDRA.<br />Los DOIs deben separarse mediante coma o linea nueva."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "propiedad en tiempo de ejecución. Las propiedades no están definida."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la presentación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de proveedor de servicios"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La publicación atribuye a este"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado entidades similares"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Leyenda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca o seleccione un valor en el campo nombre de subvención."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigación por pais"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Un máximo de 10 entidades pueden ser comparadas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Usando información almacenada en caché"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lugar de publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastrar y soltar para cambiar el orden de los editores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirme"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no hay url proporcionada para este enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aquí están las personas que tengan interés en <a href=\"{1}\"> {0} </a> que están en esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interactuando con la visualización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para facilitar la lectura de la visualización, los términos y grupos de búsqueda se escalan de acuerdo a la cantidad de resultados devueltos. Los grupos también reciben diferentes tonos de acuerdo con la cantidad de términos de búsqueda conectados. Cuanto más oscura es la sombra, más términos de búsqueda se conectan a un grupo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de puesto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferida por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de actividad de investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Label (Etiquetas alternas)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Modelo independiente de URI"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Segundo nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Complete la plantilla con sus datos. Puede completar varias plantillas si desea cosechar varios archivos a la vez."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "departamento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pausa"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organización central"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El fin de año debe ser posterior al inicio de año."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se regenerarán los siguientes modelos de caché."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mejor resultado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anterior"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fax"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Año"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ha seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Años incluidos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Descargar plantilla"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Partitura musical"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Miembro de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Las líneas de inicio que se muestran arriba reflejan las becas del último año completo. Sin embargo, estas tablas muestran la información de subvención para todos los años, basados en la información cargada en el sistema VIVO."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear dirección postal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección de correo electrónico para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 1: Agregar su ORCID iD"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la credencial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tiene un desconocido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discursos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gracias"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta membresía"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de publicación de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(Por ejemplo, título de la tesis, información de transferencia, etc)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contacto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor existente o introduzca un nuevo valor en el campo Persona."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para activar esta opción, primero debe seleccionar una"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorar actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Empezando"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Al hacer clic en cualquier nodo en la visualización, información adicional se puede ver en el Pestaña 'Información' en el lado derecho. Para grupos de personas, los participantes en el grupo y su información puede ser vista, y los investigadores individuales pueden eliminarse del gráfico. Al seleccionar un término de búsqueda, se mostrarán todos los grupos adjuntos. Debajo de cada grupo se recupera la información completa de cada persona, y el número de subvenciones y publicaciones correspondientes para cada investigador dentro de las capacidades mapeadas se muestra. Al hacer clic en el nombre de un investigador se llevará a la búsqueda original resultados."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ningunas publicaciones en el sistema se han atribuido a esto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "relación de asesoramiento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volumen"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargando datos para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "años (no trazada anteriormente)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note que se recuperarán metadatos de Crossref, si el ID de PubMed permite la asignación a un DOI."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de credencial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de organizador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(Por ejemplo, para premios de muchos años)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para la instancia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de la organización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo Nombre."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Borrar seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conteo de subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Registros _START_ - _END_ de _TOTAL_ "@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Seleccione una clase existente desde una extensión local"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informe"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grado faltante"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Está seguro que desea eliminar este editor?:"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigación local"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compruebe las personas que desea excluir de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en los últimos 10 años"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvención (es)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Exportar los códigos QR"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ayuda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Evento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "años"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icono de coautor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departamentos asociados"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar un autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fecha de Cierre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "continuar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un valor en el campo dirección."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Está seguro que desea eliminar este autor:"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dentro de los últimos 10 años"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asignatura"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sugerencia: puede expandir un término de búsqueda amplio en conceptos más pequeños haciendo clic en & lsquo; buscar y expandir & rsquo ;."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Información"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección postal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvenciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca o seleccione un valor en el campo Nombre de Documento."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver los resultados"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un Tipo de relación de Asesoría."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "desglosar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no tienen información de la revista."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "propiedad en tiempo de ejecución. Las propiedades se apuntaron al directorio de instalación del Cosechador."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eliminar el enlace de la página web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El Inicio de Año debe ser anterior al Fin de Año."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crea un concepto propio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Desea añadir su ORCID iD?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gráfico temporal sintetizado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos los individuos con un interés en esta área."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enlace Scopus ID"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asesor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sufijo de nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear concepto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 3"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volver a la publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor existente o introduzca un nuevo valor en el campo nomnbre del Premio u Honor."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mostrar etiquetas de disciplina"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Persona"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta información de recursos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vuelva a la página de su perfil VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concepto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, especifique un rol para esta actividad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "página de perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "acuerdo inicial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artículo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Usted debe ser un administrador para usar esta herramienta."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear año otorgado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ingrese un área de investigación en el campo de búsqueda de arriba y presione 'Buscar'. El diagrama resultante muestra el término de búsqueda, renderizado en naranja, conectado al grupo azul de investigadores que están activos en esa área. Ingrese otro término de búsqueda para ver cómo se relacionan los investigadores de ambas búsquedas. Siga añadiendo términos de búsqueda para crear un mapa de capacidades."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Caso legal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre del premio recibido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de documento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Facultad de 1000 enlaces"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entrada de presentación para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos los individuos de esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en el año en curso incompleto (no trazada anteriormente)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa de capacidades"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enumere sólo (sub)disciplinas cuyos nombres contengan el texto."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirme su(s) obra(s)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gráfico"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "requerido con nuevos Apellidos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coautor (es)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sitios web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de organizador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Apellido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no ver enlace"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organización principal de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fecha incompleta / intervalo de tiempo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para obtener una descripción completa."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Su registro ORCID está conectado a VIVO</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Agregar un editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue una participación nueva"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "con años conocido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Servicio de búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editorial"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continúe con el paso 2"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta asesorado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no hay papeles para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coinvestigador (es)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "otorgado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Correo electrónico principal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenido a la herramienta de Mapeo de capacidades. Esta herramienta visualiza cómo los investigadores se relacionan con otros investigadores a través de términos de búsqueda."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualizar Modelos en caché para visualización"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otorgado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vista rápida del perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se ha encontrado contenido de investigación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "del año en curso incompleto"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Añadir una nueva página Web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "con año desconocido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Incapaz de recuperar datos de la citación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carta"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Disciplinas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para obtener una visión más completa."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Descargar datos como"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa comparativo perfiles de conocimiento"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Falla para leer su registro ORCID.</p> <p>La confirmación no puede continuar.</p>"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compruebe las subvenciones que desea excluir de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El número máximo de elementos para la comparación es 3."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar año otorgado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue un rol nuevo de investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continúe con el paso 1"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título de la presentación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un valor existente o introduzca un nuevo valor en el campo Nombre."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vista estándar del perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "red de coinvestigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "actividad de investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidatura"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "servicio de extensión a la comunidad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Áreas de investigación afiliadas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Puede agregar uno o varios IDs de PubMed para que coincidan. Cada ID debe separarse mediante coma o linea nueva."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada tipo de relación de Asesor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel del investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar personas afiliadas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este rol de investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concepto (tipo)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ciérrame"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrar conceptos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La actividad de publicación de una universidad, organización o persona puede ser asignado al mapa para generar perfiles de conocimientos. El proceso es el siguiente: (1) El conjunto único de revistas es identificado, (2) el número de veces que cada revista sirvió como una publicación local se calcula, y (3) el tamaño del área de las 13 disciplinas y 554 subdisciplinas es calculado en base a estos recuentos en el lugar de publicación de las revistas. Tenga en cuenta que algunas revistas están asociado con exactamente una disciplina (sub), mientras que otros, por ejemplo, los interdisciplinares como <em>Ciencia</em> o <em>Naturaleza</em>, son fraccionalmente asociados con múltiples (sub) disciplinas. Las subdisciplinas heredan los colores de sus disciplinas principales. (Sub) disciplinas sin ningún tipo de publicaciones asociadas se muestran en gris. "@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol en la institución"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de la actividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de un máximo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue una membresía nueva"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, visite íntegro"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta no es mi obra"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datos para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "año otorgado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada para la relación de Asesoría"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Red de Coinvestigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "El número de la columna publicaciones muestra cómo muchas de las publicaciones se asigna a cada (sub)disciplina. Esta cuenta puede ser fraccionada debido a que algunos lugares de publicación están asociados con más de una (sub)disciplina. Cada publicación en ese lugar contribuye fraccionadamente a todas las (sub)disciplinas asociadas de acuerdo con un esquema de ponderación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "compartir el URI"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icono del mapa de la ciencia"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Quitar la conexión del editor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Correo electrónico"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profesorado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icono de coinvestigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "este investigador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regresar a Administrar Conceptos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "credenciales"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferida a"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Guardar"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "está configurado correctamente con su información de bases de datos y espacio de nombres."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subir"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No hay mas obras pendientes para reclamar.<br />Puede agregar más IDs abajo o vaya a ver el perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvenciones activos para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estas cifras se basan únicamente en las publicaciones que se han cargado en la aplicación VIVO. Si este es tu perfil, puedes entrar en las publicaciones adicionales a continuación."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Superponer y examinar los perfiles de competencias de una o más organizaciones. El código de colores según la organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Los modelos se actualizan cada vez que se reinicia el servidor. Dado que esto no es generalmente práctico sobre instancias de producción, los administradores pueden usar el enlace \"actualización de caché\" para hacer esto sin reiniciar."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor seleccione un tipo en la lista desplegable."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "red de Coautor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Icono de vista rápida"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volver al menu Herramienta de Procesamiento de Datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta persona no tiene actualmente páginas web. Agregue una nueva página web haciendo clic en el botón de abajo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicaciones hasta la fecha de hoy"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Agregue una actividad clínica nueva"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enlace de descarga"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Un máximo de 10 entidades se pueden comparar. Elimine algunas y vuelve a intentarlo."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualización a gran escala, como el Gráfico temporal o el Mapa de Ciencia implican calcular el recuento total de publicaciones en forma de subvenciones para alguna entidad. Dado que esto también significa la comprobación a través de todos sus subentidades, las consultas subyacentes pueden hacer uso intensivo de la memoria y consumir mucho tiempo. Para una experiencia de usuario más rápida, queremos guardar los resultados de estas consultas para su posterior reutilización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Paso 1: Agregar su ORCID iD"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "en el sistema."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobre los datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ir al perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tablas"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargando información del mapa. . ."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todas las investigaciones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interactividad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Envíe los ID"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigadores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clase interna institucional"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Áreas de investigación de la facultad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para ello hemos diseñado una solución de almacenamiento en caché que mantendrá información sobre la jerarquía de las organizaciones - a saber,que publicaciones están asociadas a que organizaciones - almacenando el modelo RDF."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Icono vista completa"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si es el autor de una obra, por favor seleccione su nombre de la lista de autores.<br />Los metadatos extraídos podrían estar incompletos. Si no ve su nombre en la lista, seleccione \"Autor no enlistado”"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Último"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ningún autor vinculados"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, espere mientras se recolectan sus datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error al procesar la petición: el artículo no puede ser excluido de la página de perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Qué es esto?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(paso completado)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "En el cosechador de VIVO, el"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Haga clic para mostrar el"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Credencial seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "número de teléfono para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enlace permanente a la visualización actual"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Identificador de Objeto Digital (DOI)"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conteo de publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Está seguro de que desea eliminar esta página web?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "¿Desea añadir su ORCID iD?"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fuente de vocabulario"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscrito"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vista rápida del perfil."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concedido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Persona seleccionada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grado de candidatura"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menú"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Términos de uso"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta forma no es capaz de manejar la edición de esta posición, debido a que está asociada con múltiples posiciones particulares."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Apellido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primer nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos los miembros de esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "más"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar dirección postal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primera publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado miembros en la facultad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mi perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Desarrollado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este cuerpo es de la plantilla en el archivo vivo/productMods/templates/freemarker/body/menupage/grants.ftl. En el modelo de presentación, la página de becas muestra: la propiedad requiresBodyTemplate que define que la página de becas anula la plantilla predeterminada. La plantilla predeterminada de estas páginas está en /vitro/webapp/web/templates/freemarker/cuerpo/menupage/menupage.ftl"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | conectar compartir descubrir"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigadores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Inicio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil de VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Finalizar sesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear entrada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagen de marcador de posición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primera beca"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asistente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estado."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Acerca de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta técnica podría usarse para definir las páginas sin elementos de menú, que obtienen su contenido a partir de una plantilla FreeMarker. Un ejemplo sería la página acerca de."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol proveedor de servicios"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dirección de correo clectrónico"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lugares en todo el estado."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limitar la búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provincia o región"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "derechos de autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lugar de subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar página"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un nuevo valor en el campo Rol."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Versión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última beca"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay subvenciones para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle uno"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estados."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargando imagen del sitio web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrar búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "usuario"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta forma no es capaz de manejar la edición de esta subvención, debido a que se encuentra asociada con múltiples subvenciones individuales."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente no hay investigadores con un enfoque geográfico definido."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos los departamentos académicos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regiones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol de organizador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrador del sitio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soporte"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigadores en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participación en la facultad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "elemento de menú"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión para administrar este sitio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países y regiones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol de revisor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado departamentos académicos."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volver a conceder"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Permitir la entrada de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Buscar en VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle tres"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de dirección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cambiar selección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aquí están los profesores del departamento de {0} que son miembros de esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvenciones en VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel de liderazgo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay {0} papeles para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Añadir"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenido a VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esto crearía una página que utilice about.ftl como el cuerpo. Se accede a la página a través de /about y anularía todas las asignaciones de servlet mapeados en web.xml."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "área de investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contáctanos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "contraseña"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO es una herramienta de descubrimiento de investigación centrada en permitir la colaboración entre científicos de todas las disciplinas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Colección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle dos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cargando datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "volver a"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fecha de concesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore o busque información sobre las personas, departamentos, cursos, becas y publicaciones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mi cuenta"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre completo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Años de participación en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos los profesores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrar búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel de liderazgo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lugar de subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio seleccionado"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol proveedor de servicios"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primer nombre"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contáctanos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle tres"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol de revisor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Términos de uso"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta forma no es capaz de manejar la edición de esta posición, debido a que está asociada con múltiples posiciones particulares."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Asistente"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagen de marcador de posición"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "usuario"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "contraseña"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta forma no es capaz de manejar la edición de esta subvención, debido a que se encuentra asociada con múltiples subvenciones individuales."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países y regiones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Finalizar sesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar página"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de subvención"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mi cuenta"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado miembros en la facultad."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lugares en todo el estado."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provincia o región"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soporte"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigadores en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Apellido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Añadir"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explore o busque información sobre las personas, departamentos, cursos, becas y publicaciones."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Permitir la entrada de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | conectar compartir descubrir"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cambiar selección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participación en la facultad"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrador del sitio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Colección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión para administrar este sitio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos los departamentos académicos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mi perfil"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estado."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esto crearía una página que utilice about.ftl como el cuerpo. Se accede a la página a través de /about y anularía todas las asignaciones de servlet mapeados en web.xml."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Desarrollado por"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos los miembros de esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dirección de correo clectrónico"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos los profesores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, introduzca un nuevo valor en el campo Rol."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "volver a"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar dirección postal"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Años de participación en"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenido"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fecha de concesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de dirección"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primera publicación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aquí están los profesores del departamento de {0} que son miembros de esta organización."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "limitar la búsqueda"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre completo"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Versión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Inicio"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente no hay investigadores con un enfoque geográfico definido."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Buscar en VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "derechos de autor"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No se han encontrado departamentos académicos."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cargando imagen del sitio web"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última beca"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este cuerpo es de la plantilla en el archivo vivo/productMods/templates/freemarker/body/menupage/grants.ftl. En el modelo de presentación, la página de becas muestra: la propiedad requiresBodyTemplate que define que la página de becas anula la plantilla predeterminada. La plantilla predeterminada de estas páginas está en /vitro/webapp/web/templates/freemarker/cuerpo/menupage/menupage.ftl"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay subvenciones para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estados."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primera beca"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvenciones en VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regiones"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "más"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cargando datos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta técnica podría usarse para definir las páginas sin elementos de menú, que obtienen su contenido a partir de una plantilla FreeMarker. Un ejemplo sería la página acerca de."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crear entrada"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rol de organizador"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle uno"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO es una herramienta de descubrimiento de investigación centrada en permitir la colaboración entre científicos de todas las disciplinas."@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Acerca de"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dirección calle dos"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil de VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "área de investigación"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "De momento no hay {0} papeles para"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "investigadores"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Iniciar sesión"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenido a VIVO"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volver a conceder"@es ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: la personne ne peut être retirée de la page de l'organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conférence choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cette organisation n'a aucune organisation subordonnée, ni aucune personne aillant des"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only organizations whose name contains this text."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de formation pédagogique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "au cours des dernières 10"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vider"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre de la page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subventions par année"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "et tous ses enfants."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service à la profession"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Il n'existe actuellement aucun modèle construit pour la visualisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans une année complète"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Type de poste."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparer les organisations"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom complet pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autres courriels"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Afin qu'une ontologie locale soit reconnue ici, son espace de nom URI doit respecter cette structure"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revendiquer les publications de<br />{0}"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "valeur de date/temps incomplète"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "service à la profession dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suivant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de la ressource"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir les subventions et projets que vous désirez <em>exclure</em> de votre profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Code postal."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans l'outil de moissonnage (harvester) de VIVO, le fichier"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comment désirez-vous comparer?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Domaine principal du diplôme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connectez-vous pour inscrire des informations supplémentaires concernant vos subventions apparaissant sur votre page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institutions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "voir toutes les subventions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Plus d'infos sur les codes QR"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre du poste"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cliquer sur l'icône de la page"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une entrée dans le champ Type de formation pédagogique."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ex.: instructeur, facilitateur, assistant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom du concept"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Assistant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coauteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom du prix"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "code QR de vCard"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For more information on the UCSD map of science and classification system, see"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moissonnage complété. Pour un nouveau jeu de métadonnées, veuillez recharger la page."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type d'événement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous pouvez inscrire un ou plusieurs DOIs à lier. Ils peuvent être saisis sous forme numérique ou d'URL:<br /><br />e.g."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Courriel."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ceci est généralement dû à une configuration erronnée du moissonnage. Veuillez vous assurer que:"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucun(e) éditeur(-trice) lié(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ERREUR INCONNUE DE NIVEAU ENTITE"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle d'éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Difficulté à trouver une classe appropriée?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cochercheur(-euse)s dédoublonné(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: Les organisations ou personnes listées ci-après sont limitées à celles relevant directement de {0} dans la structure de l'organisation. Il est possible d'explorer les organisations ou personnes se retrouvant sous une organisation secondaire en sélectionnant l'icône apparaîssant près du nom d'une organisation secondaire sous le graphique à droite."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retirer du graphe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les pages web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Télécharger"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil inconnu"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "L'utilisateur ne devrait pas normalement voir cette erreur. Il s'agit vraisemblablement d'un problème qui doit être rapporté."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Votre identifiant ORCID est confirmé: {0}</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "l'outil de moissonnage (harvester) de VIVO est installé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retirer du graphe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "à travers 554 sous-disciplines scientifiques"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir la chronologie complète et le réseau des cochercheur(-euse)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Allez sur votre page de profil pour inscrire des informations supplémentaires concernant vos subventions."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activité clinique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "About VIVO's Map of Science Visualization"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coauteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de présentation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Services de vocabulaires externes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO a échoué à ajouter un identifiant externe à votre dossier ORCID.</p> <p>Le lien n'a pu être établi.</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: le terme ne peut être retiré"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "For other maps of science, see"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle \"Responsable de\""@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Graphe temporel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre total de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La subvention a été exclue avec succès de la page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coauteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Brevet"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Masquer les noms"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each subdiscipline. This count can be fractional because some publication venues are associated with more than one subdiscipline. Each publication in such a venue contributes fractionally to all associated subdisciplines according to a weighting scheme."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditeur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jeu de données"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "téléphone"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle de fournisseur(-euse) de services"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dans l'outil de moissonnage de VIVO (harvester) l'usager du serveur web (typiquement Tomcat) a les droits en lecture/écriture sur le répertoire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette de conseiller"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Livre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Code QR"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre non retrouvé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information complémentaire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autres courriels"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Facette géographique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: cette information est basée uniquement sur les subventions présentes dans la base de données de VIVO. Ceci peut ne représenter qu'une fraction de la production totale de la personne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une entrée existante ou en saisir une nouvelle pour le champ Nom."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This visualization is based on the publications we were able to 'science locate' for {0}, and therefore it may not be fully representative of the overall publication activity for {0}."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous avez déjà revendiqué cette publication."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attributeur choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "réviseur de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Charger le(s) gabarit(s) complété(s)."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur: les sections problématiques telles que ci-dessus devraient toutes avoir été traitées."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Critique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir les subventions actives"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capture de la page web {0}"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le script s'exécute"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auteur(e) non listé(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "participants"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Nom de famille du poste."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône QR"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étiquette (type d )"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "revenir ici ensuite pour définir la classe interne institutionnelle."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cochercheur(-euse)s dédoublonné(e)s par année"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer une nouvelle"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une entrée existante pour le champ Type d'organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu de moissonnage"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Avancement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of up to three organizations or persons can be compared via \"Compare organizations.\" In the table on the left, select up to three organizations. The expertise profile of each organizations will be represented as data overlay. Each organizations is represented in a distinct color and a top-10 list of subdisciplines with the highest number of publications is given below the comparison map. Data can be saved as CSV file."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Date de publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type d'organisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de relation de direction"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coordonnées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvention administrée par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rôle d'éditeur(-trice) dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Présentation choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cette classe sera utilisée pour désigner les membres internes de votre institution."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "écoles"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premier"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Il a été impossible de réordonner les pages web."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le champ Nom de famille ne peut contenir une virgule. Veuillez saisir le prénom dans le champ Prénom."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO vous redirige vers le site d'ORCID.</li> <li>Connectez-vous à votre compte ORCID. <ul class=\"inner\"><li>Si vous n'avez pas encore d'identifiant ORCID, vous pouvez en créer un.</li></ul></li> <li>Vous permettez à VIVO de lire votre dossier ORCID (une seule fois)</li> <li>VIVO lit votre dossier ORCID.</li> <li>VIVO enregistre que votre identifiant ORCID iD est confirmé.</li></ul>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ceci vous permettra de limiter les personnes présentées sur vos pages d'accueil (Personnes, Recherche, etc.) à celles de votre institution."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle d'éditeur(-trice) de collection"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discours"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'une formation pédagogique pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir toutes les subventions dans VIVO ainsi que les cochercheur(-euse)s correspondant(e)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coauteur(e)s dédoublonné(e)s par année"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "est en cours de rafraîchissement. La visualisation se chargera dès que nous aurons terminé le calcul. Pendant ce temps, vous pouvez parcourir d'autres données dans VIVO et revenir dans quelques minutes."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication(s)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de l'événement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle de réviseur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "texte du lien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Directeur sélectionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans la base de donnés VIVO."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de l'organisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Terme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette de l'événement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Réseaux"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fermer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "par subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: la page web ne peut être retirée."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type d'entité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Législation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Article de conférence"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "graphe temporel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étiquette d'entité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prénom"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter un identifiant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The VIVO Map of Science visualization uses the UCSD map of science and classification system that was computed using paper-level data from about 25,000 journals from Elsevier's Scopus and Clarivate Analytics' Web of Science (WoS) for the years 2001-2010. The UCSD map of science assigns the 25,000 journals to 554 subdisciplines that are further aggregated into 13 main disciplines of science. In the map, each discipline has a distinct color (green for 'Biology', brown for 'Earth Sciences', etc.) and a label. (Sub)disciplines that are similar closer to one another on the map. (Sub)disciplines that are especially similar are connected by grey lines."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for a organization. Color coding by discipline."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organisateur de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer la date de publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le visionnement de ce contenu requiert Adobe Acrobat Player."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La personne a été retirée avec succès de la page de l'organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le paramètre saisi pour le code QR est invalide."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nous sommes en train de mettre ces modèles en mémoire cache. Le cache est construit (une seule fois) à la première demande de l'utilisateur après un redémarrage du serveur.  Pour cette raison, le même modèle sera servi jusqu'au prochain redémarrage. Cela signifie que les données de ces modèles peuvent devenir périmées selon la date de leur dernière création. Cela fonctionne assez bien pour l'instant. Dans les prochaines versions, nous améliorerons cette solution afin que les modèles soient stockés sur disque et mis à jour périodiquement."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Année récompensée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer la date de publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "total"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Speech"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Page de début"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisation choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cartographie des sciences"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Identifiant PubMed"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'éditeur pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'un(e) chercheur(-euse) principal(e) pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "engagement et service communautaire dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gestion des publications pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subventions avec"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 liens"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune publication présente dans le système n'a été attribuée à cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prix choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparaison"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Livre choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AAAA"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, inscrire le prénom de cette personne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisations et personnes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans mon institution"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veuillez sélectionner au moins une source de vocabulaire externe à rechercher."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "auteur(e) manquant(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 2 (recommandé): Lier votre dossier ORCID à VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prix ou récompenses pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Learn more about VIVO's Map of Science visualization?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Il a été impossible de réordonner les éditeur(-trice)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune des"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conseil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pourquoi est-ce nécessaire?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle de vulgarisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, consultez le"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer cette activité clinique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "courriel principal"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Êtes-vous certain de vouloir retirer ce terme?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type d'URL"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle d'éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône URI"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer une nouvelle classe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une valeur existante pour le champ Type de document."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Il a été impossible de réordonner les auteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "supprimer le lien auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidature"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Thèses"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "image de fond"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les auteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "série"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organisation administratrice pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Une erreur est survenue à l exécution de cette recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter le concept sélectionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termes de recherche courants"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR de vCard"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement de poste pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 liens"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Classe interne à l'institution"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les chercheur(-euse)s du département {0}  qui sont intéressé(e)s par ce domaine."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Numéro civique et rue"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The listed organizations are children of the {0} node in the organizational hierarchy. You may 'drill down' to see the organizations below a given sub-organization by selecting the chart icon next to a selected sub-organization's name below the graph on the right."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pour utiliser cette fonctionnalité, définir une valeur pour cette propriété qui pointe sur le répertoire d'installation de l'outil d'ingestion (harvester) avant de redéployer et de redémarrer l'application."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Effacer la requête"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hyperlien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cartographie des sciences"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de l'éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "existe et l'usager du serveur web en a les droits de lecture et d'écriture."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ou en ajouter un nouveau."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Map of Science visualization depicts the topical expertise a university, organization, or person has based on past publications loaded into VIVO. The {0} expertise profile is shown here -- larger circle sizes denote more publications per topic area."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cliquer pour accéder à la page web {0}"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Code postal"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle de \"Responsable de\""@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chercher"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ex.: modérateur, conférencier, panéliste"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vérifier cette correspondance"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Article"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étendre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, inscrire une valeur dans le champ Numéro de télécopieur."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actuellement, il n'y a aucune subvention de {0} pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer la page web de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "{0} identifiants restants"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "n'ont pas pu être cartographiées à l'aide de l'information contenue dans leurs revues."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications (publs.)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informations"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir le profil de cette personne"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Numéro"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Inscrire une valeur dans le champ Titre préféré."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune ontologie locale trouvée."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Année de fin"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "éditeur manquant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sauvegarder tout au format CSV"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subventions par années"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type d'organisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 liens"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publications attribuées à ce"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle de vulgarisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sujet de recherche sélectionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expertises"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de l'activité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'un(e) chercheur(-euse) pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Charger le(s) fichier(s)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étendre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir une publication existante ou en saisir une nouvelle dans le champ Titre."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualisation de la carte des sciences"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter un concept"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Afficher les noms"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Exporter le code QR"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Links"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous ne trouvez pas le concept que vous souhaitez? Créez un concept interne à VIVO."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nouvelle ontologie locale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Année d'émission"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle d'enseignement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "collection ou série"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activité manquante"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The table below summarizes the publications plotted on the Map of Science. Each row corresponds to a (sub)discipline on the map."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Titre du poste."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diplôme manquant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les personnes dans <a href=\"{1}\">{0}</a> qui sont intéressées par ce domaine de recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Glisser-déposer pour réorganiser les auteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisations"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Affiliation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sauvegarder les publications non cartographiées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Numéro de téléphone"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun concept spécifié."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Années de participation à cette subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "groupe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les personnes dans le <a href=\"{1}\">{0}</a> qui sont intéressées par ce domaine."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom du document"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter l'auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "date de publication pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unités"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter une page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "L'information des tables suivantes couvre toutes les années."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir au profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "présentation manquante"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditeur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Vous avez refusé à VIVO l'autorisation de lire votre dossier.</p> <p>La confirmation a échoué.</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veuillez sélectionner au moins un terme dans les résultats de recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chargement des personnes . . ."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucune personne associée à cette position"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cette information est uniquement basée sur {0} qui ont été chargées dans VIVO."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "n'a pas été positionnée selon le domaine scientifique."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Obtenir Flash"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous n'avez pas la permission de revendiquer pour cet usager"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Glisser et déplacer pour réorganiser les pages web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir la chronologie complète et le réseau des coauteur(e)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: L'éditeur(-trice) n'a pas été retiré(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun domaine scientifique correspondant n'a été retrouvé"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de la personne"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "événement manquant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur: aucun traitement de chargement spécifié, ou un traitement inconnu a été spécifié."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Numéro"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "où"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sélectionner une organisation existante ou en créer une nouvelle."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pour construire une première cartographie, saisir un terme de recherche représentant un large domaine d'expertise.."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recherche globale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications par année"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: l'auteur(e) n'a pas été retiré(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vérifier que ces publications sont bien celles que vous souhaitez revendiquer et indiquer le rôle que vous y avez exercé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type d'activité d'enseignement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications revendiquées par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Effacer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 1"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cliquer sur un terme pour afficher"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cet(te) auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "direction"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Qu'est-ce qui est impliqué dans le processus de mise en cache ?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO vous redirige vers le site d'ORCID</li> <li>Vous permettez à VIVO d'ajouter un identifiant externe à votre dossier ORCID (une seule fois)</li> <li>VIVO ajoute un identifiant externe à votre dossier.</li></ul>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tout afficher"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "numéro de télécopieur pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pays"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapitre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "d autres personnes partageant le même intérêt."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Consulter votre dossier ORCID."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 2"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Espace de nom local"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Que désirez-vous comparer?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organisation manquante"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reference Basemap"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% d'activité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter Éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publié dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sous-disciplines"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capacité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "n'a été positionnée selon le domaine scientifique."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Maison d'édition choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir tous les enseignants intéressés par ce domaine de recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "une nouvelle ontologie locale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "éditer le lien vers la page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>votre dossier ORCID comporte déjà un lien vers VIVO.</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle d'enseignement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre du prix ou de la distinction"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "domaines de recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvention manquante"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune subvention active pour ce département."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personnes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The map can be explored at two levels-by 13 disciplines or 554 subdisciplines. Clicking on a node in the map brings up the number of fractionally associated journal publications and the percentage of publications mapped to this (sub)discipline. Hover over a discipline in the table on the left to see what circles it corresponds to on the map. Use slider below map, on the right to reduce number of subdisciplines shown to improve legibility."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Numéro de téléphone."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fin"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si vous êtes l'éditeur de la publication, choisissez \"Éditeur(-trice)\""@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activitées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Événement choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Une erreur est survenue et le processus de moissonnage doit s'arrêter."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Niveau du domaine scientifique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activité d'enseignement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La publication a été retirée avec succès de la page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "titre du lien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Prénom du poste."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications avec"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 4"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de rôle"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle de réviseur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Changer la limite des résultats"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cet espace affiche de l'information relative aux termes et groupes de termes. Cliquer sur un groupe pour afficher les informations qui y sont associées."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "disciplines"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saisir les données"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fichier"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each (sub)discipline."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "historique des postes pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter la page web de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Présenté à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cochercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'un(e) cochercheur(-euse) principal(e) pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connectez-vous pour inscrire des informations supplémentaires concernant vos publications apparaissant sur votre page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éd."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Préfixe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Effacer les entrées sélectionnées."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: la publication ne peut être retirée de la page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Page de fin"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chapitre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun résultat pour cette recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvention choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The publication coverage of this visualization can be improved by including more publication data in the VIVO system, and by ensuring that each publication in the VIVO system is associated with a journal that the Map of Science recognizes (based on the holdings of Clarivate Analytics' Web of Science database and Elsevier's Scopus database). Journal names containing typos or other idiosyncrasies may need to be cleaned up before they are recognized. You may contact a VIVO system administrator if publication coverage is a concern."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fichiers chargés"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les subventions et les projets pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: les étiquettes non cochées n'ont pas pu être supprimées."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actes de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lecture seule"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sous-disciplines"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les éditeur(-trice)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cliquer pour ingérer le(s) fichier(s)."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fonctions avancées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer cette participation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administré par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cet espace présente la liste des termes de la recherche en cours dans la cartographie. Inscrire un terme de recherche pour débuter."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Outils de visualisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carte"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Assistant sélectionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revue choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si vous ne souhaitez pas revendiquer une publication, choisissez \"Cette publication n'est pas la mienne\"."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Début"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vol."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de ressource inconnu"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom du département ou de l'école dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "coresponsabilité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Ville/municipalité."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ville/municipalité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cliquer pour afficher la page de profil complète."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URL de la page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de l'institution"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Article de journal"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom du (de la) chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre préféré"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Allez sur votre page de profil pour inscrire des informations supplémentaires concernant vos publications."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cochercheur(-euse)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "est en cours de rafraîchissement. La visualisation se chargera dès que nous aurons terminé le calcul. Pendant ce temps, vous pouvez rechercher ou parcourir d'autres données dans VIVO et revenir dans quelques minutes."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Années de participation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Définition"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fichier"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cartographiées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ingérer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de publications."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b>% of activity</b> column shows what proportion of the publications were mapped to each subdiscipline."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entrer {0}:"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Année de début"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "par publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mettre la première lettre de chaque mot en majuscule"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Description"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 5"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cette information est uniquement basée sur les"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette de rôle conseil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle dans la présentation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subventions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Pays."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conseils de visualisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Le nombre maximum de chercheurs retrouvés pour un terme donné est déterminé par la valeur 'limite' qui est fixée à 10 par défaut. Hausser cette limite augmentera le nombre possible de connexions entre différentes expertises. Toutefois, garder à l'esprit qu'une limite trop élevée peut rendre la lecture de la cartographie plus difficile."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "qui ont été chargés dans le système VIVO comme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sélectionner ou créer un concept interne à VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type d'activité clinique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Vous avez refusé à VIVO le droit d'ajouter un identifiant externe à votre dossier ORCID.</p> <p>Le lien n'a pu être établi.</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre préféré pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucune personne associée à ce rôle"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veuillez entrer ou sélectionner une valeur dans le champ Diplômes."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entité parente"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conférence"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "message d'erreur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note: Cette information est basée uniquement sur les publications présentes dans la base de données de VIVO. Ceci peut ne représenter qu'une fraction de la production totale de la personne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "personnes de l'organisation ayant cet intérêt de recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, inscrire le nom de famille de cette personne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actuellement, les DOIs émis par Crossref, DataCite et mEDRA sont reconnus.<br />Les DOIs doivent être séparés par une virgule ou un saut de ligne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property dans runtime.properties n'est pas défini."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "titre de la présentation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle de fournisseur(-euse) de services"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La publication attribuée à ce"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune entité correspondante retrouvée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Légende"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir ou saisir une valeur pour le champ Nom de la subvention."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recherche pan-nationale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Un maximum de 10 entités peuvent être comparées."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Utilisation des données cachées à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lieu de publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Glisser et déplacer pour réordonner les éditeur(-trice)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirmer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucune URL fournie pour ce lien"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les personnes qui ont un intérêt dans <a href=\"{1}\">{0}</a> et qui font partie de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de l'auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interagir avec la cartographie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pour rendre la visualisation plus facile à lire, les termes de recherche sont classés selon le nombre de résultats retournés. Les groupes reçoivent également différentes nuances de couleur en fonction du nombre de termes de recherche connectés. Plus l'ombre est foncée, plus le nombre de termes recherchés auxquels un groupe est connecté est élevé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de poste"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "attribué par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type d'activité de recherche:"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étiquette (étiquettes alternatives)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Modèle URI indépendant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Deuxième prénom"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saisir les données dans le gabarit. Vous pouvez compléter plusieurs gabarits si vous souhaitez moissonner plusieurs fichiers simultanément."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "département"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Figer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organisation intermédiaire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "L'année de fin doit être postérieure à l'année de début."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Les modèles en cache suivants seront régénérés."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Meilleure correspondance"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Précédent"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Numéro de télécopieur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Année"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous avez sélectionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Années couvertes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Télécharger le gabarit"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Partition"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "affiliation dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Les lignes pointillées ci-dessus reflètent les subventions accordées au cours de la dernière année civile complète. Toutefois, ces tableaux présentent les renseignements sur les subventions pour toutes les années, en fonction de l'information chargée dans le système VIVO."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer une adresse postale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "adresse courriel pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 1: Ajouter votre identifiant ORCID"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom du diplôme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a un inconnu"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discours"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Merci"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer cette affiliation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'une publication pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(ex.: titre de la thèse, etc.)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coordonnées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une entrée existante ou en créer une nouvelle pour le champ Personne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pour activer cette option vous devez d'abord choisir un"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorer les activités"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pour commencer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "En cliquant sur un noeud, de l'information supplémentaire est affichée dans l'onglet 'Informations' du côté droit de la fenêtre. Dans le cas de groupes de chercheurs, les participants et leurs métadonnées sont affichées. Les personnes peuvent être retirées du graphe individuellement. La sélection d'un terme permet d'afficcher tous les groupes associés. Sous chaque groupe les données de chaque individu sont affichées. Le nombre de publications et de subventions correspondant à chaque chercheur sont également présentées. En cliquant sur le nom du chercheur on accède à sa fiche complète"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune publication dans le système n'a été attribuée à ce"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "relation de conseil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volume"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chargement de données pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "année (non indiquée dans le tableau ci-dessus)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Les métadonnées seront repêchées de Crossref si l'identifiant PubMed peut être lié à un DOI."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de diplôme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle d'organisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ex.: pour des prix couvrant plusieurs années"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pour votre instance"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nom de l'organisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auteur(e) choisi(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Nom."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retirer du graphe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de subventions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enregistrement _START_ - _END_ de _TOTAL_"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir une classe existante d'une extension locale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rapport"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diplôme manquant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Êtes-vous certain de vouloir retirer cet(te) éditeur(-trice):"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recherche locale"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir les personnes que vous désirez <em>exclure</em> de la page des profils."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "au cours des 10 dernières années complètes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subvention(s)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Exporter les codes QR"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aide"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Événement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "années"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône de coauteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Départements associés"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter un(e) auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Date de fermeture"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Animer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, renseigner le champ Numéro civique et rue."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Êtes-vous certain de vouloir retirer cet auteur(e):"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "durant les 10 dernières années"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sujet de recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conseil: pour étendre la recherche à d'autres concepts reliés cliquewr sur  &lsquo;Étendre&rsquo;."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "adresse postale pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subventions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une valeur existante ou en saisir une nouvelle pour le champ Nom du document."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir les résultats"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir un type de relation de direction."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "forer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "n'a pas d'information relative à la revue."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "property dans runtime.properties pointe sur le répertoire d'installation de l'outil de moissonnage (harvester)."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Supprimer le lien vers la page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "L'année de début doit précéder l'année de fin."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer votre propre concept"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Désirez-vous ajouter un identifiant ORCID?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "forage du graphe temporel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir toutes les personnes ayant un intérêt pour ce sujet."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lien Scopus"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Directeur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suffixe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer le concept"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 3"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir à la publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publié"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, choisir une entrée existante ou en créer une nouvelle pour le champ Prix et distinctions."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Afficher les étiquettes des disciplines"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personne"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Information manquante sur la ressource"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir à votre page de profil VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Auteur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veuillez spécifier un rôle pour cette activité."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "page de profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "initiales"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Élément"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous devez être administrateur(-trice) pour utiliser cet outil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer l'année récompensée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saisir un terme de recherche et cliquer sur 'Chercher'. Le graphe résultant affiche les expertises sous forme de carrés orangés. À ces sujets sont reliés des points de couleur bleu représentant les chercheurs. Ajouter un autre terme de recherche pour voir comment les résultats de combinent. Ajouter d'autres termes au besoin."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Document juridique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Récipiendaire du prix"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Type de document"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lien de Faculté 1000"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'une présentation pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditeur choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir toutes les personnes de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans l'année courante incomplète (non indiquée dans le tableau ci-dessus)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cartographie d'expertises"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "List only (sub)disciplines whose names contain this text."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirmer vos publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Image"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "requis avec un nouveau nom de famille"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coauteur(e)(s)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sites web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle d'organisateur(trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de famille"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucun lien disponible"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organisation parente de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "intervalle de date/temps incomplet"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pour de plus amples informations."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Votre dossier ORCID est lié à VIVO</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter un(e) éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter une participation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "avec année établie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Service de recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Maison d'édition"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continuer à l'étape 2"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette d'assistant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Il n'y a actuellement aucun article pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "cochercheur(-euse)(s)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primé par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Courriel principal"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "La cartographie d'expertises est un outil simple et efficace qui permet la recherche, l'exploration et la découverte d'experts à travers une cartographie visuelle représentant les liens entre les chercheurs et leurs domaines de recherche."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rafraîchir les modèles en cache pour la visualisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Attribué par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vue rapide du profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune recherche trouvée."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "depuis l'année courante incomplète"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter une nouvelle page web"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "avec année incertaine"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impossible de retrouver les métadonnées"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lettre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Disciplines"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "complet pour de plus amples informations."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organisations"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Télécharger les données en tant que"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expertise Profile Comparison Map"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO n'a pas pu lire votre dossier ORCID.</p> <p>La confirmation a échoué.</p>"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditeur(-trice)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir les publications que vous souhaitez <em>exclure</em> de la page des profils."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Un maximum de trois éléments peuvent être comparés."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer l'année récompensée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter un rôle de chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continuer à l'étape 1"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titre de la présentation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement de"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Choisir une entrée existante ou en saisir une nouvelle dans le champ Nom."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vue complète du profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "réseau des cochercheur(-euse)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "activité de recherche:"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidat"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "engagement et service communautaire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Domaines de recherche associés"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vous pouvez inscrire un ou plusieurs identifiant(s) PubMed à lier. Les identifiants doivent être séparés par des virgules ou des sauts de ligne."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'une relation de direction pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les affiliations des personnes à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Éditer ce rôle de chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Concept (type)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fermez-moi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les concepts"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publication activity of a university, organization, or person can be overlaid on the map to generate expertise profiles. The process is as follows: (1) The set of unique journals is identified, (2) the number of times each journal served as a publication venue is calculated, and (3) the area size of the 13 disciplines and 554 subdisciplines is calculated based on these journal publication venue counts. Note that some journals are associated with exactly one (sub)discipline while others, e.g., interdisciplinary ones like <em>Science</em> or <em>Nature</em>, are fractionally associated with multiple (sub)disciplines. Subdisciplines inherit the colors of their parent disciplines. (Sub)disciplines without any associated publications are given in gray."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle au sein de l'istitution"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "d'activité"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "d'un maximum"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter une affiliation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, consulter le"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cette publication n'est pas la mienne"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Données pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "année récompensée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "enregistrement d'une relation d'assistant pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Réseau des cochercheur(-euse)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "The <b># of pubs.</b> column shows how many of the publications were mapped to each (sub)discipline. This count can be fractional because some publication venues are associated with more than one (sub)discipline. Each publication in such a venue contributes fractionally to all associated (sub)disciplines according to a weighting scheme."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "partager cette URI"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône de la carte des sciences"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "retirer le lien éditeur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "courriel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personnes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône de cochercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ce(tte) chercheur(-euse)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir à la gestion des concepts"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diplômes"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "attribué pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sauvegarder"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "est correctement configuré selon le nom de votre base de données et son nom de domaine."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Charger"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune autre publication à revendiquer.<br />Vous pouvez ajouter des identifiants ci-après, ou revenir à votre profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subventions actives pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diplôme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ces chiffres sont basés uniquement sur les publications qui ont été chargées dans cette application VIVO. Si c'est votre profil, vous pouvez entrer d'autres publications ci-dessous."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay and examine expertise profiles for one or more organizations. Color coding by organization."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Les modèles sont actualisés chaque fois que le serveur redémarre. Comme ce n'est généralement pas pratique sur les instances de production, les administrateurs peuvent utiliser le lien \"rafraîchir le cache\" ci-dessus pour le faire sans redémarrer."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "SVP, sélectionner un type dans la liste déroulante."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Réseau des coauteur(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône de vue rapide"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir au menu des outils de moissonnage de données"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucune page web n'est associée à cette personne. Ajouter une page web en cliquant sur le bouton ci-dessous."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publications jusqu'à ce jour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ajouter une activité clinique"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lien de téléchargement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Un maximum de 10 entités peuvent être comparées. SVP, retirez-en quelques unes et recommencez."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Les visualisations à grande échelle comme le graphique temporel ou la carte des sciences impliquent de calculer le nombre total de publications ou de subventions pour une entité donnée. Comme cela signifie aussi vérifier toutes ses sous-entités, les requêtes sous-jacentes peuvent demander beaucoup de mémoire et prendre beaucoup de temps. Pour une expérience utilisateur plus rapide, nous souhaitons sauvegarder les résultats de ces requêtes pour une réutilisation ultérieure."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Étape 1: Ajouter votre identifiant ORCID"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dans le système."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data Overlay"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aller au profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tables"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chargement de la cartographie . . ."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Afficher toutes les recherches"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interactivity"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Soumettre des identifiants"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cochercheur(-euse)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "classe interne institutionnelle"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Domaines de recherche facultaires"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "À cette fin, nous avons conçu une solution de mise en mémoire cache qui conservera les informations sur la hiérarchie des organisations - à savoir, quelles publications sont attribuées à quelles organisations - en stockant le modèle RDF."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icône de vue complète"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Si vous n'êtes l'auteur(e) d'une publication, sélectionnez votre nom dans la liste des auteur(e)s.<br />Les métadonnées repêchées peuvent être incomplètes. Si votre nom n'apparaît pas, sélectionnez \"Auteur(e) non listé(e)\"."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dernier"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aucun(e) auteur(e) lié(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veuillez attendre. Données en cours de chargement."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erreur lors du traitement de la demande: la subvention ne peut être exclue de la page de profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Qu'est-ce que c'est?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(étape complétée)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dans l'outil de moissonnage VIVO (Harvester), le répertoire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cliquer pour afficher"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diplôme choisi"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "numéro de téléphone pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lien persistant vers la visualisation courante"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digital Object Identifier (DOI)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nombre de publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Êtes-vous certain de vouloir retirer cette page web?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Désirez-vous ajouter un identifiant ORCID?"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Source de vocabulaire"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscrit"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "un aperçu rapide du profil."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subventionné"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Personne sélectionnée"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Candidature au diplôme"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_tenderfoot.ttl
@@ -1,0 +1,871 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conditions d'utilisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impossible d'éditer ce poste depuis le formulaire. Le poste est associé à plusieurs individus."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "collection ou série"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de famille"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prénom"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type de subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir tous les membres de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "plus"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer le courriel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Première publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun membre de la faculté retrouvé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mon profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Propulsé"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | Connecter, partager, découvrir"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheurs"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profil VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Déconnexion"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer un enregistrement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "emplacement de l'image"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Première subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participant"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "province."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "À propos"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle du fournisseur de service"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Courriel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "localisations de niveau provincial."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrer la recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province ou région"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "droit d'auteur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lieu de la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pays"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer la page"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saisir une nouvelle valeur dans le champs Rôle."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dernière subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actuellement aucune subvention pour "@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "première ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "provinces."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chargement de l'image"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "utilisateur(trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impossible d'éditer cette subvention depuis le formulaire. La subvention est associée à plusieurs chercheur(-euse)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun chercheur(-euse) ayant une facette géographique."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "voir tous les départements"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vue"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "régions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle d'organisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administration du site"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aide"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheur(-euse)s en"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Membres facultaires"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dernière publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "élément de menu"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connectez-vous pour gérer ce site"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pays et régions."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de réviseur(e)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun département retrouvé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retourner à la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvention pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chercher dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3e ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "changer votre sélection"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les personnes des {0} départements qui font partie de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subventions dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de direction"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun {0} article pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenue"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenue dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "personnes du département associées à ce domaine"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nous joindre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mot de passe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO est une plateforme de valorisation de la recherche facilitant la collaboration entre chercheurs de toutes les disciplines."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2e ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Distinction choisie"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chargement des données"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "retourner à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connexion"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "date de la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Consulter ou chercher de l'information sur les personnes, départements, cours, subventions et publications."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mon compte"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom complet"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Années de participation dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "voir toutes les facultés"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_wilma.ttl
@@ -1,0 +1,853 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Limiter la recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de direction"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vue"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lieu de la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Distinctions choisies"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de fournisseur de services"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prénom"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nous joindre"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3e ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle de réviseur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conditions d'utilisation"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impossible d'éditer ce poste depuis le formulaire: le poste est associé à plusieurs personnes."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participant(e)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "emplacement de l'image"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "utilisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dernière publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mot de passe"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Impossible d'éditer cette subvention depuis le formulaire: la subvention est associée à plusieurs chercheur(-euse)s."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pays et régions."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Déconnexion"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer la page"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "type de subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mon compte"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun membre de la faculté trouvé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "localisations de niveau provincial."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Province ou région"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aide"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheurs en"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom de famille"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajouter"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Parcourez ou recherchez des informations sur des personnes, des départements, des cours, des subventions et des publications."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subvention pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | Connecter, partager, découvrir"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "changer votre sélection"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Membres facultaires"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administration du site"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Collection"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pays"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connectez-vous pour gérer ce site"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "voir tous les départements"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mon profil"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "province."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This would create a page that would use about.ftl as the body.  The page would be accessed via /about and would override all servlet mappings in web.xml."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Propulsé par"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voir tous les membres de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Courriel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "voir toutes les facultés"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saisir une nouvelle valeur dans le champ Rôle."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "revenir à"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Éditer le courriel"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "collection ou série"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Années de participation dans"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gérer les publications"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenue"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Date de la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "étiquette d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Première publication"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voici les personnes des {0} départements qui font partie de cette organisation."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrer la recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nom complet"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Version"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun chercheur(-euse) trouvé(e) ayant une facette géographique."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recherche VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "droit d'auteur"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun département trouvé."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Chargement du site"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dernière subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This body is from the the template file vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  In the display model, the grants page has a display:requiresBodyTemplate property that defines that the grants page overrides the default template. The default template for these pages is at /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actuellement aucune subvention pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "provinces."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Première subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subventions dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "régions"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "plus"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chargement des données"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This technique could be used to define pages without menu items, that get their content from a freemarker template.  An example would be the about page."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Créer un enregistrement"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rôle d'organisateur(-trice)"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "première ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO est une plateforme de valorisation de la recherche facilitant la collaboration entre chercheur(-euses)s de toutes les disciplines."@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "À propos"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2e ligne d'adresse"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profil VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "personnes du département associées à ce domaine de recherche"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aucun article {0} pour"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "chercheur(-euse)s"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Connexion"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bienvenue dans VIVO"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revenir à la subvention"@fr-CA ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "solicitação de processamento de erro: a pessoa não pode ser excluída da página da organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferência selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta organização tem nem sub-organizações, nem as pessoas com"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Listar apenas organizações cujo nome contém este texto."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Formação Pedagógica"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no último 10 completo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reinicialização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome da Webpage"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants por ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diretório e todos os seus filhos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "serviço à profissões"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "modelos Atualmente não há são construídos para uso através da visualização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "em um ano de conclusão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um valor no campo Tipo de posição."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Compare organizações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome completo para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Emails adicional"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para que uma ontologia local ser reconhecido aqui, o seu namespace URI deve seguir nesse padrão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reivindicação obras para<br />{0}"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conta"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "data incompleta / valor de tempo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "serviço à profissões em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Próxima"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do recurso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confira esses grants e projetos que você deseja excluir da página do perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo Código Postal."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in vivo Harvester, o arquivo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Como você quer comparar?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Maior Campo de Grau"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faça login para entrar detalhes adicionais sobre seus subsídios em sua página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Instituições"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizar todas as subvenções"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mais informações sobre os QR Code"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Posição Título"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique no ícone webpage"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, selecione um valor no campo Tipo de Treinamento Educacional."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eg, Instrutor, Facilitador, Assistente"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "orientando"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do prêmio"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QRCode"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Investigator"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para mais informações sobre o mapa UCSD de ciência e sistema de classificação, veja"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dados recebidos. Por outro lado, por favor, atualize a página."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de evento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você pode inserir um ou mais DOIs para corresponder, e pode ser inserido como um ID ou URL:<br /><br />p.ex."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo Endereço de Email."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Isso é mais provável devido a uma configuração imprópria. Por favor, verifique o seguinte:"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor não ligados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entidade de nível Erro indefinido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Não é possível encontrar uma classe apropriada?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo /"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-pesquisadores unico"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: as organizações ou pessoas abaixo são apenas aqueles que são diretamente abaixo {0} na hierarquia da organização. Você pode \"drill down\" para ver as organizações ou pessoas abaixo de um determinado sub-organização, selecionando o ícone gráfico ao lado do nome de uma sub-organização selecionada abaixo do gráfico à direita."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remover grupo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar Páginas da Web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil desconhecido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O usuário final não deve ver este erro em circunstâncias normais, de modo que este é provavelmente um bug e deve ser relatado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Seu ID de ORCID é confirmado como {0}</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Harvester está instalado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Remova capacidade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "através de 554 sub-disciplinas científicas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver cronograma completo e rede de co-investigador."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ir para página do seu perfil para entrar detalhes adicionais sobre seus subsídios."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividade clínica"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobre Visualização do Vivo Mapa da Ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-autores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Apresentação Tipo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Serviços de Vocabulário externos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO falhou ao adicionar um ID externo ao seu registro ORCID.</p> <p>A vinculação não pode continuar.</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erro ao processar o pedido: termo não removido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para outros mapas de ciência, veja"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de \"chefe de\""@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gráfico Temporal"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "número total de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O item foi excluído com sucesso a partir da página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-autores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patente"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiquetas de grupos de ocultação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A coluna <b># de pubs.</b> mostra quantos dos publicações foram mapeados para cada especialidade. Este contagem pode ser fraccionada porque alguns publicação associadas a mais do que um subcampo. Cada publicação em tal local contribui fragmentação de todas as sub-disciplinas associadas de acordo com a um sistema de ponderação."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conjunto de dados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "telefone"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de provedor de serviços"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in vivo Harvester, o usuário do servidor web (normalmente tomcat6) leu e acesso ao escrever"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rótulo orientador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Livro"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QRCode"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título não encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informações Complementares"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "emails adicionais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Foco geográfico"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: Esta informação está baseada exclusivamente em concessões que foram carregados no sistema VIVO. Isto pode ser apenas uma pequena amostra de trabalho total da pessoa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira ou selecione um valor no campo Nome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta visualização é baseada nas publicações, fomos capazes de 'localizar ciência' para {0}, e portanto, não pode ser plenamente representativo a atividade de publicação global para {0}."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você já reivindicou esta obra."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecionado conferrer"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "revisor da"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome da Bolsas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Envie seu modelo completo (s)."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erro: seção problemática como acima devem todos ter sido manipuladas."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Revista"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todas as bolsas ativas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "captura de tela da página {0}"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Script a ser executado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor não cotado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "participaram"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você deve inserir um valor no campo Sobrenome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "qr ícone"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rótulo (Type)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e depois volte aqui para definir a classe institucional."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Único co-pesquisadores por ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar um novo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, selecione um valor no campo Tipo de Organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Menu de Inserção"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Progresso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicação de até três organizações ou pessoas podem ser comparados através de \"Comparar organizações\". Na tabela à esquerda, selecione até três organizações. A perícia perfil de cada organizações será representado como sobreposição de dados. Cada organizações é representada em uma cor distinta e uma lista top-10 de subdisciplinas com o maior número de publicações é dada abaixo do mapa de comparação. Os dados podem ser salvos como arquivo CSV."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data da Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Relação da Assessoria"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Página web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informaçãos de Contato"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Imagem"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessão que está sendo administrado por"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "papel regras em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "apresentação selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta classe será utilizado para designar aqueles indivíduos internos para sua instituição."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "escolas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeiro"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "reordenação de páginas web falhou."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O campo de sobrenome não pode conter vírgulas. Por favor, insira o primeiro nome no campo Nome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redireciona você para o site do ORCID.</li> <li>Você faz login na sua conta ORCID. <ul class=\"inner\"><li>Se você não tem uma conta, pode criar uma.</li></ul></li> <li>Você diz ao ORCID que o VIVO pode ler o seu registro do ORCID.</li> <li>VIVO lê seu registro ORCID.</li> <li>VIVO nota que seu ID de ORCID está confirmado.</li></ul>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Isso permitirá que você para limitar os indivíduos indicados em suas páginas do menu (pessoas, investigação, etc.) para apenas aqueles dentro de sua instituição."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "série de regras da coleção ou editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tese"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "formação educacional para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todas as subvenções Vivo e correspondente rede de co-investigador."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-autores unico por ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "está sendo atualizada. A visualização será carregado, logo que estamos a fazer computing, ou você pode pesquisar ou procurar outros dados in vivo e voltar em poucos minutos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicação (s)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do evento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de revisor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "texto do link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Advisor Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no banco de dados VIVO."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome da organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta do vento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Redes"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fechar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por Grants"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pedido = Erro ao processar: página web não foi removido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Entidade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legislação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comunicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gráfico temporal"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rótulo entidade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome próprio"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicione um ID"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A visualização do VIVO Mapa da Ciência usamos o mapa UCSD da ciência e da classificação do sistema que foi calculado usando dados de paper-levela partir de cerca de 25.000 revistas da Elsevier de Scopus and Web, além da Clarivate Analytics Web of Science (WoS) dos anos de 2001-2010. O mapa UCSD da ciência atribui os 25.000 revistas para 554 subdisciplinas que estão agregadas principalmente em 13 disciplinas da ciência. No mapa, cada disciplina tem uma cor distinta (Verde para 'Biologia', marrom para \"Ciências da Terra\", etc.) e um rótulo. (SUB)disciplinas que são mais semelhança umas as outras no mapa. (Sub)disciplinas que são especialmente semelhante são ligados por linhas cinzentas."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay e examine o pergil para uma organização. Cor definida para disciplina."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizador da"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit data de publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este conteúdo necessita do Adobe Flash Player."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A pessoa foi excluído com sucesso a partir da página da organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você passou um valor inválido para o parâmetro de visualização do QRCode."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "No momento, estamos cache esses modelos na memória. O cache é construído (apenas uma vez) na primeira solicitação do usuário após a reinicialização do servidor. Devido a isso, o mesmo modelo será servido até a próxima reinicialização. Isto significa que os dados nestes modelos pode tornar-se obsoleto dependendo de quando foi criado último. Isso funciona bem o suficiente para agora. Em versões futuras, vamos melhorar esta solução para que os modelos são armazenados no disco e periodicamente atualizado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ano Premiado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar data de publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "total de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discurso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "página inicial"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organização selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapa da ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PubMed ID"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor de entrada para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "principal entrada investigador para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "alcance & serviço comunitário em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gerenciar publicações para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants com"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">= 4 links"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Não há publicações no sistema têm sido atribuídas a esta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Comparando"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Escolhidas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "AAAA"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digite um nome para essa pessoa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizações e Pessoas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dentro da minha instituição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, selecione pelo menos uma fonte de vocabulário externo de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autor não encontrado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 2 (recomendado): Vinculando seu registro ORCID ao VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prêmio ou honra para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Saiba mais sobre VIVO Mapas de visualização Ciêntifica?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pesquisador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordenamento dos editores falhou."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "None do"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aconselhamento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por que é necessário?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de provedor de divulgação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, visite o"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta atividade clínica"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "e-mail principal"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tem certeza de que deseja remover este termo?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de URL"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri ícone"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar uma nova classe"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um valor no campo Tipo de Documento."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reordenamento dos autores falhou."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove link do autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidatura"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Teses"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagem de fundo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar Autores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "série"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administrar organização para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Foi encontrado um erro na execução da pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar Conceito Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termos de pesquisa atuais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "posição entrada para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 links"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Classe Institucional"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aqui estão os membros do corpo docente no {0} departamento que têm interesse nessa área de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endereço"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "As organizações listadas são filhos do nó {0} na hierarquia organizacional. Você pode 'drill down' para ver as organizações abaixo de um determinado sub-organização, selecionando o ícone gráfico ao lado do nome de uma sub-organização selecionada abaixo do gráfico à direita."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para utilizar esta funcionalidade, por favor, defina um valor para essa propriedade que aponta para o diretório de instalação do Harvester antes de reimplantar e reiniciar o aplicativo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "consulta de pesquisa clara"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hyperlink"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa da Ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diretório existe e o usuário do servidor web tem acesso de leitura e ele escrever."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ou adicionar um novo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO Mapa de visualização Ciêntifica retrata a experiência de uma universidade, organização ou pessoa tem com base na últimas publicações carregadas no VIVO. Aqui é mostrado o perfil de especialização da {0}--largo círculos denotam mais as publicações por área temática."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique para ver o {0} da página web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Código Postal"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de \"chefe de\""@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "eg, Moderador, Palestrante, Especialista"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verificar esta combinação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artigo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Expandir"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo número de fax."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "documento selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há {0} bolsas para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar página de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Há {0} IDs restantes"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "não poderia ser combinado com uma localização no mapa usando a sua informação do jornal."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações (pubs.)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Info"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver perfil dessa pessoa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo de título preferido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente não há ontologias locais reconhecidos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ano de finalização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editor faltando"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Salvar tudo como CSV"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants por ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo Organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 links"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicações atribuídas a este"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de provedor de divulgação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Área de Assunto Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termos de pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome da atividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de investigador para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enviar arquivo (s)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pesquisa e Expansão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs /"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione uma publicação existente no campo Título ou digite um novo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa de Visualization Ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar Conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mostrar etiquetas de grupo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "code = Exporta QR Code"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Links"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Não é possível encontrar o conceito que você quer? Crie o seu próprio."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nova ontologia local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ano Emitido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de ensino"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Coleção ou série"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividade não encontrada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A tabela abaixo resume as publicações plotadas no Mapa da Ciência. Cada linha corresponde a uma (Sub)disciplina no mapa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira um valor no campo Posição Título."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "credencial desaparecida"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estes são os indivíduos em <a href=\"{1}\"> {0} </a> que tenham interesse nesta área de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastar e soltar para reordenar autores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membro"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Salvar UNMAPPED Publicações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número de Telefone"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente não há conceitos especificados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anos de participação no Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grupo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estes são os indivíduos na <a href=\"{1}\"> {0} </a> que tenham interesse nesta área de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações em VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome do Documento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar Autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "data de publicação para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departamentos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar Página Web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "As informações nas tabelas a seguir é para todos os anos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retornar para Página de Perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "apresentação não encontrada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Você negou a solicitação da VIVO de leitura do seu registro ORCID.</p> <p>A confirmação não pode continuar.</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, selecione pelo menos um termo a partir dos resultados de busca de busca."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carregando corpo docente. . ."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pessoa não encontrada nesta posição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta informação está baseada exclusivamente em {0} que foram carregados no sistema VIVO."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "não foi \"ciência localizado.\""@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "obter Flash"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você não tem permissão para reivindicar para este usuário"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastar e soltar para reorganizar páginas da web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver cronograma completo e rede de co-autor."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "borda"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erro ao processar o pedido: editor não retirados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sem áreas da ciência correspondente encontrado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome de pessoa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "evento não encontrado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Erro: Não arquivo não tem uma tarefa especificada, ou a tarefa é desconhecido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Issue"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "foram"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regras em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione uma organização existente ou criar um novo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crie um 'primeiro passe' mapa de capacidade digitando um termo de pesquisa que poderia ser dito representar uma ampla capacidade de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Global Research"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações por ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pedido = Erro ao processar: Autor não retirados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verifique se essas são as obras que você deseja reivindicar, e indique seu relacionamento com eles."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ensino tipo de atividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Reivindique publicações de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Limpar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 1"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique em uma área para ver os outros"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "deste autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "liderança"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O que está envolvido no processo de armazenamento em cache?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO redireciona você para o site do ORCID.</li> <li>Você diz ao ORCID que VIVO pode adicionar um \"ID externo\" ao seu registro ORCID.</li> <li>VIVO adiciona o ID externo.</li></ul>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver tudo ..."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "número de fax para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "País"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capítulo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "com o mesmo interesse."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualize seu registro ORCID."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 2"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Namespace local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O que você quer comparar?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organização não encontrada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Referência Basemap"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% de actividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar o Editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicado em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subdisciplinas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "capacidade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ter sido \"-ciência localizado.\""@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicação Selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos os docentes com interesse nesta área."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uma nova ontologia local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "editar link da página web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Seu registro ORCID já inclui um link para VIVO.</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de ensino"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome do prêmio ou honra"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "áreas de pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessão desaparecida"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente não há bolsas ativas para este departamento."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pessoas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O mapa pode ser explorado em dois níveis-por 13 disciplinas ou 554 subdisciplinas. Clicando em um nó no mapa traz o número de publicações em revistas associadas e a percentagem de publicações mapeadas para esta (sub)disciplina. Passe o mouse sobre uma disciplina na tabela à esquerda para ver o que circunda corresponde a no mapa. Use controle deslizante abaixo mapa, sobre o direito de reduzir o número de subdisciplinas mostrados para melhorar a legibilidade."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo de número de telefone."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fim"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se você editou a obra, por favor selecione \"Editor\"."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividades"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Evento Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ocorreu um erro e a o processo de recebimento do arquivo não pode continuar."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nível do Espaço Ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividade de ensino"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A vontade publicação foi excluído com sucesso a partir da página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você deve inserir um valor no campo Nome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações com"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 4"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de papel"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de revisor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alterando o valor de corte"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este painel exibe informações sobre o indivíduo Pesquisar termos e grupos. Clique em um grupo para exibir suas informações."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "disciplinas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preencha dados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arquivo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A coluna <b>% of activity </b> mostra que proporção das publicações foram mapeados para cada (sub)disciplina."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "posição de entrada para a história"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar página web para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "apresentado na"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-principal entrada investigador para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faça login para entrar detalhes adicionais sobre suas publicações na sua página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prefixo do nome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Limpar todas as entidades selecionadas."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "solicitação de processamento de erro: a publicação não pode ser excluída da página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fim Página"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Capítulo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum resultado de pesquisa foram encontrados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A cobertura da visualização desta publicação pode ser melhorados através da inclusão de mais dados na publicação VIVO sistema, e por garantir que cada publicação no sistema dentro VIVO é associada com um jornal que o Mapa de Ciência reconheca (com base nas participações do banco de dados da Clarivate Analytics Web of Science e banco de dados Scopus da Elsevier). Os nomes dos jornais que contenham erros de digitação podem precisar de ser revisados antes de serem reconhecidos. Você pode entrar em contato com o administrador do sistema VIVO se a cobertura da publicação é uma preocupação."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arquivos carregados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar Grants e Projetos para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "solicitação de processamento de erro: os rótulos não verificadas não pôde ser excluído."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conceito Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Procedimento de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Apenas exibição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Subdisciplines"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar Editors"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique no botão para colher seu arquivo (s)."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Características avançadas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta participação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administrado pela"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este painel exibe uma lista dos termos de pesquisa atualmente no gráfico. Procure por algo para começar."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ferramentas de Visualização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Orientando Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Periódico Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se você não deseja reivindicar uma obra, por favor selecione \"Esta obra não é minha\"."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Início"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de recurso desconhecido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departamento ou nome da escola dentro do"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estado / Província / Região"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-autoria"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo Cidade / Local."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cidade / Local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique para ver a página de perfil padrão."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "webpage url"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Designação da instituição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Artigo de revista"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título Preferred"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ir para página do seu perfil para entrar detalhes adicionais sobre suas publicações."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-pesquisadores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "está sendo atualizado. A visualização será carregado, logo que estamos a fazer computing, ou você pode pesquisar ou procurar outros dados in vivo e voltar em poucos minutos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "anos de participação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "arquivo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapeado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Receber"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de pubs."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A coluna <b>% da atividade</b> mostra que proporção das publicações foram mapeados para cada especialidade."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Entre {0}:"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Início Ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "por Publications"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uso letra maiúscula para a primeira letra de cada palavra"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Descrição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 5"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta informação está baseada exclusivamente em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rótulo conselheiro"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel na apresentação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grants"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo País."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pistas visuais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A quantidade de pesquisadores recuperados para cada termo de pesquisa pois é limitado pelo valor de corte no formulário de pesquisa (10 por padrão). Aumentar esse ponto de corte aumentará a probabilidade de uma interseção entre diferentes termos de pesquisa. Isso também aumentará a complexidade do gráfico, no entanto, e pode dificultar a identificação de padrões."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicação selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "que foram introduzidos no sistema a partir de VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crie o seu próprio conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de atividade clínica"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Você negou a solicitação da VIVO para adicionar um ID externo ao seu registro ORCID.</p> <p>A vinculação não pode continuar.</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "título preferido para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pessoa não encontrada com este papel"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira ou selecione um valor no campo Nome de credenciais."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entidade-mãe"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "notificação de erro"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nota: Esta informação está baseada exclusivamente em publicações que foram carregados no sistema VIVO. Isto pode ser apenas uma pequena amostra de trabalho total da pessoa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "indivíduos com a área de pesquisa nessa organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um sobrenome para esta pessoa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente, DOIs emitidos por Crossref, DataCite e mEDRA são suportados.<br />Cada DOI deve ser separado por uma vírgula ou nova linha."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "propriedade em runtime.properties está indefinido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome da apresentação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de provedor de serviços"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A publicação atribuída a este"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum entidades correspondentes foram encontrados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lenda"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, Digite ou selecione um valor no campo do Nome do Grant."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Research todo o País"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "um máximo de 10 entidades podem ser comparados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Usando informações em cache em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local de Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Arrastar e soltar para reordenar editores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirme"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "não foi fornecido url"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aqui estão os indivíduos com interesse em <a href=\"{1}\"> {0} </a> que estão nesta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interagindo com a visualização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para tornar a visualização mais fácil de ler, Os termos e grupos de pesquisa são dimensionados de acordo com para o número de resultados retornados. Os grupos também recebem tons diferentes de acordo com o número de termos de pesquisa conectados. Quanto mais escura a sombra, mais termos de pesquisa estão conectados a um grupo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de posição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferido pelo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tipo de atividade da pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rótulo (Labels suplente)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URI Independent Modelo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do meio"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preencha o modelo com seus dados. Você pode preencher vários modelos se você deseja enviar vários arquivos de uma só vez."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "departamento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pausa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organização envolvidas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Final de Ano deve ser posterior ao ano de início."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Os seguintes modelos em cache será regenerado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Melhor correspondência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anterior"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Número Fax"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ano"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você selecionou"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Anos Inclusive"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download template"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Partitura musical"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "membro da"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "As linhas de ignição mostrados acima refletem bolsas do último ano civil completo. Estas tabelas mostram, contudo, a informação de subvenção para todos os anos, com base na informação carregada no sistema VIVO."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar Endereço para correspondência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "endereço de e-mail para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 1: Adicione seu ID de ORCID"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome Credencial"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "têm um desconhecido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discursos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Obrigado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite esta adesão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada para publicação para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(por exemplo, o título Tese, info, etc. Transferência)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contato"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um valor existente ou digite um novo valor no campo Pessoa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para ativar esta opção, você deve primeiro selecionar um"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Explorar atividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Começando"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ao clicar em qualquer nó na visualização, informações adicionais podem ser visualizadas no Guia 'Informações' no lado direito. Para grupos de pessoas, os participantes do grupo e suas informações podem ser vistas, e os pesquisadores individuais podem ser removidos do gráfico. A seleção de um termo de pesquisa exibirá todos os grupos anexados. Sob cada grupo, as informações completas para cada pessoa são recuperadas, e o número de bolsas e publicações correspondentes Para cada pesquisador dentro dos recursos mapeados é mostrado. Clicar no nome de um pesquisador levará à busca original resultados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Não há publicações no sistema têm sido atribuídas a este"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "relação aconselhamento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volume"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carregamento de dados para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ano (não cartografado acima)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Note que os metadados serão recuperados do Crossref, se o ID PubMed puder ser resolvido para um DOI."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Credencial"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de organizador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(por exemplo, para os prémios plurianuais)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para a instância"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome da organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor preencha o campo Nome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eliminar selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contagem Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Registros _START_ - _END_ de _TOTAL_ "@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione uma classe existente a partir de uma extensão local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Relatório"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "diploma em falta"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tem certeza de que deseja remover este editor:"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Research local"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verifique aquelas pessoas que você deseja excluir da sua página do perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nos últimos 10 anos completos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant (s)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Exporta QRCode"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ajuda"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Evento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "anos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icon = co-autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Associated Departamentos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Acrescente um Autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Data de fechamento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etomar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor insira um valor no campo Endereço."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tem certeza de que deseja remover este autor:"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dentro dos últimos 10 anos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Área Temática"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dica: você pode expandir um longo termo de pesquisa em conceitos menores clicando em & lsquo; procure e expanda & rsquo ;."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "endereço de correio para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessões"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira ou selecione um valor no campo Nome do documento."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veja resultados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, selecione uma Assessoria Tipo de Relação."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "detalhamento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ainda não temos informação revista."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "propriedade em runtime.properties é apontado para o diretório de instalação Harvester."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "apagar link da página web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O ano de início deve ser anterior ao final do ano."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Crie sua própria Conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você deseja adicionar um ID de ORCID?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gráfico temporal"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos os indivíduos com interesse nesta área."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ID link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "orientador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome Sufixo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar Conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 3"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voltar à publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publicado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um valor existente ou digite um novo valor no campo de nome Premio ou Honra."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mostrar rótulos de disciplina"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pessoa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "falta informação do recurso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Volte para a página do seu perfil VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor especifique um regra para essa atividade."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "página de perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "inicial ok"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "item"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você deve ser um administrador para usar esta ferramenta."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar ano premiado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digite uma área de pesquisa no campo de pesquisa acima e pressione 'Pesquisar'. O diagrama resultante exibe o termo de pesquisa, renderizado em laranja, conectado ao grupo azul de pesquisadores que atuam nessa área. Digite outro termo de pesquisa para ver como os pesquisadores de ambas as pesquisas se relacionam. Continue adicionando termos de pesquisa para criar um mapa de capacidade."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Processo judicial"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nome do prêmio recibo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de Documento"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculdade de 1000 link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada apresentação para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editor Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos os indivíduos desta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no atual ano incompleto (não cartografado acima)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa de Capacidade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lista única de (sub)disciplinas cuja os nomes contenham este texto."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confirme sua(s) obra(s)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gráfico"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "requeimento necessita um novo sobrenome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-autor (es)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sites"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de organizador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobrenome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver no link"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organização de origem de"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "data incompleta / intervalo de tempo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para uma visão completa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Seu registro ORCID está vinculado ao VIVO</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar um Editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione uma nova participação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "com anos conhecido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Serviço de pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publisher"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue com o passo 2"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rótulo orientando"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há papéis para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigador (s)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concedido pelo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primary Email"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bem-vindo à ferramenta Mapeamento de Capacidade. Esta ferramenta visualiza como os pesquisadores se relacionam com outros pesquisadores através de termos de pesquisa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "refresh Models em cache para Visualization"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferidos pelo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualização rapida"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum conteúdo encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "a partir do atual ano incompleto"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar nova página Web"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ano desconhecido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Incapaz de recuperar os detalhes da citação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carta"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Disciplinas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para uma visão mais completa."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizações"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "download como"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa da Comparação do Conhecimento dos Perfis"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO falhou ao ler seu registro ORCID.</p> <p>A confirmação não pode continuar.</p>"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Confira essas publicações que você deseja excluir da página do perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O número máximo de itens para comparação é 3."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Edit ano premiado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo papel de investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Continue com o passo 1"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Título da apresentação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um valor existente ou digite um novo valor no campo Nome."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Visualização padrão do perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "co-investigador rede"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "atividade de pesquisa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "candidato"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "alcance e serviço comunitário"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Afiliadas Áreas de Investigação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você pode inserir um ou mais IDs PubMed para corresponder. Cada ID deve ser separado por uma vírgula ou nova linha."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "orientador relacionado para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel do pesquisador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar pessoas ligadas a"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Edite este papel de investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Conceito (tipo)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Proximo de mim"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Gerenciar Conceitos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicação de uma universidade, organização ou pessoa podem ser sobrepostos para gerar perfis especificos. O processo é o seguinte: (1) Um conjunto único de revistas é identificado, (2) o número de vezes que cada revista serviu como publicação será calculado, e (3) O tamanho da área das disciplinas 13 e das 554 subdisciplinas são calculados com base nessas contagens de publicação da revista. Note-se que algumas revistas são associada exatamente com (sub)disciplina de outros, por exemplo, aqueles interdisciplinares como <Em>Science</em> ou <em>Nature</em>, são fracos associada a múltiplas (sub)disciplinas. Subdisciplines herdar as cores de suas disciplinas mãe. (SUB)disciplinas sem quaisquer publicações associadas são dadas em cinza."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Papel na instituição"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de atividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "de um máximo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione um novo adesão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, visite o pleno"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta obra não é minha"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dados para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ano concedidos para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "orientando relacionado para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigador da Rede"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "A coluna <b># de pubs.</b> mostra quantas das publicações foram mapeadas para cada (sub)disciplina. Esta contagem pode ser fraccionada, porque alguns publicação estão associadas a mais do que uma (sub)disciplina. Cada publicação em tal local contribui fração de todas as (sub)disciplinas associadas de acordo com um sistema de ponderação."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "compartilhar a uri"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mapa de ícone ciência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "remove ligação editor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Corpo Docente"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icon = co-investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "este investigador"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voltar para Gerenciar Conceito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "credenciais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "conferido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Guardar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "está configurado corretamente com suas informações de banco de dados e namespace."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Enviar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Não há mais obras para reivindicar.<br />Você pode inserir mais IDs abaixo ou ir para o seu perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bolsas ativas para a"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grau"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Estes números baseiam-se exclusivamente sobre as publicações que foram carregados para este aplicativo VIVO. Se este for o seu perfil, você pode entrar publicações adicionais abaixo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Overlay e examine o pergil para uma ou mais organizações. Cor definida para organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Os modelos são atualizadas a cada vez que o servidor for reiniciado. Uma vez que este não é geralmente prático sobre instâncias de produção, os administradores podem passar a usar o link \"cache refresh\" acima de fazer isso sem uma reinicialização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecione um tipo na lista drop-down."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-autor de rede"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "icone de visualizção rápido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Voltar para menu de Ferramentas de Inserção de Dados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este indivíduo não há páginas web específicas. Adicione uma nova página web, clicando no botão abaixo."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publicações até hoje"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Adicione uma nova atividade clínica"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link para download"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "máximo 10 entidades podem ser comparados. Por favor, remova alguns e tente novamente."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizações de grande escala como o Temporal Graph ou o Mapa de ciência envolvem cálculo contagens totais de publicações ou de doações para alguma entidade. Uma vez que este também significa verificar através de todas as suas sub-entidades, as consultas subjacentes pode ser tanto memória intensiva e demorado. Para uma experiência de usuário mais rápido, queremos salvar os resultados destas consultas para reutilização posterior."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Passo 1: Adicione seu ID de ORCID"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no sistema."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dados Oprimidos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vá para seu perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tabelas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carregando as informações do mapa. . ."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizar todas as pesquisas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interatividade"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Envie os IDs"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Co-investigadores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "class institucional interna"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculdade Áreas de Investigação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Para este fim, criaram uma solução de cache que irá reter informações sobre a hierarquia das organizações - a saber, que as publicações são atribuídos a que as organizações - por armazenar o modelo RDF."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ícone de visualizção completa"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Se você é um autor de uma obra, por favor selecione seu nome na lista de autores.<br />Os metadados recuperados podem estar incompletos. Se você não consegue ver seu nome listado, selecione \"Autor não cotado\"."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Último"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autor não possui linl"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aguarde enquanto seus dados são recebidos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "solicitação de processamento de erro: o item não pode ser excluída da página de perfil."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo / config / vivo.xml"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O que é isso?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(passo completado)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "in vivo Harvester, a"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Clique para exibir a"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selecionado Credencial"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "número de telefone para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ligação persistente para visualização atual"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Identificador de Objeto Digital (DOI)"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Contagem de Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tem certeza de que deseja remover esta página web?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Você deseja adicionar um ID de ORCID?"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fonte de vocabulário"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Manuscrito"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "perfil de visualização rápida."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concedido"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pessoa selecionada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grau de candidatura"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Cardápio"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termos de Uso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este formulário é incapaz de lidar com a edição desta posição porque está associada com vários posição de indivíduos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobrenome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeiro nome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de concessão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos os membros desta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar Endereço para correspondência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeira Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum membro do corpo docente encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Meu perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Desenvolvido por"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este corpo é do arquivo do modelo vivo/productMods/templates/freemarker/body/menupage/grants.ftl. No modelo de exibição, a página de doações tem um display: requiresBodyTemplate propriedade que define que a página de doações substitui o modelo padrão. O modelo padrão para estas páginas é a /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | conectar compartilhar descobrir"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pesquisadores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "perfil VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sair"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar Entrada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagem padrão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeiro Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participante"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobre"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta técnica pode ser usada para definir páginas sem itens do menu, que obtenha seu conteúdo a partir de um template freemarker. Um exemplo seria a página sobre."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provedor de Serviço de Função"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endereço Email"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "locais em todo o estado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "busca limite"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "província ou região"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local de publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar Página"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira um novo valor no campo Regras."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Versão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há subsídios para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rua um endereço"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carregando a imagem do site"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrar busca"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Usuário"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este formulário é incapaz de lidar com a edição desta subvenção, pois está associada a vários indivíduos de subvenção."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente não há pesquisadores com um foco geográfico definido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos os departamentos acadêmicos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizção"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regiões"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regras da Organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suporte"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pesquisadores em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculdade Associadas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "item de menu"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Login para o gerenciamento do site"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países e regiões."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regras do revisor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum departamento acadêmico encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retornar para grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de concessão para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Buscar no VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endereço três"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de endereço"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "seleção mudança"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aqui estão os docentes do departamento da {0} que são membros desta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subsídios na Vivo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regras da Liderança"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há {0} papéis para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bem vindo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bem-vindo ao VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Isso criaria uma página que usaria about.ftl como o corpo. A página seria acessada via /about e iria substituir todos os mapeamentos de servlet no web.xml."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "indivíduos do departamento com pesquisa nesta área"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fale Conosco"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "senha"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vivo é uma ferramenta de descobertas focada em pesquisa, que permite a colaboração entre cientistas em todas as disciplinas."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Colecção"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "endereço de rua em dois"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "carregamento de dados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "retorno à"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Login"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessão Data"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Busca ou pesquisa de informações sobre pessoas, departamentos, cursos e muito mais."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Minha Conta"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome completo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "anos de participação no"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizar todos os docentes"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrar busca"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regras da Liderança"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizção"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Local de publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Premio Selecionado"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provedor de Serviço de Função"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeiro nome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fale Conosco"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endereço três"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regras do revisor"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Termos de Uso"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este formulário é incapaz de lidar com a edição desta posição porque está associada com vários posição de indivíduos."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Participante"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "imagem padrão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Usuário"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "senha"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este formulário é incapaz de lidar com a edição desta subvenção, pois está associada a vários indivíduos de subvenção."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países e regiões."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sair"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar Página"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tipo de concessão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Minha Conta"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum membro do corpo docente encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "locais em todo o estado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "província ou região"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Suporte"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pesquisadores em"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobrenome"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adicionar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Busca ou pesquisa de informações sobre pessoas, departamentos, cursos e muito mais."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "entrada de concessão para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | conectar compartilhar descobrir"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "seleção mudança"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faculdade Associadas"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Site Admin"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Colecção"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "países"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Login para o gerenciamento do site"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ver todos os departamentos acadêmicos"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Meu perfil"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Isso criaria uma página que usaria about.ftl como o corpo. A página seria acessada via /about e iria substituir todos os mapeamentos de servlet no web.xml."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Desenvolvido por"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ver todos os membros desta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Endereço Email"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "visualizar todos os docentes"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Por favor, insira um novo valor no campo Regras."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "retorno à"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Editar Endereço para correspondência"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "anos de participação no"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bem vindo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "concessão Data"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "etiqueta de endereço"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeira Publicação"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aqui estão os docentes do departamento da {0} que são membros desta organização."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "busca limite"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nome completo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Versão"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Index"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Atualmente não há pesquisadores com um foco geográfico definido."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Buscar no VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "copyright"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenhum departamento acadêmico encontrado."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Carregando a imagem do site"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Última Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Este corpo é do arquivo do modelo vivo/productMods/templates/freemarker/body/menupage/grants.ftl. No modelo de exibição, a página de doações tem um display: requiresBodyTemplate propriedade que define que a página de doações substitui o modelo padrão. O modelo padrão para estas páginas é a /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há subsídios para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "estados."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primeiro Grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subsídios na Vivo"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regiões"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mais"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "carregamento de dados"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Esta técnica pode ser usada para definir páginas sem itens do menu, que obtenha seu conteúdo a partir de um template freemarker. Um exemplo seria a página sobre."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Criar Entrada"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Regras da Organização"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rua um endereço"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vivo é uma ferramenta de descobertas focada em pesquisa, que permite a colaboração entre cientistas em todas as disciplinas."@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sobre"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "endereço de rua em dois"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "perfil VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "indivíduos do departamento com pesquisa nesta área"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Actualmente não há {0} papéis para"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pesquisadores"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Login"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Bem-vindo ao VIVO"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Retornar para grant"@pt-BR ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU.ttl
@@ -1,0 +1,6268 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка при обработке запроса: лицо не может быть удалено со страницы организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная конференция"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "У этой организации нет ни подорганизаций, ни людей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Перечислить только организации, в чьем имени содержится данный текст."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вид образовательной подготовки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "за последние 10 полных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сбросить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название веб-страницы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Грантов в год"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "и все его подкаталоги."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "работа по специальности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время не существует построенных моделей для использования  в визуализации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в полном году"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Авторы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите значение в поле „Название должности“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сравнить организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "полного имени"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дополнительные адреса электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для того чтобы здесь применялась локальная онтология, ее URI пространства имен должен соответствовать следующему образцу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Заявить о правах на работы для<br />{0}"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Количество"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "неправильно введённая дата/время"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "работа по специальности в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вперед"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название источника информации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Отметьте те гранты и проекты, которые вы хотите <em>убрать</em> со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста введите значение в поле „Почтовый индекс“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В Подборщике VIVO файл"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Как вы хотите сравнивать?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Основная область обучения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войдите в систему, чтобы ввести дополнительные сведения о своих грантах на странице своего профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Учреждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "просмотреть все гранты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Подробнее о QR-коде"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название должности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "щёлкните по пиктограмме страницы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите значение в поле „Вид образовательной подготовки“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "например, инструктор, фасилитатор, ассистент"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название концепции"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Консультируемый"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "соавтор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название награды"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-код электронной визитной карточки vCard"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Исполнитель"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для получения дополнительной информации о карте науки и системе классификации UCSD см."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сбор данных завершен.  Для повтора, пожалуйста, обновите страницу."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "тип мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы можете ввести один или несколько DOI для сопоставления, которые могут быть введены либо как ID, либо как URL:<br /><br />например."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите значение в поле Адрес электронной почты."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Скорее всего, это связано с неправильной конфигурацией Подборщика. Пожалуйста, убедитесь в следующем:"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "нет связанного редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "УРОВЕНЬ СРАВНЕНИЯ НЕ ЗАДАН"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не можете найти подходящий класс?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Уникальные со-исследователи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Примечание: ниже перечислены только те организации или люди, которые находятся непосредственно под {0} в иерархии организаций. Вы можете 'опуститься ниже', чтобы просмотреть организации или людей на уровне ниже данной подорганизации, выбрав значок диаграммы рядом с названием выбранной подорганизации под графиком справа."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Удалить группу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Управление списком веб-страниц"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Download"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "связь"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Неизвестный профиль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Конечный пользователь не должен видеть эту ошибку при нормальных обстоятельствах, поэтому, вероятно, это ошибка, о которой следует сообщить."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ваш ORCID подтвержден как {0}</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Установлен Подборщик VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Убрать компетенцию"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "по 554 научным субдисциплинам"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Посмотреть полную хронологию и сеть со-исследователей."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Перейдите на страницу своего профиля, чтобы ввести дополнительные сведения о своих грантах."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "клиническое мероприятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "О визуализации „Карты наук“ VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Список соавторов"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип доклада"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Внешние службы словарей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p> VIVO не удалось добавить внешний идентификатор к вашей записи ORCID.</p><p>Связывание не может быть продолжено.</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка при обработке запроса: термин не удален"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Другие карты науки см."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль „руководителя“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Временной график"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Общее число"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Элемент был успешно удалён со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "соавторы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Патент"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "скрыть метки групп"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Колонка <b>колич. публ.</b> показывает, сколько публикаций было сопоставлено с каждой субдисциплиной. Это число может оказаться не целым, поскольку некоторые места публикации связаны с более чем одной субдисциплиной. Каждая публикация в таком месте вносит дробный вклад во все связанные субдисциплины в соответствии со схемой взвешивания."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Набор данных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "телефон"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль поставщика услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В Подборщике VIVO веб-серверу (обычно это tomcat6) разрешён доступ для чтения и записи в каталог"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка консультанта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Книга"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-код"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название не найдено."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дополнительные сведения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "дополнительные адреса электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Географическая ориентация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Примечание: Эта информация основана исключительно на грантах, которые были загружены в систему VIVO. Это может быть лишь небольшая выборка из общего объема работы данного лица."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите или выберите значение в поле „Название“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта визуализация основана на публикациях, которые мы смогли „научно локализовать“ для {0}, и поэтому она может не полностью отражать общую публикационную активность для {0}."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы уже заявили о своей претензии на эту работу."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная организация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Организация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "рецензент"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузите заполненный шаблон(ы)."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Error: problematic section as above should all have been handled."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Обзор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать все действующие гранты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "скриншот страницы {0}"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выполняющийся сценарий"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Неуказанный автор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "посещено"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы должны ввести значение в поле Фамилия."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Иконка QR"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Метка (тип)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "и затем вернитесь сюда, чтобы задать собственный класс для учреждения."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Уникальных со-исследователей в год"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создайте новый"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите значение в поле „Тип организации“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Меню Ввод данных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ход выполнения задания"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикационную активность организаций или лиц числом до трёх можно сравнить при помощи пункта меню „Сравнить организации“. В таблице слева выберите не более трех организаций. Профиль специализации каждой организации будет представлен при помощи наложения данных. Каждая организация помечается своим цветом, а под картой сравнения приводится список 10 субдисциплин с наибольшим количеством публикаций. Данные могут быть сохранены в виде файла в формате CSV."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дата публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "тип организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип отношений консультирования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Веб-страница"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Контактная информация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изображение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "грант, администрируемый"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "роль редактора в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное выступление"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этот класс будет использоваться для обозначения лиц, работающих в вашем учреждении."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "школ"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Первая"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Переупорядочивание веб-страниц не удалось."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В поле Фамилия не допускаются запятые. Пожалуйста, введите имя в предназначенное для этого поле Имя."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO перенаправляет вас на веб-сайт ORCID.</li><li>Вы входите в свою учетную запись ORCID.<ul class=\"inner\"><li>Если у вас нет учетной записи, вы можете ее создать.</li></ul></li><li>Вы сообщаете ORCID, что VIVO разрешено читать информацию из вашей записи ORCID.</li> <li>VIVO считывает информацию из вашей записи ORCID.</li><li>VIVO сообщает, что Ваш ORCID iD подтверждён.</li></ul>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Это позволит ограничить круг лиц, отображаемых на страницах меню (Люди, Исследования и т.д.), только сотрудниками вашего учреждения."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "роль редактора коллекции или серии"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Диссертация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "из"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись об образовании и повышении квалификации,"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просмотреть все гранты VIVO и соответствующую сеть со-исследователей."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Уникальных соавторов в год"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "из"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "сейчас обновляется. Визуализация загрузится, как только мы закончим вычисления, или вы можете искать или просматривать другие данные в VIVO и вернуться через несколько минут. "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикация(и)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль рецензента"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "текст в поле ссылки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный консультант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в базе данных VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Термин"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сети"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Закрыть"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "по грантам"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка обработки запроса: веб-страница не удалена."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Законодательный акт"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Доклад на конференции"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "временной график"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Имя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "электронная визитная карточка Vcard"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить идентификатор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Визуализация VIVO Map of Science использует карту науки UCSD и систему классификации, которая была рассчитана на основе данных из приблизительно 25 000 журналов из Elsevier's Scopus и Clarivate Analytics's Web of Science (WoS) за 2001-2010 годы. Карта науки UCSD распределяет эти 25 000 журналов по 554 субдисциплинам, которые далее объединяются в 13 основных научных дисциплин. На карте каждая дисциплина имеет свой цвет (зеленый для \"Биологии\", коричневый для \"Наук о Земле\" и т.д.) и обозначение. (Под)дисциплины, которые похожи друг на друга, ближе друг к другу на карте. (Под)дисциплины, которые особенно похожи, соединены серыми линиями."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Наложение и изучение профилей специализации для организации. Цветовое кодирование по дисциплинам."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "организатор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменить дату публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для этого содержимого требуется Adobe Flash Player."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Данное лицо было успешно удалено со страницы организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы передали недопустимое значение для параметра отображения qrCode."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время мы кэшируем эти модели в памяти.  Кэш создается (только один раз) при первом запросе пользователя после перезапуска сервера.  Из-за этого одна и та же модель будет обслуживаться до следующего перезапуска. Это означает, что данные в этих моделях могут устаревать в зависимости от того, когда они были созданы в последний раз. Пока это работает достаточно хорошо. В будущих релизах мы улучшим это решение, чтобы модели хранились на диске и периодически обновлялись."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год присвоения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Задать дату публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "всего"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выступление"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Начальная страница"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная организация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "карта научных дисциплин"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Идентификатор PubMed ID"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о роли редактора для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись руководителя гранта для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "работа с населением и общественностью в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Управление списком публикаций для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Гранты с участием"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 связей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В системе не найдено публикаций, которые бы относились к данной организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная награда"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сравнивать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное издание"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ГГГГ"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите имя этого человека. "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Организации и люди"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для моей организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите хотя бы один внешний источник лексики для поиска."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт автора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Шаг 2 (рекомендуется): Свяжите свою запись ORCID с VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "награда или почетная грамота"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Хотите узнать больше о визуализации „Карты наук“ VIVO?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "научный сотрудник"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Переупорядочивание списка редакторов не удалось."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ни одна из"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "консультирование"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Почему это необходимо?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль провайдера аутрич-услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста посетите"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Число"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить это клиническое мероприятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "основной адрес электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы уверены, что хотите удалить этот термин?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип URL"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "значок URI"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создайте новый класс"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите значение в поле Вид материала."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Переупорядочивание списка авторов не удалось."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "убрать ссылку на автора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "кандидатура"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Диссертации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "верхнее фоновое изображение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работа с авторами"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "серия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "управляющая организация для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "тыс."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "При выполнении этого поискового запроса произошла ошибка."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить выбранное понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Текущий набор поисковых терминов"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR-код электронной визитной карточки vCard "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о занимаемых должностях"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 связи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Собственный класс для учреждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие преподаватели подразделения {0} интересуются данной областью исследований."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Перечисленные организации являются дочерними по отношению к узлу {0} в организационной иерархии. Вы можете \"„спуститься вниз“, чтобы увидеть организации, расположенные ниже данной подорганизации, выбрав значок диаграммы рядом с названием выбранной подорганизации под графиком справа."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Чтобы использовать эту возможность, пожалуйста, определите значение для этого свойства, которое указывает на каталог установки Подборщика прежде, чем переустановить и перезапустить приложение."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "очистить поисковый запрос"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Гиперссылка"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Карта научных дисциплин"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "имя редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "и пользователю веб-сервера разрешён доступ к нему для чтения и записи."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "или введите нового."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Визуализация \"Карта науки\" VIVO отображает тематический опыт университета, организации или человека на основе прошлых публикаций, загруженных в VIVO. Здесь показан профиль специализации {0} — более крупные круги обозначают большее количество публикаций по данной тематической области."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Щёлкните, чтобы просмотреть страницу {0}"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Почтовый индекс"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль „руководитель“"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Найти"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "например, модератор, докладчик, руководитель секции"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Проверьте это совпадение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Статья"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Раскрыть"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите значение в поле Номер факса."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный материал"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент не найдено грантов {0}  у"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактировать веб-страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Осталось {0} идентификаторов"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не удалось сопоставить с местоположением на карте, на основе информации из их журнала."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "публикаций"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Информация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать анкету данной персоны"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Номер"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста введите значение в поле Желательное обращение."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Локальные онтологии пока не определены."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год окончания"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не задан редактор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сохранить все в формате CSV"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Гранты за год"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вид организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 связи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "приписываемых ему публикаций"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль поставщика аутрич-услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная предметная область"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Поисковые термины"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись исполнителя гранта для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузить файл(ы)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Найти и раскрыть"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите существующую публикацию в поле Название или введите новую."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Визуализация карты науки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать метки групп"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Экспортировать QR-код"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ссылки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не можете найти нужное Вам понятие? Выберите или создайте понятие, задаваемое в системе VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "новая локальная онтология"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год выдачи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль преподавателя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Коллекция или серия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В приведенной ниже таблице обобщены публикации, нанесенные на Карту наук. Каждая строка соответствует (под)дисциплине на карте."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите значение в поле „Название должности“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не указан диплом"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие персоны в <a href=\"{1}\">{0}</a> интересуются данным исследованием."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменяйте порядок перечисления авторов перетаскиванием"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "участие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сохранить не отображенные  на карте публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Номер телефона"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время не определено ни одного понятия."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Годы участия в гранте"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "группа"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие персоны в <a href=\"{1}\">{0}</a> интересуются данной областью исследований."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикации в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название материала"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить автора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "дата публикации для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Научные подразделения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить веб-страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Информация в следующих таблицах представлена за все годы."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться на страницу анкеты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не хватает презентации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Вы отклонили запрос VIVO на ознакомление с вашей записью ORCID.</p><p>Подтверждение не может быть продолжено.</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите хотя бы один термин из результатов поиска."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загружаем данные преподавателя . . ."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт персоны в этой должности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта информация основана исключительно на {0}, которые были загружены в систему VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не была „научно локализована“"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Скачать Flash"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "У вас нет полномочий заявлять о правах от имени этого пользователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Меняйте порядок перечисления веб-страниц перетаскиванием"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Посмотреть полную хронологию и сеть соавторов."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "связь"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка при обработке запроса: редактор не удален"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Соответствующих областей науки не найдено"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "имя персоны"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не хватает мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка: Не указано задание на сборку файлов, или указано неизвестное задание."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выпуск"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "было"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выберите существующую организацию или создайте новую."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Постройте карту возможностей ‘в первом приближении’, введя поисковый термин или набор терминов, предположительно характеризующий целое поле исследований."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Глобальное исследование"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикации по годам"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка при обработке запроса: автор не удален"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, проверьте, что это именно те работы, права на которые вы хотите заявить, и укажите ваше отношение к ним."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вид преподавательской деятельности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Заявить о публикациях"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Очистить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этап 1"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Щёлкните здесь, чтобы просмотреть других людей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "данный автор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "руководство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Что кэшируется?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO перенаправляет Вас на сайт ORCID</li><li>Вы информируете ORCID, что VIVO может добавить „внешний ID“ к вашей записи ORCID.</li><li>VIVO добавляет внешний ID.</li></ul>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать все..."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "номер факса для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Страна"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Глава"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "с такими же интересами."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просмотрите свою запись в ORCID."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этап 2"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Локальное пространство имен"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип анкеты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Исследования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Что вы хотите сравнивать?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Основная справочная карта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% деятельности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Опубликовано в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "субдисциплины"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "возможность"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "была „научно локализована“"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное издательство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать всех преподавателей, интересующихся данной областью исследований."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "новую онтологию"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "редактировать ссылку на веб-страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ваша запись в ORCID уже содержит ссылку на VIVO.</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль преподавателя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название награды или почетной грамоты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "области исследований"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не указан грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В этом научном подразделении нет действующих грантов."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Люди"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Карта может быть исследована на двух уровнях — по 13 дисциплинам или 554 субдисциплинам. При нажатии на вершину графа на карте отображается количество частично связанных с этим узлом журнальных публикаций и процент публикаций, сопоставленных с этой (под)дисциплиной. Наведите курсор на дисциплину в таблице слева, чтобы увидеть, каким кругам она соответствует на карте. Используйте ползунок под картой справа, чтобы уменьшить количество отображаемых субдисциплин для улучшения читаемости."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите значение в поле Номер телефона."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Окончание,"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Если вы редактировали работу, выберите „Редактор“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное мероприятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Произошла ошибка, и сбор файлов не может быть продолжен."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Уровень Научная область"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "преподавательская деятельность,"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикация была успешно удалена со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название ссылки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы должны ввести значение в поле Имя."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Число публикаций"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этап 4"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип роли"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль рецензента"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменение значения отсечки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Здесь отображается информация об отдельных поисковых терминах и группах. Щелкните по названию группы, чтобы отобразить информацию о ней."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "дисциплины"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Внести данные"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Файл"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Колонка <b>% активности</b> показывает, какая доля публикаций была сопоставлена с каждой (под)дисциплиной."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись должностной истории для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить веб-страницу для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Представлено на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "со-исследователь"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись соруководителя гранта для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войдите в систему для добавления информации о ваших публикациях на странице вашего профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ред."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Префикс имени"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Очистить все выбранные сущности."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка обработки запроса: публикация не может быть удалена со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Конечная страница"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Глава"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ничего не найдено."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Охват публикаций в этой визуализации может быть улучшен путем включения большего количества данных о публикациях в систему VIVO и обеспечения того, чтобы каждая публикация в системе VIVO была связана с журналом, который Карта наук опознает (основываясь на сведениях из базы данных Web of Science компании Clarivate Analytics и базы данных Scopus компании Elsevier). Названия журналов, содержащие опечатки или другие особенности, возможно, придется очистить, прежде чем они будут распознаны. Вы можете обратиться к системному администратору VIVO, если вас не устраивает охват публикаций."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загруженные файлы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Управление грантами и проектами для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка при обработке запроса: не отмеченные метки не могут быть удалены."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Материалы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показывать только"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Субдисциплины"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Управление списком редакторов"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Свойство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Нажмите на кнопку, чтобы собрать ваш файл(ы)."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Исследовать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дополнительные функции"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить это участие в мероприятии"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "под управлением"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "На этой панели отображается список поисковых запросов, которые в настоящее время находятся на графике. Начните поиск."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Инструменты визуализации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Карта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная запись о консультировании"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный журнал"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Если вы не хотите заявлять права на произведение, выберите „Это не моя работа“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Запись в блоге"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Начало, "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ред."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Неизвестный тип ресурса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название факультета или учебного заведения в пределах"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Республика / Край / Область"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvester.location"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "соавторство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста введите значение в поле „Город / Населенный пункт“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Город / Населенный пункт"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Щёлкните для просмотра стандартной страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "адрес веб-страницы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название учреждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Журнальная статья"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "имя исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Желательное обращение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для добавления информации о ваших публикациях перейдите на страницу вашего профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "со-исследователи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в настоящее время обновляется. Визуализация будет загружена, как только мы закончим вычисления, или вы можете поискать или просмотреть другие данные в VIVO и вернуться к ним через несколько минут."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Годы участия в проекте"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Определение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "файл"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "представленные на карте"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Подобрать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "публикаций"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Колонка <b>% активности</b> показывает, какая доля публикаций была сопоставлена с каждой субдисциплиной."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Введите {0}:"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год начала"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "по публикациям"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пишите каждое слова с прописной буквы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Описание"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этап 5"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта информация основана только на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка консультанта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль в выступлении"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Гранты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста введите значение в поле „Страна“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Визуальные подсказки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Количество исследователей, найденных по каждому поисковому термину, ограничено максимальным значением, заданным в форме поиска (по умолчанию 10). Увеличение значения отсечки повышает вероятность пересечения результатов для различных поисковых терминов. Однако это также увеличивает сложность графа и может затруднить выявление закономерностей."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "которые были загружены в систему VIVO к "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выберите или создайте понятие, задаваемое в системе VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вид клинического мероприятия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Вы отклонили запрос VIVO на добавление внешнего идентификатора к вашей записи ORCID.</p><p>Связывание не может быть продолжено.</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "желательное обращение к"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт персоны в этой роли"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Введите или выберите значение в поле Название диплома."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "родительская сущность"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "конференция"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "уведомление об ошибке"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Примечание. Эта информация основана только на публикациях, которые известны системе. Это может быть только малой долей всех работ автора."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "содрудники этой организации, работающие в данной области исследований"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите фамилию этого человека."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время поддерживаются DOI, выданные Crossref, DataCite и mEDRA.<br />Они должны разделяться запятыми или символами перевода строки."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "свойство не определено в runtime.properties."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название презентации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль поставщика услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Приписываемая ему публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Соответствующих сущностей не найдено"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Легенда"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите или выберите значение в поле Название гранта."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Исследование в масштабах страны"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Можно сравнивать не более 10 объектов."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Используя информацию, кэшированную на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Место публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Упорядочите список редакторов перетаскиванием"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Подтвердить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для этой ссылки не задан URL"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данной организации следующие лица интересуются <a href=\"{1}\">{0}</a>."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "имя автора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работа с визуализацией"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Чтобы визуализация была понятнее, поисковые термины и группы масштабируются в зависимости от количества полученных результатов. Группам также присваиваются различные оттенки в зависимости от количества связанных с ними поисковых терминов. Чем темнее оттенок, тем больше поисковых терминов связано с группой."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип должности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "кем выдана"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вид исследовательской деятельности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Метка (альтернативные метки)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Независимая модель URI "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Отчество"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Заполните шаблон своими данными.  Вы можете заполнить несколько шаблонов, если хотите собрать несколько файлов одновременно."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "подразделение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "приостановить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "организация-посредник"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год окончания не может предшествовать году начала."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие кэшированные модели будут перестроены."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Лучшее соответствие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Назад"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Номер факса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы выбрали"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Годы включительно"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузить шаблон"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Музыкальная партитура"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "участие в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показанные выше графики, отражают гранты за последний полный календарный год. Однако в этих таблицах представлена информация о грантах за все годы, основанная на информации, загруженной в систему VIVO."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать почтовый адрес"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "адрес электронной почты для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Шаг 1: Дабавить ваш ORCID ID"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название диплома"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "неизвестная ошибка"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выступления"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Спасибо"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить это членство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о публикации для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(например, название диссертации, информация о переводе и т.д.)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Контакты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите существующее или введите новое значение в поле „Персона“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Чтобы включить эту опцию, необходимо сначала выбрать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Исследовать деятельность"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "С чего начать?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Нажав на любой узел визуализации, можно просмотреть дополнительную информацию на вкладке „Информация“ с правой стороны. Для исследовательских групп есть возможность просмотреть участников группы и информацию о них, отдельных исследователей можно удалить из графика. При выборе поискового запроса отображаются все связанные группы. По каждой группе представлена полная информация о найденных участниках, количестве соответствующих грантов и публикаций для каждого исследователя, представленного на построенной карте возможностей. Щёлкнув по имени исследователя, можно вернуться к исходным результатам поиска."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ни одна публикация в системе не была ему приписана"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "консультационные отношения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Том"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузка данных для "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "год (не указан выше)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Обратите внимание, что метаданные будут получены из Crossref, если PubMed ID может быть преобразован в DOI."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип диплома"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль Организатора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(например, для многолетних премий)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для вашего экземпляра класса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный автор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите значение в поле Имя."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Удалить выбранное"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Число грантов"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Записи _START_ - _END_ из _TOTAL_ "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выберите существующий класс"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Отчёт"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "не определена степень"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы уверены, что хотите удалить из списка этого редактора:"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Местное исследование"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Отметьте тех людей, которых вы хотите <em>убрать</em> со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "за последние 10 полных лет"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Грант(ы)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Экспортировать QR-коды"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Help"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Мероприятие,"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "лет"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "значок соавтора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Связанные научные подразделения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить автора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дата окончания"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "продолжить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста введите значение в поле „Улица, дом“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы точно хотите удалить этого автора:"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "за последние 10 лет"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Предметная область"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Совет: вы можете конкретизировать широкий поисковый термин через более узкие понятия, нажав ‘найти и раскрыть’. "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Информация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "почтовый адрес для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "гранты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите или введите значение в поле Название материала."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просмотреть результаты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста выберите тип отношений консультирования."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "сократить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "нет информации о журнале."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в runtime.properties указывает на каталог установки Подборщика."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "удалить ссылку на веб-страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год начала должен предшествовать году окончания."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать собственное понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы хотите добавить ORCID?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Развёртка временного графика"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать всех, кто интересуется этой областью исследований."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ссылка на Scopus ID"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Консультант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Суффикс имени"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Этап 3"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться к публикации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "опубликовано"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста выберите существующее значение или введите новое значение названия награды или знака почёта."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать метки дисциплин"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Персона"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "недостаёт источника информации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться на страницу профиля VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Автор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Понятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, укажите роль для этой деятельности."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "страница профиля"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "первичное одобрение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работа,"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Только администратору разрешено пользоваться этим инструментом."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Задать год награждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Введите область исследования в поле поиска выше и нажмите „Поиск“. Полученная диаграмма отображает поисковый запрос, выделенный оранжевым цветом, связанный с синей группой исследователей, работающих в этой области. Введите другой поисковый термин, чтобы увидеть, как связаны исследователи из обоих поисковых запросов. Продолжайте добавлять поисковые термины, чтобы построить карту возможностей."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Судебное дело"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "название наградного документа"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вид материала"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Преподаватель с 1000 связей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о выступлении для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранный редактор"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать всех в данной организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в текущий полный год (не указан выше)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Карта возможностей"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Перечислите только те (под)дисциплины, в названиях которых есть эти слова."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Подтвердите свою работу(ы)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изображение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "требуется новая фамилия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Соавтор(ы)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Веб страницы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль организатора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Фамилия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "no view link"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Родительская организация для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "неправильно введённая дата/временной интервал"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для детального обзора."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Ваша запись ORCID связана с VIVO</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую запись об участии в мероприятии"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "с известным годом"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Служба поиска"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Издательство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Продолжить. Шаг 2"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка консультанта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время нет документов по"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Со-исследователи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "назначено"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Основной адрес электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добро пожаловать в инструмент „Картирование возможностей“. Это средство представления в визуальной форме связей между исследователями, обнаруживаемых при помощи поисковых запросов. "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Обновление кэшированных моделей для визуализации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Присвоено"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать краткую анкету"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Информация об исследованиях не найдена."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в текущем неполном году"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить новую веб-страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "с неизвестным годом"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Невозможно получить данные о цитировании"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Письмо в редакцию"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "дисциплин"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "за более подробным обзором."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "организации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "мероприятие"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузить данные в виде"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Карта сравнения профилей специализации"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO не удалось прочитать Вашу запись ORCID.</p><p>Подтверждение не может быть продолжено.</p>"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редакторы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Отметьте те публикации, которые вы хотите <em>убрать</em> со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Максимальное количество элементов для сравнения – 3."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменить год награждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую роль исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Продолжить. Шаг 1"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Название доклада"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите существующее значение или введите новое значение в поле Имя."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Показать полную анкету"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "сеть участников исследования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "исследовательская деятельность"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "кандидат"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "работа с населением и общественностью"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Аффилированные области исследований"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы можете ввести один или несколько идентификаторов PubMed ID для сопоставления. Идентификаторы должны разделяться запятой или символом перевода строки."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о консультировании для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Управление перечнем людей, аффилированных с"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Изменить эту роль исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Понятие (тип)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Закрыть"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работа с понятиями"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикационная деятельность университета, организации или человека может быть наложена на карту для создания профилей специализации. Процесс происходит следующим образом: (1) определяется набор уникальных журналов, (2) подсчитывается количество раз, когда каждый журнал служил местом публикации, и (3) на основе этих подсчетов мест публикации журналов рассчитывается площадь 13 дисциплин и 554 поддисциплин. Обратите внимание, что некоторые журналы связаны ровно с одной (под)дисциплиной, в то время как другие, например, междисциплинарные журналы, такие как <em>Science</em> или <em>Nature</em>, частично связаны с несколькими (под)дисциплинами. Субдисциплины наследуют цвета своих родительских дисциплин. (Под)дисциплины, не имеющие связанных с ними публикаций, выделены серым цветом."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль в учреждении"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "деятельности"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "из максимального числа"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новое членство"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, обратитесь к полной версии"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Это не моя работа"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Данные"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Год награждения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись о взаимоотношениях с консультантом для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сеть участников исследования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Колонка <b>колич. публ.</b> показывает, сколько публикаций было сопоставлено с каждой (под)дисциплиной.Этот подсчет может быть дробным, поскольку некоторые места публикации связаны с более чем одной (под)дисциплиной. Каждая публикация в таком месте вносит дробный вклад во все связанные (под)дисциплины в соответствии со схемой взвешивания."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "поделиться URI"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "значок карты науки"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "удалить ссылку редактора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Электронная почта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Преподаватель"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "значок со-исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "данного исследователя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться к работе с понятиями"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "дипломы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "кому выдана"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сохранить изменения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "правильно сконфигурирован и содержит необходимую информацию о вашей базе данных и пространстве имен"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Больше не осталось работ, на которые можно претендовать.<br />Вы можете ввести другие идентификаторы ниже или просмотреть свой профиль."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Действующие гранты в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Степень"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эти показатели основаны исключительно на публикациях, которые были загружены в данное приложение VIVO. Если это ваш профиль, вы можете ввести дополнительные публикации ниже."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Наложение и изучение профилей специализации для одной или нескольких организаций. Цветовое кодирование по организациям."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Модели обновляются при каждом перезапуске сервера.  Поскольку на производственных экземплярах это обычно нецелесообразно, администраторы могут использовать ссылку „Обновить кэш“ выше, чтобы сделать это без перезапуска."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, выберите тип из выпадающего списка."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Сеть соавторства"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пиктограмма просмотра краткого варианта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Возврат к меню Инструменты ввода данных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для этого объекта пока не указаны веб-страницы. Добавьте новую веб-страницу, нажав на кнопку ниже."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Публикации до сегодняшней даты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Добавить новую клиническую деятельность"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ссылка для скачиывания"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ондновременно можно сравнивать до 10 объектов. Пожалуйста удалите какие-нибудь объекты и попробуйте заново."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Крупномасштабные визуализации, такие как Временной график или Карта науки, предполагают подсчет общего количества публикаций или грантов для некоторого объекта. Поскольку это также означает проверку всех его подсубъектов, базовые запросы могут занимать много памяти и времени. Для ускорения работы пользователей мы хотим сохранить результаты этих запросов для последующего повторного использования."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Шаг 1: Добавление вашего ORCID"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "в системе."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Наложение данных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Перейти к профилю"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Таблицы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузка информации о карте..."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать все исследования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работа с картой"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Записать идентификаторы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Со-исследователи"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Собственный класс учреждени"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Области исследования, в которых работает данный преподаватель"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Для этого мы разработали кэширующее решение, которое сохраняет информацию об иерархии организаций, а именно, какие публикации приписываются каким организациям, в виде RDF-модели."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пиктограмма просмотра полного вариант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Если вы являетесь автором произведения, выберите свое имя в списке авторов.<br />Полученные метаданные могут быть неполными. Если вы не видите своего имени в списке, выберите „Неуказанный автор“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Последняя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "автор не указан"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, подождите, пока ваши данные будут собраны."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ошибка обработки запроса: элемент не может быть удалён со страницы профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Что это такое?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(шаг выполнен)."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В Подборщике VIVO есть каталог"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Щёлкните для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранные дипломы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "номер телефона для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Постоянная ссылка на текущую визуализацию"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Цифровой идентификатор объекта (DOI)"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Число публикаций"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы уверены, что хотите удалить упоминание об этой веб-странице?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вы хотите добавить ORCID?"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Источник словаря"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Рукопись"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "быстрого просмотра профиля."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "предоставлен"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранное лицо"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Учёная степень"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Меню"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать новый объект"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Условия использования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Невозможно отредактировать описание этой должности при помощи данной формы, поскольку оно связано одновременно с несколькими лицами с такой Должностью."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Фамилия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Имя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Тип гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просмотреть всех сотрудников этой организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ещё"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактировать почтовый адрес"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Первая публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не найдено сотрудников факультетов."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Мой профиль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работает под управлением"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Это содержимое берется из файла шаблона vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  В модели отображения, страница грантов имеет свойство display:requiresBodyTemplate свойство, которое определяет, что страница грантов переопределяет шаблон по умолчанию. Шаблон по умолчанию для этих страниц находится в /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | связывайтесь, делитесь, ищите"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "научные сотрудники"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Каталог"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "профиль VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выйти"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать запись"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "стандартное изображение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Первый грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Слушатель"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "штат."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "О системе"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта техника может быть использована для определения страниц без пунктов меню, которые получают свое содержание из шаблона freemarker.  Примером может быть страница „О системе“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль поставщика услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Профиль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Адрес электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "места в пределах штата."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ограничить область поиска"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Область или регион"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "авторское право"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Место предоставления гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "страны"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактировать страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите новое значение в поле „Роль“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Версия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Последний грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент не найдено грантов у "@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса 1"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "штаты."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузка изображения сайта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Поиск с фильтрами"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пользователь"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Невозможно отредактировать описание этого гранта при помощи данной формы, поскольку оно связано одновременно с несколькими участниками гранта."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент в системе не зарегистрированы учёные из интересующего Вас географического региона."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать все научные подразделения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вид"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "регионы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль организатора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Администратор сайта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Поддержка"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "научные сотрудники в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Принадлежность к преподавательскому составу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Последняя публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пункт меню"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войдите, чтобы работать с сайтом"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "страны и регионы."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль рецензента"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не найдено научных подразделений."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться к гранту"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись по гранту для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Искать в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса 3"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка адреса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменить выбранное"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие преподаватели кафедры {0} являются сотрудниками этой организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "гранты в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль руководителя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент не найдено публикаций {0} у"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добро пожаловать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добро пожаловать в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Таким образом, будет создана страница, использующая в качестве основы файл about.ftl. Страница будет доступна через /about и она будет переопределять все сопоставления сервлетов в web.xml."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "сотрудников кафедры, ведущих исследования в данной области"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Связаться с нами"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пароль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO это система для поиска информации о научных исследованиях, облегчающая междисциплинарное сотрудничество учёных."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Коллекция"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "строка адреса 2"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбранная награда"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "загрузка данных"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вернуться к"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войти"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дата предоставления гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просматривайте или ищите информацию о персонах, подразделениях, курсах, грантах и публикациях."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Моя учетная запись"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Полное имя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Годы участия в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать все факультеты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Поиск с фильтрами"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль руководителя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вид"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Место предоставления гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выбор награды"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль поставщика услуг"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Имя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Связаться с нами"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса 3"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль рецензента"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Условия использования"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "This form is unable to handle the editing of this position because it is associated with multiple Position individuals."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Посетитель"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "стандартное изображение"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пользователь"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Последняя публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "пароль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта форма не может обработать редактирование данного гранта, так как он связан с несколькими лицами гранта."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "страны и регионы."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Выйти"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактировать страницу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "на"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "тип гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Моя учетная запись"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не найдено сотрудников факультетов."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "места в пределах штата."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Область или регион"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Поддержка"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "научные сотрудники в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Фамилия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добавить"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просматривайте или ищите информацию о персонах, подразделениях, курсах, грантах и публикациях."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "запись по гранту для"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | связывайтесь, делитесь, ищите"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Профиль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Изменить выбранное"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Принадлежность к преподавательскому составу"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать новый объект"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Администрирование"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Коллекция"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "страны"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войдите, чтобы работать с сайтом"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать все научные подразделения"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Мой профиль"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "штат."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Таким образом, будет создана страница, использующая в качестве основы файл about.ftl. Страница будет доступна через /about и она будет переопределять все сопоставления сервлетов в web.xml."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Работает под управлением"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Просмотреть всех членов этой организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Адрес электронной почты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "показать все факультеты"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Пожалуйста, введите новое значение в поле „Роль“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "вернуться к"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Редактировать почтовый адрес"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Годы участия в"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добро пожаловать"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Дата предоставления гранта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "метка адреса"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Первая публикация"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Следующие преподаватели кафедры {0} являются сотрудниками этой организации."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ограничить область поиска"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Полное имя"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Версия"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Каталог"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент в системе не зарегистрированы учёные из интересующего Вас географического региона."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Искать в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "авторское право"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Не найдено научных подразделений."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Загрузка изображения сайта"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Последний грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Это содержимое взято из файла шаблона vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  В модели отображения, страница грантов имеет свойство display:requiresBodyTemplate свойство, которое определяет, что страница грантов переопределяет шаблон по умолчанию. Шаблон по умолчанию для этих страниц находится в /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В настоящее время не найдено информации о грантах у"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "штаты."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Первый грант"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "гранты в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "регионы"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ещё"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "загружаются данные"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Эта техника может быть использована для определения страниц без пунктов меню, которые получают свое содержание из шаблона freemarker.  Примером может быть страница „О системе“."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Создать запись"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Роль организатора"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса 1"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO это система для поиска информации о научных исследованиях, облегчающая междисциплинарное сотрудничество учёных."@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "О системе"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Строка адреса 2"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "профиль VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "сотрудников кафедры, ведущих исследования в данной области"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "В данный момент не найдено публикаций {0} у"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "научные сотрудники"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Войти"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Добро пожаловать в VIVO"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Вернуться к гранту"@ru-RU ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS.ttl
@@ -1,0 +1,6267 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:error_excluding_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: osoba ne može biti uklonjean sa stranice organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana konferencija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova organizacije nema ni pod-organizacije ni ljude sa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite samo organizacije čije ime sadrži ovaj tekst."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip edukativnog treninga"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u poslednjih 10 kalendarskih"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_reset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Restartovati"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_reset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv veb stranice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant-ovi na godišnjem nivou"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "direktorijumu i svom sadržaju istog."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "služenje struci"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_constructed_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno ne postoje konstruisani modeli za vizualizaciju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_constructed_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_completed_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u okviru čitave godine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_completed_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_type_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite vrednost za polje Tip Pozicije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_type_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poredite organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_name_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "puno ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ostali Email-ovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:namespace_must_use_this_pattern.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da bi lokalna ontologija ovde bila prepoznata, URI njenog imenskog prostora (namespace URI) mora da prati sledeći šablon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "namespace_must_use_this_pattern" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_claim_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Polaganje prava na<br />{0}"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_claim_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:count_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "count_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nepotpuna vrednost za datum i vreme"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:service_to_profession_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "služenje struci u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_to_profession_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_next_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sledeći"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_next_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resource_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv resursa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resource_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_grants_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selektujte one grantove i projekte koje želite da <em>izostavite</em> sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_grants_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost u polje za Poštanski broj."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unutar VIVO Prikupljača, fajl"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:how_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kako želite da poredite?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "how_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:major_field.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Glavna oblast za diplomu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "major_field" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prijavite se kako bi ste uneli dodatne informacije o Vašim grantovima."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutions_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institucije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutions_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pregledajte sve grantove"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:more_qr_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Više informacija o QR kodovima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "more_qr_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv pozicije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_webpage_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica kliknite na veb stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_webpage_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_educational_training_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite vrednost za polje Tip edukativnog treninga."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_educational_training_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_role_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "npr. instruktor, profesor, asistent"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_role_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv koncepta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kadidat"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "koautor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv nagrade"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR Kod"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istraživač"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Za više informacija o UCSD naučnoj mapi i njihovom klasifikacionom sistemu, pogledajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_complete.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikupljanje završeno. Za još jedno, molimo Vas da ponovo učitate stranicu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_complete" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tip događaja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Možete uneti jedan ili više DOI-a za pretragu, i možete ih uneti ili kao ID ili kao URL:<br /><br />npr."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_email_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite email adresu u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_email_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uzrok ovoga je najverovatnije nepravilno podešavanje za prikupljanje fajlova. Molimo Vas da proverite sledeće:"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nema povezanik urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:level_undefined_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "GREŠKA - NIVO ENTITETA NIJE DEFINISAN"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "level_undefined_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ne možete da pronađete odgovarajuću klasu?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jedinstvenih ko-istražitelja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_hierarchy_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napomena: ispod su navedeni samo one organizacije i ljudi koji se nalaze direktno ispod {0} unutar organizacione hierarhije. Možete da idete na dole (\"dril down\") kako bi ste videli organizacije i ljude ispod date pod-organizacije tako što ćete izabrati ikonicu grafikona pored naziva odabrane pod-organizacije,ispod grafikona sa desne strane."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_hierarchy_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_group.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uklonite grupu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_group" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_web_pages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte veb stranicema"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_web_pages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preuzmite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nepoznat profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:probably_a_bug_so_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Krajnji korisnik ne bi trebalo da vidi ovu grešku u normalnim okolnostima, te je ovo verovatno greška i treba da je prijavite."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "probably_a_bug_so_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirmed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Vaš ORCID iD je potvrđen kao {0}</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirmed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da je VIVO Prikupljač instaliran."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_capability.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uklonite sposobnost"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_capability" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:across_subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u okviru 554 naučne poddiscipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "across_subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_timeline_copi_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pogledajte potpunu mrežu ko-istražitelja i vremensku liniju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_timeline_copi_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Idite na Vašu profilnu stranicu kako bi ste uneli dodatne informacije o Vašim grantovima."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "klinička aktivnost"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:about_map_of_science_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O VIVO-ovoj vizualizaciji \"Naučne Mape\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "about_map_of_science_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koautori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip Prezentacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:external_vocabulary_services.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Eksterni servisi rečnika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "external_vocabulary_services" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO nije uspeo da doda Eksterni ID u Vaš ORCID sadržaj.</p> <p>Nije moguće nastaviti sa povezivanjem</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_term_not_deleted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: izraz nije uklonjen"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_term_not_deleted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_description_the_introduction_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Za druge naučne mape, pogledajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_description_the_introduction_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ulogu \"šef\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vremenski grafikon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total_number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ukupan broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total_number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Stavka je uspešno uklonjena sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "koautori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_patent.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Patent"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_patent" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hide_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sakrijte labele grupa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hide_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<b>'Broj publikacija'</b> kolona prikazuje koliko publikacija je mapirano na svako od (pod)disciplina. Ovaj broj ne mora biti ceo, s obzirom da su neke publikacije povezane sa više (pod)disciplina. Takve publikacije ne doprinose ceo broj ukupnom broju publikacija date discipline, već samo razlomak na osnovu težinske šeme."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Urednik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_dataset.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Set podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_dataset" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:phone.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "telefon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "phone" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodaj novog davaoda usluge"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fourA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unutar VIVO Prikupljača, korisnik veb servera (uglavnom tomcat) ima pravo pristupa pisanja i čitanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fourA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela savetnika\t"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Knjiga"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "QR Kod"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:title_not_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Titula nije pronađena."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "title_not_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodatne informacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:additional_emails.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ostali email-ovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "additional_emails" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:geographic_focus.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Geografski fokus"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "geographic_focus" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_grant_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napomena: Ove informacije se zasnivaju isključivo na publikacijama koje se nalaze unutar VIVO sistema. Ovo je možda samo mali podskup ukupnih radova neke osobe."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_grant_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_an_organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite ili odaberite vrednost unutar polja za Ime."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_an_organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova vizuelizacija je zasnovana na publikacijama koje smo mogli da nađemo za {0}, i zbog toga možda ne predstavlja u potpunosti sve publikacije za {0}."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_already_claimed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Več ste položili autorska prava na ovaj rad."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_already_claimed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_conferred.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran poverilac"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_conferred" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reviewer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "recenzent za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv granta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_completed_templates.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otpremite Vaše popunjene šablone."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_completed_templates" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:problematic_section_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška: problematična sekcija, kao što je gore navedena, je trebalo već da bude rešene."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "problematic_section_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_review.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Recenzija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_review" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite sve aktivne grantove"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:screenshot_of_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "slika veb stranice {0}"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "screenshot_of_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:script_executed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Skripta se izvršava"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "script_executed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unlisted_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nenaveden autor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unlisted_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:attended.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prisustvovali"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attended" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Morate uneti prezime u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:qr_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "qr ikonica"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "qr_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Labela (Tip)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_here_to_define_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "i zatim se vratite ovde da definišete unutrašnje klase institucije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_here_to_define_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coinvestigators_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jedinstvenih ko-istražitelja po godini"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coinvestigators_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte novu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost unutar polja za Tip organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Meni za unos podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:progress_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napredak"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "progress_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moguće je porediti publikacje dve ili tri organizacije/osobe koristeći funkcionalnost \"Poredite organizacije.\" U tablei sa leve strane odaberite do 3 organizacije. Profili ekspertiza odabranih organizacija biće predstavljeni na istoj naučnoj mapi. Svaka organizacija će biti predstavljena zasebnom bojom, a lista od po 10 poddisciplina iz kojih organizacije imaju najviše publikacija će se nalaziti ispod mape. Podaci mogu biti sačuvani kao CSV fajl."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datum objavljivanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tip organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip odnosa mentora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veb stranica"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontakt Informacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_figure.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Slika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_figure" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant kojim upravlja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uloga urednika za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana prezantacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova klasa će se koristiti za određivanje pojedinaca unutar Vaše institucije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:schools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "škola"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "schools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_first_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prvi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_first_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_reordering_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Promena redosleda veb stranica nije uspela."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_reordering_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:malformed_last_name_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Polje za prezime ne sve da sadrži zarez. Molimo Vas unesite ime u polje za ime."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "malformed_last_name_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO Vas preusmerava na ORCID-ov veb sajt.</li> <li>Ulogujete se na Vaš ORCID nalog. <ul class=\"inner\"><li>Ako nemate nalog, možete ga kreirati.</li></ul></li> <li>Napomenite ORCID-u da će VIVO možda čitati vaš ORCID sadržaj.</li> <li>VIVO pristupa vašem ORCID zapisu.</li> <li>VIVO beleži da je Vaš ORCID iD proveren i potvrđen.</li></ul>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class_intro_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo će Vam omogućiti da ograničite (filtrirate) pojedince koji se prikazuju na Vašim meni-stranicama (Ljudi, Istraživanja, itd.) na samo one koji su deo vaše institucije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class_intro_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_series_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ulogu urednika za kolekciju ili niz"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_series_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_thesis.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Teza"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_thesis" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "od"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:educational_training_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "edukativni trening za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "educational_training_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_grants_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pregledaje sve VIVO grantove i njihovu odgovarajuću mrežu istražitelja."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_grants_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:unique_coauthors_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Jedinstvenih koautora po godini"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unique_coauthors_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "od"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refreshing_data_message.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "se trenutno osvežavaju. Vizualizacije će biti prikazana čim se završi proračunavanje, možete da pretražujete ostale podatke unutar VIVO-a, i da se vratite na ovu stranicu za nekoliko minuta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refreshing_data_message" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv događaja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_doi.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "DOI"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_doi" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu ulogu recenzenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tekst linka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran savetnik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_the_vivo_db.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unutar VIVO baze podataka."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_the_vivo_db" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:term_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izraz"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "term_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela događaja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:networks.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mreže"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "networks" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publikacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zatvorite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "po grantovima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_removing_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: veb stranica ne može biti uklonjena."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_removing_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip entiteta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legislation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zakon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legislation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_paper_conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Konferencijski rad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_paper_conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vremenski grafikon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Labela entiteta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vcard"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_orcid_id.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte ID"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_orcid_id" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO-ova vizualizacije Naučne Mape koristi UCSD naučnu mapu i klasifikacioni sistem koji je kreiran uz pomoć papirnih podataka iz oko 25,000 primeraka časopisa \"Elsevier's Scopus\" i \"Clarivate Analytics' Web of Science (WoS)\" između 2001. i 2010.godine. UCSD naučna mapa grupiše 25,000 časopisa u 554 poddiscipline koje se dalje sumiraju u 13 glavnih naučnih disciplina. Unutar mape, svaka disciplina ima zasebnu boju (zelena za \"Biologiju\", braon za \"Nauke o Zemlju\" itd.) i labelu. (Pod)discipline koje su slične se nalaze bliže jedna drugoj na mapi. (Pod)discpline koje su posebno slične su povezane sivom linijom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_tool_tip_text.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istražite profile ekspertiza za jednu ili više organizacija. Boje su podeljene po disciplinama."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_tool_tip_text" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizer_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizator"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ažurirajte datum izdavanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:content_requires_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovaj sadržaj zahteva Adobe Flash Player."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "content_requires_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Osoba je uspešno uklonjena sa stranice organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:invalid_qr_code_parameter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uneli ste neispravnu vrednost parametra za prikaz \"qrCode\"-a."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "invalid_qr_code_parameter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno ove modele keširamo u memoriji. Keš se kreira (samo jednom) prilikom prvog zahteva korisnika nakon restarta servera. Zbog ovog će se koristiti isti model sve dok se server ne restartuje, što znači da podaci u modelu možda neće biti konzistentni u zavisnosti od toga kada su kreirani. Ovo funkcioniše dovoljno dobro za sada. U narednim verzijama aplikacije ćemo unaprediti ovo rešenje tako da se modeli čuvaju na disku i periodično periodično osvežavaju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodeljeno godine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_publication_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte datum izdavanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_publication_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ukupno"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_speech.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Govor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_speech" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Početna strana"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrane organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naučna mreža"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by_pmid.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "\"PubMed\" ID"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by_pmid" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_of_entry.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "urednik unosa za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_of_entry" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unos rukovodioca istraživanja za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip publikacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "društveno koristan rad za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_publications_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte publikacijama za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grantovi sa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ">=4 linka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_publications_for_this_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ni jedna publikacija unutar sistema nije prepisana ovoj organizaciji"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_publications_for_this_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_award.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana nagrada"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_award" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:comparing_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upoređivanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "comparing_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_book.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana knjiga"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_book" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_hint_format.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "YYYY"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_hint_format" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_first_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite ime ove osobe."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_first_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_and_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizacije i ljudi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_and_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_my_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unutar moje institucije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_my_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_vocabulary_source_to_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite makar jedan eksterni izvor rečnika nad kojim će se izvršiti pretraga."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_vocabulary_source_to_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autor nedostaje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 2 (preporučuje se): Povezivanje ORCID sadržaja sa VIVO-om"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_or_honor_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nagrada ili priznanje za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_or_honor_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_learn_more.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pročitajte više o 'Map of Science' vizuelizaciji?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_learn_more" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "istraživač"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_editors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Promena redosleda urednike nije uspela."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_editors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:none_of_the.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ni jedan "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "none_of_the" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "savetovanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:why_needed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zašto je to potrebno?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "why_needed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu PR menadžera"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_visit.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas pogledajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_visit" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu kliničku aktivnost"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "primarni email"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_term_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da li ste sigurni da želite da uklonite ovaj izraz?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_term_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:url_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URL tip"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "url_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_editor_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodaj novu ulogu urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_editor_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uri ikonica"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_new_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte novu klasu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_new_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_document_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite vrednost za tip dokumenta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_document_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reordering_authors_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Promena redosleda autora nije uspela."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reordering_authors_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_author_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uklonite vezu ka autoru"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_author_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kandidatura"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidacy" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:theses_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Teza"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "theses_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:background_top_image.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "gornja slika pozadine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "background_top_image" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte autorima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "serijal"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administering_organization_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "administrira organizaciju za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administering_organization_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:thousands_short.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "k"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "thousands_short" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_service_unavailable.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Došlo je do greške tokom pretrage."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_service_unavailable" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte odabrane koncepte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_cur_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutni izrazi pretrage"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_cur_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vcard_qr.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vCard QR"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vcard_qr" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos pozicije za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "3 linka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institutional_internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Institucionalna unutrašnja klasa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institutional_internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_with_researh_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo su članovi zaposleni sa {0} departmana koji su zainteresovani za ovu istraživačku oblast."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_with_researh_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Adresa ulice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikazane organizacije su pod-čvorovi {0} čvora unutar organizacione hijerarhije. Možeze prikazati više informacija o organizacijama koje se nalaze ispod neke druge pod-organizacije tako što ćete kliknuti na ikonicu pored imane odabrane pod-discipline, što se nalaze ispod grafa, sa desne strane."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:define_value_for_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da bi ste videli ovu funkcionalnost, molimo Vas da definišete vrednost za svojstvo koje ima putanju ka direktorijumu gde je instaliran Prikupljač pre nego što restartujete i ponovo pokrenete aplikaciju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "define_value_for_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_search_query.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "očistite upit pretrage"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_search_query" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:hyperlink.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hiperlink"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "hyperlink" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naučna mreža"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "direktoriju postoji, i korisnik veb servera ima pravo pristupa za čitanje i pisanje u okviru tog direktorijuma."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:or_add_new_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ili dodajte novog."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "or_add_new_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO vizuelizacija 'Map of Science' predstavlja ekspertize određenog univerziteta, organizacije ili osobe, zasnovano na publikacijama koje se nalaze u VIVO sistemu. Ovde je prikazan profil ekspertiza za {0} -- veći krugovi predstavljaju više publikacija u datoj oblasti."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_view_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kliknite kako bi ste prešli na {0} veb stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_view_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:postal_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poštanski broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "postal_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_head_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu ulogu \"šefa\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_head_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pretražite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "npr. Moderator, Govornik, Panelista"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:verify_match_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Proverite i potvrdite ovo podudaranje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "verify_match_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Članak"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Proširite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo vas unesite faks broj u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_document.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrani dokument"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_document" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:currently_no_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema {0} grant-ova za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_wbpage_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ažurirajte veb stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_wbpage_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_remaining.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ima još {0} preostalig id-eva"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_remaining" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_map_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nije moguće spojiti sa lokacijom na mapi koristeći informacije o časopisu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_map_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publikacije (pubs.)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Info"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_info" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_this_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite profil ove osobe"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_this_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:number_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "number_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite željenu titulu u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_local_oncologies.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema prepoznatljivih lokalnih ontologija."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_local_oncologies" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kraj godine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaje editor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_all_as_csv.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sačuvajte sve kao CSV"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_all_as_csv" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grantovi po godini"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:org_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "org_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "2 linka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rad ne doprinosi ovome"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_outreach_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodaj novou ulogu PR Menadžera"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_outreach_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana oblast predmeta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_terms.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izrazi pretrage"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_terms" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istraživački unos za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otpremite fajl(ove)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_search_expand.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pretražite i proširite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_search_expand" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "logs/"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_pub_or_enter_new.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas da odaberete postojeću publikaciju u polju za Naslov ili unesite novu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_pub_or_enter_new" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vizualizacije naučne mape"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte koncept"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_group_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prikažite labele grupa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_group_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_code.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izvezite QR kod"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_code" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:links_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Linkovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "links_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cannot_find_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ne možete da pronađete koncept koji Vam je potreban? Kreirajte koncept u VIVO sistemu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cannot_find_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_ontology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nova lokalna ontologija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_ontology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_issued.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina izdavanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_issued" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu ulogu nastavnika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:collection_or_series.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kolekcija ili serija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aktivnost nedostaje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tabela ispod prikazuje publikacije predstavljene na 'Map of Science' grafu. Svaki red odgovara jednoj (pod)disciplini na mapi."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_posn_title_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost u polje za Naziv Pozicije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_posn_title_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaju kredencijali"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo su pojedinci u <a href=\"{1}\">{0}</a> koji su zainteresovani za datu istraživačku oblast."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_authors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prevucite na drugo mesto da bi ste promenili redosled autora."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_authors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "članstvo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_unmapped_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sačiuvajte publikacije koje nisu mapirane"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_unmapped_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Telefonski broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_concepts_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno ni jedan koncept nije specificiran."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_concepts_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_of_grant_participation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godine primanja granta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_of_grant_participation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grupa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_researh_area_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo su pojedinci u <a href=\"{1}\">{0}</a> koji su zainteresovani za datu istraživačku oblast."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_researh_area_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikacije unutar VIVO-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv dokumenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte autora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publikacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_date_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "datum izdavanja za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_date_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departmani"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte veb stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_info_for_all_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informacije koje se nalaze u tabeli se odnose na sve godine."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_info_for_all_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na profilnu stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_presentation.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prezentacija nedostaje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_presentation" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Urednik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Odbili ste zahtev VIVO-a da pristupi vašem ORCID zapsu.</p> <p>Nije moguće nastaviti sa procesom potvrde.</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_term_from_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite barem jedan izraz iz rezultata pretrage."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_term_from_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_faculty.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Učitava se fakultet . . ."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_faculty" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_posn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaje osoba na datoj poziciji"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_posn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:info_based_on_vivo_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ove informacije se zasnivaju isključivo na {0} koje su učitane u VIVO sistem."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "info_based_on_vivo_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:not_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nije \"naučno-lociran.\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "not_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:get_flash.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nabavite Flash"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "get_flash" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unauthorized_for_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nemate pravo potvrde za ovog korisnika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unauthorized_for_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_to_reorder_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prevucite stavku na drugu poziciju kako bi ste promenilči redosled veb stranica"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_to_reorder_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_full_timeline_and_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pogledajte potpunu mrežu koautora i vremensku liniju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_full_timeline_and_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_editor_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: urednik nije uklonjen"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_editor_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_science_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije pronađena naučna objast koja se podudara sa pretragom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_science_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv osobe"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "događaj nedostaje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_no_job_specified.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška: Niste naveli zadatak za prikupljanje fajlova, ili ste naveli nepoznat zadatak."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_no_job_specified" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:issue_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izdanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "issue_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:were.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "su"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "were" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_create_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odaberite postojeću organizaciju ili kreirajte novu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_create_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izgradite mapu sposobnosti iz &lsquo;prvog prolaza&rsquo; tako što ćete uneti<!-- set of--> izraz za pretragu<!--s--> koji može da predstavlja široko polje istraživačkih mogućnosti."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:global_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Globalno istraživanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "global_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_per_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Radovi po godini"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_per_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_author_request.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: autor nije uklonjen"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_author_request" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas proverite da li su ovo radovi na koje želite da položite autorska prava, i naznačite koji je Vaš udeo u kreiranju datih radova."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tip nastavne aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:claim_publications_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Položite autorska prava na radove od strane"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "claim_publications_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Očistite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 1"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kliknite na oblast da vidite ostale"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ovaj autor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:leadership.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "rukovodstvo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_caching_process.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Šta je sve uključeno u proces keširanja?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_caching_process" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<ul><li>VIVO Vas preusmerava na ORCID-ov veb sajt.</li> <li>Napomenete ORCID-u da će VIVO možda dodati \"eksterni ID\" unutar Vašeg ORCID zapisa.</li> <li>VIVO dodaje eksterni ID.</li></ul>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite sve ..."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "faks broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Država"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:chapter_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poglavlje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "chapter_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_area_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sa istim interesovanjem."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_view_orcid_record.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "PŠregledajte Vaš ORCID sadržaj."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_view_orcid_record" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 2"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_namespace.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lokalni prostor imena (Namespace)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_namespace" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip profila"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istraživački radovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_to_compare.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Šta želite da poredite?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_to_compare" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizacija nedostaje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:reference_basemap_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Referenca na baznu mapu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reference_basemap_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:percent_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "% aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "percent_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Objavljeno u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "subdiscipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_key1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sposobnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_key1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:been_science_located.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "je \"naujčno-lociran.\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "been_science_located" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publisher.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran izdavač"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publisher" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_faculty_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite sve zaposlene na fakultetu sa interesovanjem za ovu oblast."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:new_local_oncology.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nova lokalna ontologija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "new_local_oncology" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ažurirajte link do veb stranice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_already_present.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Vaš ORCID nalog je već povezan sa VIVO-om</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_already_present" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_teacher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu nastavnika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_teacher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_honor_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv nagrade ili priznanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_honor_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "istraživačke oblasti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaje grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_active_grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema aktivnih grantova za ovaj departman."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_active_grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:people_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ljude"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "people_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapu možete istraživati na dva nivoa - po 13 disciplina ili 554 poddiscipline. Klikom na čvor unutar mape videćete brojne povezane časopise, radove i procenat radova mapiranih na datu (pod)disciplinu. Ako prevučete miš preko određene discipline unutar tabele sa leve strane videćete koji joj krugovi odgovaraju na mapi. Možete koristiti slajder ispod mape, kako bi ste smanjili broj poddosciplina prikazan na mapi i istu učinili čitljivijom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_telephone_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite broj telefona u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_telephone_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kraj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ako ste urednik ovog rada, molimo Vas odaberite \"Urednik\"."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_event.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran događaj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_event" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_harvest_cannot_continue.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Došlo je do greške i ne može da se nastavi sa prikupljanjem fajlova."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_harvest_cannot_continue" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:science_area_level.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nivo naučne oblasti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "science_area_level" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:teaching_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nastavne aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "teaching_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_successfully_excluded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rad je uspešno uklonjen sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_successfully_excluded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:link_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv linka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "link_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:first_name_empty_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Morate uneti ime u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name_empty_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publications_with.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Publikacije sa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publications_with" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 4"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip uloge"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_reviewer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu rencenzenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Promena maksimalnog broja rezultata pretrage"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text7.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovaj panel sadrži informacije o pojedinim izrazima pretrage i pojedinim grupama. Kliknite na neku od grupa da bi prikazali njene informacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text7" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines_lower.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "discipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines_lower" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_pubtype_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_pubtype_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Popunite podatke"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fajl"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_third_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kolona <b>% aktivnosti</b> prikazuje koji procenat publikacija je mapirano na svaku od (pod)disciplina."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_third_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:posn_history_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos istorije pozicija za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "posn_history_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_webpage_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte veb stranicu za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_webpage_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presented_at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prezentovano na"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presented_at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "koautiri "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_principal_investigator_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unos zamenika rukovodioca istraživanja za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_principal_investigator_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prijavite se kako bi ste uneli dodatne informacije o Vašim radovima."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:editor_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "editor_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_prefix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prefiks naziva"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_prefix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clear_all_selected_entities.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Očistite sve odabrane entitete."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clear_all_selected_entities" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: rad ne može biti uklonjen sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Završna strana"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_chapter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poglavlje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_chapter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_serch_results_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ni ejdan rezultat pretrage nije pronađen."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_serch_results_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_three_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Procenat ukupnih publikacija koji je uključen u  ovu vizuelizaciju se može poboljšati tako što će se uneti veći broj publikacija u VIVO sistem, i tako što će svaka publikacija biti povezana sa naučnim časopisom koji je prepoznat od strane 'Map of Science' vizuelizacije (zasnovano na podacima iz 'Clarivate Analytics' Web of Science' i 'Elsevier's Scopus' bazama podataka). Nazivi časopisa koji imaju slovnu ili bilo koju drugu grešku treba da se preprave pre nego što mogu da budu prepoznati tokom vizuelizacije. Ako smatrate da broj publikacija koji se nalaze na grafu ne odgovara broju publikacija unutar VIVO sistema, kontaktirajte vašeg administratora."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_three_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uploaded_files.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otpremljeni fajlovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uploaded_files" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_grants_and_projects.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte grantovima i projektima za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_grants_and_projects" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_processing_type_change.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: nečekirane labele nije moguće obrisati."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_processing_type_change" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran koncept"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:proceedings_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zbornik radova"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "proceedings_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:only_display.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Samo prikažite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "only_display" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subdisciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poddiscipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subdisciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte urednicima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:the_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "the_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:click_to_harvest.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kliknite na dugme da prikupite podatke iz fajlova."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "click_to_harvest" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istražite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napredne mogućnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovo učestvovanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:administered_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "čiji je administrator"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "administered_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text6.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovaj panel prikazuje listu izraza pretrage koji se trenutno nalaze na grafikonu. Za početak uradite pretragu po nekom izrazu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text6" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:visualization_tools.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Alati za vizualizaciju"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "visualization_tools" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_advisee.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran kandidat"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_advisee" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran časopis"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ako ne želite da položite autorska prava na ovaj rad, odaberite \"Ovo nije moj rad\"."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_post_weblog.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Blog"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_post_weblog" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Početak"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_abbreviated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ed."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_abbreviated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_unknown_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nepoznat tip resursa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_unknown_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:dept_or_school_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Departman ili naziv škole u okviru"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "dept_or_school_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:region.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provincija/Regija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "region" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvester_location.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "harvested.location"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvester_location" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_authorship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ko-autorstvo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_authorship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost u polje za Grad."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:city_locality.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "city_locality" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quickview_tooltip.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kliknite da vidite standartdnu profilnu stranicu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quickview_tooltip" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:webpage_url.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "url veb stranice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "webpage_url" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:institution_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv institucije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "institution_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_article_journal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Članam u časopisu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_article_journal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:investigator_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv istražitelja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "investigator_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Željena titula"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Idite na Vašu profilnu stranicu kako bi ste uneli dodatne informacije o Vašim radovima."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koautori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_being_refreshed_msg.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "se trenutno osvežava. Vizualizacije će biti prikazana čim se završi proračunavanje, možete da pretražujete ostale podatke unutar VIVO-a, i da se vratite na ovu stranicu za nekoliko minuta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_being_refreshed_msg" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_participating.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godine učestvovanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participating" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:definition_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Definicija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "definition_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:file.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "fajl"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "file" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mapped.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "namapirano"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mapped" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikupite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_pubs.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "publikacija."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_pubs" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_fourth_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kolona sa nazivom <b>% aktivnosti</b> prikazuje koji deo publikacija je mapiran na svaku od pod-disciplina."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_fourth_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unesite {0}:"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Početna godina"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:by_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "po publikacijama"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "by_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:use_capitals_each_word.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "koristite veliko slovo na početku svake reči"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "use_capitals_each_word" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Opis"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_five.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 5"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_five" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ove informaciju su bazirane isključivo na"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisingRel_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela savetodavca"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisingRel_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_presentation_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga u prezentaciji"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_presentation_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grantovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_country.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost u polje za Državu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_country" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vizualne oznake"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text5.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj istraživača koji se dobavljaju iz baze podataka za svaki od izraza pretrage zavisi od limita navedenog u formi za pretragu (10 je podrazumevano). Povećanjem ove vrednosti se povećavaju šanse da će toći do preseka između oistraživača vezanih za različite izraze pretrage (oblasti istraživanja). Međutim, ovo će takođe povećati kompleksnost grafikona, što će možda otežati uočavanje pojedinih elemenata ili nekih šablona."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text5" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana publikacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disclaimer_text_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "koji se nalaze unutar VIVO sistema od"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disclaimer_text_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odaberite ili kreirajte koncept u VIVO sistemu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:clinical_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tip kliničke aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "clinical_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_denied.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Odbili ste zahtev VIVO-a za dodavanje Eksternog ID-a u Vaš ORCID sadržaj</p> <p>Nije moguće nastaviti sa povezivanjem</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_denied" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:preferred_title_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "željena titula za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "preferred_title_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_person_in_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaje osoba sa datom ulogom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_person_in_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_credential_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite ili unesite kredencijale u odgovarajuće polje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_credential_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_entity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nad-entitet"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_entity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conference.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "konferencija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conference" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_notification.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "obaveštenje o grešci"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_notification" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_data_note1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napomena: Ove informacije se zasnivaju isključivo na publikacijama koje se nalaze unutar VIVO sistema. Ovo je možda samo mali podskup ukupnih radova neke osobe."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_data_note1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "osobe čija je oblast istraživanja u sklopu ove organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite prezime ove osobe."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_dois_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno su podržani DOI koje izdaju \"Crossref\", \"DataCite\" i \"mEDRA\".<br />Svaki zaseban DOI treba da bude razdvojen zarezom ili novim redom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_dois_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:undefined_runtime_property.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "svojstvo u runtime.properties nije definisano."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "undefined_runtime_property" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv prezentacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_service_provider_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu davaoca usluge"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_attributed_to.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rad dopšrinosi ovone"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_attributed_to" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_matching_entities_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nisu pronađeni podudarajući entiteti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_matching_entities_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:legend_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Legenda"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "legend_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost, ili odaberize neku od ponuđenih za naziv granta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:country_wide_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istraživanje na nivou države"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "country_wide_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:short_max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Možete poredidi maksimum 10 entiteta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "short_max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:using_cache_time.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koriste se informacije keširane u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "using_cache_time" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:place_of_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mesto objavljivanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drag_drop_reorder_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prevucite na drugo mesto da promenite redosled urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drag_drop_reorder_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Potvrdite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_url_provided.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "niste uneli url za link"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_url_provided" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:individuals_with_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo su pojedinci sa interesovanjem za <a href=\"{1}\">{0}</a> koji su deo ove organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "individuals_with_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv autora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interakcija sa vizualizacijom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kako bi lakše razumeli i protumačili informacije prikazane u okviru vizualizovane mape, izrazi pretrage i grupe koje se nalaze na grafikonu su skalirane u zavisnosti od broja rezultata koji se odnose na iste. Grupe su takođe različitih nijansi u zavisnosti od broja veza sa izrazima pretrage. Što je tamnija nijansa, to je data grupa povezana sa više izraza po kojima ste radili pretragu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:position_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip pozicije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "position_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dodeljuje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "tip aktivnosti istraživanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:label_altLabels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Labela (Alternativne labele)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "label_altLabels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:uri_independent_model.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "URI nezavisan model"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "uri_independent_model" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ime roditelja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fill_in_template_with_data.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Popunite šablon sa vašim podacima. Možete popuniti više šablona ako želite da prikupljate više fajlova istovremeno."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fill_in_template_with_data" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:department.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "departman"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "department" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:pause.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pauziraj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "pause" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:middle_organization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "srednja organizacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "middle_organization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:end_year_must_be_later.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina kraja mora biti kasnije od godine početka."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "end_year_must_be_later" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cached_models_regenerated.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sledeći keširani modeli će biti ponovo generisani."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cached_models_regenerated" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:best_match.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Najbolje podudaranje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "best_match" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_previous_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prethodni"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_previous_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:fax_number.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Faks broj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "fax_number" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:you_have_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrali ste"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "you_have_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years_inclusive.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uključene godine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_inclusive" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_template.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preuzmite šablon"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_template" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_musical_score.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Muzičko delo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_musical_score" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:membership_in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "članstvo u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "membership_in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_sparkline_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Svećice koje su prikazane iznad se odnose na grantove u okviru poslednje cele kalendarske godine. Ove tabele, međutim, prikazuju informacije o grantovima za sve godine."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_sparkline_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_mailing_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte mail adresu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email adresa za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 1: Dodajte Vaš ORCID iD"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credential_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv kredencijala"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credential_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:have_an_unknown.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sadrže nepoznatu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "have_an_unknown" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:speeches_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Govori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "speeches_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_thank_you.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Hvala Vam"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_thank_you" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovo članstvo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos publikacije za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:supplemental_information_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(npr. Naslov teze)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "supplemental_information_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:contact_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontakt"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "contact_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_or_select_person_value.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite postojeću vrednost ili unesite novu u polje za Osobu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_or_select_person_value" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da bi omogućili ovu opciju, prvo morate odabrati"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:explore_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istražite aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "explore_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_headline1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Početak"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_headline1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Klikom na bilo koji od čvorova unutar mape, prikazaće se dodatne informacije unutart 'Info' taba sa desne strane. Za grupe ljudi, članovi te grupe i njihove informacije će biti prikazane, i moći ćete da uklonite pojedinačne istraživača iz mape. Odabirom izraza za pretragu će se prikazati sve povezane grupe. U sklopu svake grupe se dobavljaju informacije o svim ljudima iz iste, broj grantova koji se podudaraju kao i njihovi radovi i publikacije. Klik na ime istraživača će Vas odvesti do početnog izraza po kom je rađena pretraga."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_attributed_publications.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ni jedan rad unutar sistema nije pripisan ovome."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_attributed_publications" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advising_relationship.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vrsta savetovanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advising_relationship" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:volume_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "volume_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Učitavanje podataka za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_not_chartered.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "godinu (nije označeno iznad)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_not_chartered" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_supported.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Napomena da će metapodaci biti dobavljeni sa sajta \"Crossref\", ako \"PubMed\" ID ne može da se svede na DOI."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_supported" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:type_of_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip kredencijala"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "type_of_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu ulogu organizatora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_hint.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(npr. za nagrade koje se ne dodljuju svake godine)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_hint" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enable_internal_class_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "za vaš primer"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enable_internal_class_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organization_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organization_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrani Autori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_a_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas popunite polje za Naziv."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_a_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_selected.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_selected" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj grantova"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_records_start_end_of_total.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zapisi _START_ - _END_ od ukupno _TOTAL_ "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_records_start_end_of_total" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_existing_local_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odaberite postojeću klasu iz lokalnog proširenja ontologije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_existing_local_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_report.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izveštaj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_report" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nedostaje diploma"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_editor_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da li ste sigurni daželite da uklonite urednike:"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_editor_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:local_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Lokalno istraživanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "local_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_people_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selektujte one ljude koje želite da <em>izostavite</em> sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_people_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:last_ten_full_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u poslednjih 10 kalendarskih godina"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_ten_full_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grant_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant-ovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:export_qr_codes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izvezite QR kodove"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "export_qr_codes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:help_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pomoć"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "help_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:event_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Događaj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "event_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "godina"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica ko-autora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_departments.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povezani departmani"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_departments" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte autora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_date.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datum zatvaranja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_date" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:resume.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nastavi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "resume" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:enter_street_address.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite vrednost u polje za Adresu ulice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_street_address" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_author_removal.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Je l ste sigurni da želite da uklčonite ovog autora:"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_author_removal" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:within_last_10_years.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u okviru poslednjih 10 godina"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "within_last_10_years" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:subject_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Oblast predmeta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "subject_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Savet: možete proširiti široku pretragu po nekom opštem izrazu na više preciznijih i bolje definisanih koncepta klikom na dugme &lsquo;Pretražite i proširite&rsquo;."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:information_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Informacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "information_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:mailing_address_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mail adresa za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "mailing_address_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:grants.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grantovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_a_document_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite ili unesite vrednost za naziv dokumenta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_a_document_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_results.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pogledajte rezultate"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_results" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_advising_relationship_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite tip odnosa mentora."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_advising_relationship_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:drill_down.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "izrada"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "drill_down" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_journal_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nema informacija o sadržaju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_journal_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Svojsvo unutar runtime.properties fajla pokazuje na direktorijum gde je instaliran Prikupljač."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:delete_webpage_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uklonite link do veb stranice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "delete_webpage_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:start_year_must_precede_end.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina početka mora biti ranije od godine kraja."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "start_year_must_precede_end" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_own_concept_all_caps.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte Vaš koncept"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_own_concept_all_caps" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_confirm.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da li želite da dodate ORCID iD?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_confirm" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:temporal_graph_drill_up.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "izrada vremenskog grafikona"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "temporal_graph_drill_up" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_area.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pogledajte sve pojedince koji su zainteresovani za ovu oblast."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_area" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:scopus_id_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Scopus ID Link"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "scopus_id_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Savetnik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:name_suffix.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sufiks naziva"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "name_suffix" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_concept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte koncept"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_concept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:step_three.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 3"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "step_three" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_publication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na publikaciju"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_publication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:published.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "objavljeno"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "published" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_Award_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite postojeću vrednost ili unesite novu unutar polja za Naziv nagrade ili priznanja."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_Award_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:show_discipline_labels.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite labele discipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "show_discipline_labels" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:person_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Osoba"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "person_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:missing_info_resource.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "resource informacija koje fale"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "missing_info_resource" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_return_to_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vratite se na Vašu VIVO profilnu stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_return_to_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:author_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Autor"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "author_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koncept"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:specify_role_for_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite ulogu za ovu aktivnost."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "specify_role_for_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:profile_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "profilna stranica"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:initial_okay.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "početno \"u redu\""@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "initial_okay" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:item_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Stavka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "item_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:must_be_admin.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pristup ovom alatu imaju samo administratori."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "must_be_admin" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte godinu dodele"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unesite istraživačku oblast u polje iznad i pritisnite dugme za pretragu. Generisani dijagram sadrži termin pretrage u narandžastoj boji, povezan sa grupom istraživača (plava boja) aktivnim u toj oblasti. Možete uneti još jedan izraza za pretragu da bi ste videli kakvi su odnosi između istraživača tih oblasti. Dodavajući još različitih izraza za pretragu postepeno ćete izgraditi Mapu sposobnosti."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:at.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "na"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "at" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_legal_case.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sudski slučaj"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_legal_case" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:award_receipt_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "naziv zapisa o dodeli nagrade"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "award_receipt_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:document_type_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip dokumenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "document_type_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_of_1000.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fakultet sa 1000 linkova"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_of_1000" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unos prezentacije za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran urednik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_individuals_in_dept.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite sve osobe u ovoj organizaciji."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_individuals_in_dept" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u okviru tekuće godine (nije označeno iznad)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:capability_map.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa sposobnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "capability_map" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_info_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite samo one (pod)discipline čiji naziv sadrži sledeći tekst."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_info_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_confirm_works.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Potvrdite Vaše radove"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_confirm_works" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_graphic.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Slika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_graphic" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:required_with_last_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Potrebno je novo prezime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "required_with_last_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ko-autori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:websites.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Veb sajtovi"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "websites" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_organizer_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu organizatora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_organizer_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_capitalized_lastname.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prezime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_capitalized_lastname" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_view_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nema veze (linka)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_view_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:parent_organization_of.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Matična (nad)organizacija za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "parent_organization_of" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:incomplete_date_time_interval.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nepotpun interval za datum i vreme"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "incomplete_date_time_interval" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:for_complete_overview.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "radi potpunog pregleda."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "for_complete_overview" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step2_added.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>Vaš ORCID sadržaj je povezan sa VIVO-om</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step2_added" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_an_editor.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte urednika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_an_editor" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_attendee_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novo učestvovanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_attendee_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_known_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sa poznatom godinom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_known_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:search_service_btn.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Servis pretrage"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "search_service_btn" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publisher_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izdavač"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publisher_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nastavite korak 2"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela studenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_label" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_papers_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema radova za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_s_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koautori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_s_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:awarded_by.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nagradu dodeljuje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "awarded_by" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:primary_email_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Primarni Email"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "primary_email_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:cap_map_text_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dobrodošli u alat za mapiranje sposobnosti. Ovaj alat se koristi za vizualizaciju odnosa između različitih istraživača korišćenjem specifičnih izraza za pretragu."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "cap_map_text_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:refresh_cached_vis_models.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Osvežite keširane modele za vizualizaciju"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "refresh_cached_vis_models" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_by_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodeljuje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_by_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kratak pregled profila"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_research_content_found.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sadržaj za istraživačke radove nije pronađen."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_research_content_found" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:from_current_incomplete_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "od tekuće godine"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "from_current_incomplete_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:add_new_web_page.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte novu veb stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_new_web_page" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:with_unknown_year.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "sa nepoznatom godinom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "with_unknown_year" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_error.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije moguće dobaviti detalje o citatima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_error" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_personal_communication.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pismo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_personal_communication" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:disciplines.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Discipline"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "disciplines" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text4.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kako bi ste imali kompletnije informacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text4" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:organizations.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "organizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizations" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aktivnost"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_data_as.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preuzmite podatke kao"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_data_as" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:expertise_profile_comparision_map_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mapa poređenja ekspertskih profila"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "expertise_profile_comparision_map_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_failed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<p>VIVO nije uspeo da pročita vaš ORCID zapis.</p> <p>Nije moguće nastaviti sa procesom potvrde.</p>"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_failed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_editors.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Urednici"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_editors" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:check_pubs_to_exclude.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Selektujte one publikacije koje želite da <em>izostavite</em> sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "check_pubs_to_exclude" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_nbr_for_comp.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Maksimalan broj stavki za podeđenje je 3."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_nbr_for_comp" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_year_awarded.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aćurirajte godinu doele"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_year_awarded" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu ulogu istraživača"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_button_step1.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nastavite korak 1"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_button_step1" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:presentation_name_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Naziv prezentacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "presentation_name_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:select_or_enter_name.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas da unesete postojeću vrednost ili unesete novu u polju za Naziv."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_or_enter_name" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standard_view.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Standardni pregled profila"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standard_view" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "mreža koautora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:research_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aktivnosti istraživanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:candidate.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kandidat"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "candidate" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:outreach_comm_service.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "društveno koristan rad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "outreach_comm_service" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:affiliated_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povezane oblasti istraživanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "affiliated_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_enter_pmid_intro.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Možete uneti jedan ili više \"PubMed\" ID-eva za pretragu. Svaki ID treba da bude razdvojen zarezom ili novim redom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_enter_pmid_intro" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisor_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unost odnosa sa mentorom za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisor_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga istraživača"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_affiliated_people.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte ljudima povezanim sa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_affiliated_people" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:edit_entry_for_researcher_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Ažurirajte ovu ulogu istraživača"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_entry_for_researcher_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:concept_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koncept (Tip)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "concept_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:close_me.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Zatvorite me"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "close_me" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Upravljajte konceptima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_description.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izdavaštvo univerziteta, organizacije, ili osobe se može prikazati preko već postojeće mape kako bi se generisali ekspertski profili. Procedura je sledeća: (1) Identifikuje se set jedinstvenih časopisa, (2) izračuna se koliko puta je svaki časopis bio mesto objavljivanja, i (3) površina 13 disciplina i 554 poddiscipline se računa na osnovu predhodno izračunatog broja objavljivanja u okviru nekog časopisa. Napomena - neki časopisi povezani su sa tačno jednom (pod)disciplinom dok su neki interdisciplinarni poput časopisa <em>Science</em> ili <em>Nature</em>. Poddiscipline nasleđuju boje svojih roditeljskih (nad)disciplina. (Pod)discipline sa kojima nije povezano ni jedno izdavaštvo univerziteta, organizacije ili osobe su prikazane sivom bojom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_description" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:role_in_institution.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga unutar institucije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "role_in_institution" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_activity.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "aktivnosti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_activity" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:of_a_maximum.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "od maksimalnih"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "of_a_maximum" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_member_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novo članstvo"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_member_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text3.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas posetite punu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text3" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_not_mine.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo nije moj rad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_not_mine" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Podaci za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:year_awarded_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "godina dodele za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "year_awarded_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:advisee_relationship_entry_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos odnosa sa kandidatom za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "advisee_relationship_entry_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_network_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mreža koautora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_network_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_visualization_tool_tip_two_the_second_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "<b>'Broj publikacija'</b> kolona prikazuje koliko publikacija je mapirano na svako od (pod)disciplina. Ovaj broj ne mora biti ceo, s obzirom da su neke publikacije povezane sa više (pod)disciplina. Takve publikacije ne doprinose ceo broj ukupnom broju publikacija date discipline, već samo razlomak na osnovu težinske šeme."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_visualization_tool_tip_two_the_second_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:share_the_uri.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "podelite uri"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "share_the_uri" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:map_of_science_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica za naučnu mapu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_of_science_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:remove_editor_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "uklonite vezu sa urednikolm"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "remove_editor_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:email.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "email"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Fakulteti"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigator_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica koautora "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigator_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:this_investigator.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ovog istražitelja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "this_investigator" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_manage_concepts.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na upravljanje konceptima"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_manage_concepts" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:in.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "in" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:credentials.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "kredencijali"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "credentials" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:conferred_on.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "dodeljena"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "conferred_on" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:save_changes.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sačuvajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "save_changes" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixC.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "je ispravno konfigurisan sa informacijama o vašoj bazi podataka i imenskom prostoru (namespace)."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixC" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:upload_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Otpremite"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "upload_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_finished.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nema više radova na koje možete položiti autorska prava.<br />Možete uneti još ID-eva ispod, ili pregledati Vaš profil."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_finished" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:active_grants_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Aktivni grantovi za "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "active_grants_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Diploma"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:numbers_based_on_publications_in_vivo.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovi brojevi su bazirani isključivo na radovima i publikacijama koje su unete u VIVO aplikaciju. Ako je ovo Vaš profil, možete uneti dodatne publikacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "numbers_based_on_publications_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:compare_tool_tip_text_the_first_part.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istražite profile ekspertiza za jednu ili više organizacija. Boje su podeljene po disciplinama."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "compare_tool_tip_text_the_first_part" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_four.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Modeli se ponovo učitavaju svaki put kad se server restartuje. Sa obzirom da ovo nije praktično u produkciji, administratori mogu da koriste \"osvežite keš\" link iznad da učitaju ponovo modele bez potrebe za restartom servera."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_four" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:please_select_type.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas odaberite tip iz padajuće liste."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "please_select_type" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_author_network.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mreža koautora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_author_network" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:quick_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica za kratak pregled"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "quick_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:return_to_ingest_menu.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na meni sa alatima za učitavanje podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_ingest_menu" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:has_no_webpages.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova osoba trenutno nema veb stranicu specificiranu. Dodajte novu veb stranicu klikom na dugme ispod."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "has_no_webpages" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:through_today.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Objavljeni radovi do danas"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "through_today" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_entry_for_clinical_role.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       ": Dodajte novu kliničku aktivnost"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry_for_clinical_role" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:download_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "link za preuzimanje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "download_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:max_entity_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Možete uporediti maksimum 10 entiteta. Molimo Vas da uklonite višak i pokušate ponovo."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "max_entity_note" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vizualizacije velikih skupova podataka, kao što su 'Temporal Graph' ili 'Map of Science' uključuju računanje ukupnog broja publikacija ili grant-ova za određen entitet. S obzirom da to podrazumeva prolazak kroz sve pod-entitete datog entiteta, upit koji izvršava ovu operaciju zahteva i dosta memorije, i dosta vremena za izvršavanje. Da bi korisnici dobili brže svoje odgovore, rezultati datog upita se čuvaju u memoriji za brži pristup pri svakoj sledećoj vizualizaciji."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step1_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Korak 1: Dodajte Vaš ORCID iD"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step1_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:entity_comp_error_text2.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unutar sistema."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "entity_comp_error_text2" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_overlay_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preklapanje podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_overlay_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_go_profile.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Idite naprofil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_go_profile" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:tables_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tabele"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "tables_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:loading_map_information.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Učitavaju se informacije o mapi . . ."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_map_information" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:view_all_research.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prikažite sva istraživanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_research" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:interactivity_heading.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Interakcija sa mapom"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "interactivity_heading" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_submit_ids.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Podnesite ID-eve"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_submit_ids" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:co_investigators_capitalized.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Koautori"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "co_investigators_capitalized" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:internal_class.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "internu klasu institucije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "internal_class" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:faculty_research_areas.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Oblasti istraživanja fakulteta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_research_areas" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_tools_note_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Implementirano je keširanje koje čuva informacije o hierarhiji organizacija -- pre svega koje publikacije pripadaju kojoj organizaciji -- tako što se čuva RDF model u memoriji."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_tools_note_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:full_view_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ikonica za pun pogled"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_view_icon" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_authors_desc.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ako ste autor rada, molio Vas odaberite vaše ime u listi autora.<br />DObavljanje meta-podataka može biti nepotpuno. Ako ne vidite svoje ime u listi, odaberite \"Nenaveden autor\"."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_authors_desc" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vis_last_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poslednji"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vis_last_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:no_linked_author.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nema povezanih autora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_linked_author" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:data_being_harvested.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas sačekajte dok se podaci prikupljaju."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "data_being_harvested" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:error_excluding_grant.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Greška pri obradi zahteva: stavka ne može biti uklonjean sa profilne stranice."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "error_excluding_grant" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_sixB.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vivo/config/vivo.xml"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_sixB" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:what_is_this.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Šta je ovo?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "what_is_this" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_step_completed.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "(korak završen)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_step_completed" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:harvest_error_instructions_fiveA.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unutar VIVO Prikupljača,"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "harvest_error_instructions_fiveA" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_one.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kliknite da prikažete"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_one" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_credential.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabran kredencijal"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_credential" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:telephone_number_for.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "telefonski broj za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "telephone_number_for" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:persistent_link_to_visualization.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trajna veza (link) do trenutne vizualizacije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "persistent_link_to_visualization" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:doi_link.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Digital Object Identifier (DOI)"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "doi_link" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:publication_count.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Broj radova"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "publication_count" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:confirm_webpage_deletion.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da li ste sigurni da hoćete da uklonite ovu veb stranicu?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "confirm_webpage_deletion" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:orcid_title_add.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Da li želite da dodate ORCID iD?"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "orcid_title_add" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:vocabulary_source.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izvor rečnika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vocabulary_source" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:create_and_link_type_manuscript.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Rukopis"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_and_link_type_manuscript" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:standardview_tooltip_two.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "brzi pregled profil."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "standardview_tooltip_two" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:granted.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "odobren grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "granted" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:selected_person.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrana osoba"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "selected_person" ;
+        prop:hasPackage  "VIVO-languages" .
+
+prop-data:degree_candidacy.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kandidatura za diplomu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "degree_candidacy" ;
+        prop:hasPackage  "VIVO-languages" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_tenderfoot.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_tenderfoot.ttl
@@ -1,0 +1,869 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:collapsed_menu_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Meni"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collapsed_menu_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_termuse.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uslovi korišćenja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_position_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije moguće modifikovati ovu poziciju jer je povezana sa više osoba."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_or_series.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prezime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_type.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip grant-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prikažite sve članove ove organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:display_more.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "više"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:edit_mailing_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izmenite poštansku adresu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prva publikacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_faculty_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije pronađen ni jedan član fakulteta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myprofile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moj profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_powered.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Omogućili: "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo telo je iz template fajla vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  Unutar modela za prikaz, stranica sa grant-ovima ima display:requiresBodyTemplate svojstvo koje definiše da stranica sa grantovima override-uje pretpostavljen template. Pretpostavljen template za ove stranice se nalazi na /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | povežite se delite otkrijte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "istraživač"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_index.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Indeks"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:vivo_profile.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_logout.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Izlogujte se"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:create_entry.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte Entitet"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:placeholder_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "predodređena slika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:first_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prvi Grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:attendee_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Polaznik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_state_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "stanje."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_about.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova tehnika se može koristiti za definisanje stranica bez menija, koje dobavljaju svoj sadržaj iz freemarker template-a. Primer bi bio about stranica."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:service_provider_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga Service Provider-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:profile_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:email_address.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email Adresa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:statewide_locations.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lokacije na nivou države."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:limit_search.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ograničite pretragu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:province_or_region.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provincija ili Regija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_copyright.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autorska prava"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:place_of_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mesto grant-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:to.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "do"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_edit.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Modifikujte stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:enter_new_role_value.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Unesite novu vrednost u polje za uloga."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_version.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verzija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poslednji Grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_grants_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema grant-ova za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_one.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ulica prve adrese"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:map_states_string.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_website_image.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Učitavanje slike za vebsajt"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_filtersearch.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrirajte pretragu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_user.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "korisnik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije moguće modifikovati ovaj itip grant-a, jer je povezan sa više različitih grant-ova."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_researchers.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema istraživača unutar definisane geografske lokacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_departments.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pogledajte sve akademske departmane"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pregled"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:organizer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga Organizatora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_admin.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Admin Sajta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_support.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Podrška"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:researchers_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "istraživači u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_memberships.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Članstvo na fakultetu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:last_publication.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poslednja publikacija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_item.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "stavka menija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_item" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_loginfull.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ulogujte se kako bi ste upravljali sajtom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:countries_and_regions.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države i regije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:reviewer_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga Recenzenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:no_departments_found.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ni jedan akademski departman nije pronađen."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:return_to_grant.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na grant"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_entry_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Grant entitet za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_searchvivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pretražite VIVO"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ulica treće adrese"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_label.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela za adresu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:change_selection.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "promenite odabir"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo su zaposleni na {0} departmanu koji su članovi organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_in_vivo.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "grant-ovi u VIVO-u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:leadership_role.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga Lidera"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:currently_no_papers_for.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema {0} radova za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_welcomestart.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dobrodošli"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:add_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_title.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dobrodošli na VIVO"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grants_text_three.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo bi kreiralo stranicu koja bi koristila about.ftl za svoje telo. Stranici bi se pristupalo preko /about putanje i override-ovala bi sva servlet mapiranja u okviru web.xml-a."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:research_area.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "osobe unutar departmana sa datom oblasti istraživanja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_contactus.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontaktirajte nas"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:password.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lozinka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para1.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO je alat za pretragu i istraživanje koji se fokusira na oblast akademije i istraživača i omogućuje kolaboraciju naučnika iz različitih disciplina."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:collection_capitalized.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kolekcija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:address_street_two.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ulica druge adrese"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:select_award.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrane Nagrade"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:manage_publications_link.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:loading_data.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "učitavanje podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:indiv_foafperson_return.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vratite se na"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:menu_login.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ulogujte se"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:grant_date.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datum grant-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:intro_para2.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pretražite informacije o osobama, departmanima, kursevima, grant-ovima, i publikacijama."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:identity_myaccount.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moj nalog"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:full_name.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Puno ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:years_participation_in.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina učestvovanja u "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .
+
+prop-data:view_all_faculty.VIVO.tenderfoot
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pogledajte svo osoblje"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "tenderfoot" .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_wilma.ttl
@@ -1,0 +1,851 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prop-data: <http://vivoweb.org/ontology/core/properties/individual#> .
+@prefix prop:  <http://vivoweb.org/ontology/core/properties/vocabulary#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+
+prop-data:intro_filtersearch.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Filtrirajte pretragu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_filtersearch" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:leadership_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Vodeća uloga"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "leadership_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pogled"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:place_of_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Mesto izdavanja stipendije "@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "place_of_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:select_award.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odabrane nagrade"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "select_award" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:service_provider_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga davaoca usloge"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "service_provider_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_contactus.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kontaktirajte nas"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_contactus" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "adresa ulice 3"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:reviewer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga recenzenta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "reviewer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_termuse.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uslovi korišćenja"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_termuse" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_position_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preko ove forme ne možete da ažurirate ovu poziciju zato što se vezuje za više osoba."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_position_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:attendee_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Polaznik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "attendee_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:placeholder_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "privremena slika"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "placeholder_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_user.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "korisnik"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_user" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poslednji objavljen rad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:password.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lozinka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "password" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:unable_to_handle_grant_editing.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Preko ove forme ne možete da ažurirate ovu stipendiju zato što se vezuje za više osoba."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "unable_to_handle_grant_editing" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries_and_regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države i regioni."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries_and_regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_logout.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Odjavite se"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_logout" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_edit.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ažurirajte stranicu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_edit" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:to.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "do"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "to" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_type.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Tip stipendije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_type" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myaccount.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moj nalog"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myaccount" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_faculty_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nisu pronađeni članovi fakulteta."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_faculty_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:statewide_locations.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "lokacije na nivou čitave države."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "statewide_locations" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:province_or_region.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Provincije ili region"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "province_or_region" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_support.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Podrška"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_support" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Istraživači u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prezime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:add_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dodajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "add_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para2.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pratražite informacije o ljudima, departmanima, kursevima, stipendijama i radovima."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para2" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_entry_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "unos stipendije za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_entry_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO | povežite se  delite  otkrijte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:profile_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "profile_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:change_selection.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "promenite selekciju"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "change_selection" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_memberships.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Članstvo na fakultetu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_memberships" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_admin.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Administrator sajta"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_admin" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_capitalized.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kolekcija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_capitalized" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:countries.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "countries" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_loginfull.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prijavite se kako bi ste upravljanli sajtom i sadržajem"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_loginfull" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_departments.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "prikažite sve departmane"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_departments" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_myprofile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Moj profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_myprofile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_state_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "država."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_state_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_three.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovo bi kreiralo stranicu koja bi koristila about.ftl za telo. Stranici bi se pristupalopreko putanje /about koja bi pregazila svo mapiranje servleta u web.xml-u."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_three" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_powered.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Sajt održava"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_powered" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pogledajte sve članove ove organizacije."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:email_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Email adresa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "email_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:view_all_faculty.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "pogledajte sve fakultete"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "view_all_faculty" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:enter_new_role_value.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Molimo Vas unesite novu vrednost u polje za uloge."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "enter_new_role_value" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:indiv_foafperson_return.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "vratite se na"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "indiv_foafperson_return" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:edit_mailing_address.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ažurirajte spisak adresa"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "edit_mailing_address" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:collection_or_series.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "collection_or_series" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:years_participation_in.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Godina učešća u"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "years_participation_in" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:manage_publications_link.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "manage_publications_link" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_welcomestart.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dobrodošli"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_welcomestart" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grant_date.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Datum stipendije"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grant_date" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_label.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "labela za adresu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_label" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_publication.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prvi objavljen rad"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_publication" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:faculty_who_are_members_of_org.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Here are the faculty in the {0} department who are members of this organization."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "faculty_who_are_members_of_org" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:limit_search.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "ograničite pretragu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "limit_search" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:full_name.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Puno ime"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "full_name" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_version.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Verzija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_version" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:identity_index.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Indeks"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "identity_index" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema istraživača sa definisanim geografskikm fokusom."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_searchvivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Pretražite VIVO"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_searchvivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_copyright.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "autorska prava"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_copyright" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_departments_found.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Nije pronađen ni jedan departman."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_departments_found" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_website_image.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Učitavanje slike veb stranice"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_website_image" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:last_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Poslednja Stipendija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "last_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_text_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ovaj deo stranice je iz fajla sa šablonom (freemarker template) vivo/productMods/templates/freemarker/body/menupage/grants.ftl.  U modelu prikazivanja, stranica za stipendije ima display:requiresBodyTemplate svojstvo koje definiše da strancie za stipendije treba da \"pregazi\" podrazumevani šablon. Podrazumevani šablon za ove stranice se nalazi na /vitro/webapp/web/templates/freemarker/body/menupage/menupage.ftl"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_text_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:no_grants_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema stipendija za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "no_grants_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:map_states_string.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "države."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "map_states_string" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:first_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prva stipendija"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "first_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_in_vivo.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "nagrade unutar VIVO-a"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_in_vivo" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:regions.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "regioni"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "regions" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:display_more.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "više"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "display_more" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:loading_data.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "učitavanje podataka"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "loading_data" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:grants_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Ova tehnika se može koristiti za definisanje stranica bez stavki menija, koje dobijaju svoj sadržaj iz freemarker šablona.  Primer ovoga je stranica \"O sajtu\" (About)."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "grants_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:create_entry.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Kreirajte unos"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "create_entry" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:organizer_role.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Uloga organizatora"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "organizer_role" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_one.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "adresa ulice 1"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_one" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_para1.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO je alat namenjen pretraživanju i otkrivanju istraživačkih radova i aktivnosti, koji omogućuje saradnju između naučnika iz različitih disciplina i oblasti."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_para1" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_about.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "O sajtu"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_about" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:address_street_two.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "adresa ulice 2"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "address_street_two" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:vivo_profile.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "VIVO profil"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "vivo_profile" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:research_area.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "osobe unutar departmana koje se bave ovom istraživačkom oblasti."@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "research_area" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:currently_no_papers_for.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Trenutno nema {0} radova za"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "currently_no_papers_for" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:researchers.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "istraživači"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "researchers" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:menu_login.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Prijavite se"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "menu_login" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:intro_title.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Dobrodošli na VIVO"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "intro_title" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .
+
+prop-data:return_to_grant.VIVO.wilma
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         prop:PropertyKey ;
+        rdfs:label       "Povratak na stipendiju"@sr-Latn-RS ;
+        prop:hasApp      "VIVO" ;
+        prop:hasKey      "return_to_grant" ;
+        prop:hasPackage  "VIVO-languages" ;
+        prop:hasTheme    "wilma" .

--- a/installer/example-settings.xml
+++ b/installer/example-settings.xml
@@ -8,8 +8,8 @@
             <properties>
                 <app-name>vivo</app-name>
 
-                <vivo-dir>d:/Projekti/VIVO/home</vivo-dir>
-                <tomcat-dir>e:/cris/apache-tomcat-9.0.52</tomcat-dir>
+                <vivo-dir>/usr/local/vivo/home</vivo-dir>
+                <tomcat-dir>/usr/local/tomcat</tomcat-dir>
 
                 <default-theme>wilma</default-theme>
             </properties>

--- a/installer/example-settings.xml
+++ b/installer/example-settings.xml
@@ -8,8 +8,8 @@
             <properties>
                 <app-name>vivo</app-name>
 
-                <vivo-dir>/usr/local/vivo/home</vivo-dir>
-                <tomcat-dir>/usr/local/tomcat</tomcat-dir>
+                <vivo-dir>d:/Projekti/VIVO/home</vivo-dir>
+                <tomcat-dir>e:/cris/apache-tomcat-9.0.52</tomcat-dir>
 
                 <default-theme>wilma</default-theme>
             </properties>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -41,17 +41,6 @@
                                     <artifactId>vivo-webapp</artifactId>
                                     <type>war</type>
                                 </overlay>
-                                <!-- Overlays for multilingual support -->
-                                <overlay>
-                                    <groupId>org.vivoweb</groupId>
-                                    <artifactId>vitro-languages-webapp-core</artifactId>
-                                    <type>war</type>
-                                </overlay>
-                                <overlay>
-                                    <groupId>org.vivoweb</groupId>
-                                    <artifactId>vivo-languages-webapp-core</artifactId>
-                                    <type>war</type>
-                                </overlay>
                             </overlays>
                             <webResources>
                                 <resource>
@@ -147,19 +136,6 @@
         <dependency>
             <groupId>org.vivoweb</groupId>
             <artifactId>vivo-webapp</artifactId>
-            <type>war</type>
-        </dependency>
-        <!-- Dependencies for multilingual support -->
-        <dependency>
-            <groupId>org.vivoweb</groupId>
-            <artifactId>vitro-languages-webapp-core</artifactId>
-            <version>${project.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>org.vivoweb</groupId>
-            <artifactId>vivo-languages-webapp-core</artifactId>
-            <version>${project.version}</version>
             <type>war</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,28 +68,6 @@
 
     <profiles>
         <profile>
-            <id>Vitro-languages</id>
-            <activation>
-                <file>
-                    <exists>../Vitro-languages/pom.xml</exists>
-                </file>
-            </activation>
-            <modules>
-                <module>../Vitro-languages</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>VIVO-languages</id>
-            <activation>
-                <file>
-                    <exists>../VIVO-languages/pom.xml</exists>
-                </file>
-            </activation>
-            <modules>
-                <module>../VIVO-languages</module>
-            </modules>
-        </profile>
-        <profile>
             <id>vitro</id>
             <activation>
                 <file>

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_de_DE.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_de_DE.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE.ttl
+Deployment: [VIVO home]/rdf/i18n/de_DE/display/interface-i18n/vivo_UiLabel_de_DE.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_en_CA.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_en_CA.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA.ttl
+Deployment: [VIVO home]/rdf/i18n/en_CA/display/interface-i18n/vivo_UiLabel_en_CA.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_en_US.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_en_US.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US.ttl
+Deployment: [VIVO home]/rdf/i18n/en_US/display/interface-i18n/vivo_UiLabel_en_US.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_es.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_es.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es.ttl
+Deployment: [VIVO home]/rdf/i18n/es/display/interface-i18n/vivo_UiLabel_es.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_fr_CA.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_fr_CA.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA.ttl
+Deployment: [VIVO home]/rdf/i18n/fr_CA/display/interface-i18n/vivo_UiLabel_fr_CA.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_pt_BR.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_pt_BR.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR.ttl
+Deployment: [VIVO home]/rdf/i18n/pt_BR/display/interface-i18n/vivo_UiLabel_pt_BR.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_ru_RU.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_ru_RU.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU.ttl
+Deployment: [VIVO home]/rdf/i18n/ru_RU/display/interface-i18n/vivo_UiLabel_ru_RU.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/i18n/README_vivo_UiLabel_sr_Latn_RS.txt
+++ b/webapp/src/main/webapp/i18n/README_vivo_UiLabel_sr_Latn_RS.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS.ttl
+Deployment: [VIVO home]/rdf/i18n/sr_Latn_RS/display/interface-i18n/vivo_UiLabel_sr_Latn_RS.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_de_DE_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_de_DE_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/de_DE/display/interface-i18n/vivo_UiLabel_de_DE_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_en_CA_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_en_CA_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/en_CA/display/interface-i18n/vivo_UiLabel_en_CA_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_en_US_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_en_US_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/en_US/display/interface-i18n/vivo_UiLabel_en_US_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_es_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_es_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/es/display/interface-i18n/vivo_UiLabel_es_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_fr_CA_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_fr_CA_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/fr_CA/display/interface-i18n/vivo_UiLabel_fr_CA_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_pt_BR_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_pt_BR_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/pt_BR/display/interface-i18n/vivo_UiLabel_pt_BR_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_ru_RU_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_ru_RU_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/ru_RU/display/interface-i18n/vivo_UiLabel_ru_RU_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_sr_Latn_RS_tenderfoot.txt
+++ b/webapp/src/main/webapp/themes/tenderfoot/i18n/README_vivo_UiLabel_sr_Latn_RS_tenderfoot.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_tenderfoot.ttl
+Deployment: [VIVO home]/rdf/i18n/sr_Latn_RS/display/interface-i18n/vivo_UiLabel_sr_Latn_RS_tenderfoot.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_de_DE_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_de_DE_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel_de_DE_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/de_DE/display/interface-i18n/vivo_UiLabel_de_DE_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_en_CA_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_en_CA_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel_en_CA_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/en_CA/display/interface-i18n/vivo_UiLabel_en_CA_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_en_US_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_en_US_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel_en_US_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/en_US/display/interface-i18n/vivo_UiLabel_en_US_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_es_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_es_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel_es_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/es/display/interface-i18n/vivo_UiLabel_es_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_fr_CA_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_fr_CA_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_fr_CA_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/fr_CA/display/interface-i18n/vivo_UiLabel_fr_CA_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_pt_BR_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_pt_BR_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel_pt_BR_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/pt_BR/display/interface-i18n/vivo_UiLabel_pt_BR_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_ru_RU_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_ru_RU_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel_ru_RU_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/ru_RU/display/interface-i18n/vivo_UiLabel_ru_RU_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+

--- a/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_sr_Latn_RS_wilma.txt
+++ b/webapp/src/main/webapp/themes/wilma/i18n/README_vivo_UiLabel_sr_Latn_RS_wilma.txt
@@ -1,0 +1,8 @@
+Please note that although usage of property files for translation of UI labels is supported at the moment,
+it is deprecated and not recommended. Please, consider using ontology instead of property file located at:
+Source code: [VIVO project]VIVO/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel_sr_Latn_RS_wilma.ttl
+Deployment: [VIVO home]/rdf/i18n/sr_Latn_RS/display/interface-i18n/vivo_UiLabel_sr_Latn_RS_wilma.ttl
+
+However, if you decide to use property files, please create and post the file in the same
+directory as this Readme file.
+


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3762](https://github.com/vivo-project/VIVO/issues/3762)

[Companion PR](https://github.com/vivo-project/Vitro/pull/350)

# What does this pull request do?
Moving UI labels translations from VIVO-languages into VIVO (+ adoption of a pom file)

# What's new?
webapp directories from VIVO-languages repository are not needed any more. Together with [PR](https://github.com/vivo-project/VIVO/pull/3797) for doing the same for home directories from Vitro-languages should enable archiving the VIVO-languages repositories.

# How should this be tested?

- Checkout https://github.com/vivo-project/VIVO-languages/tree/i18n-redesign as VIVO-languages project
- Remove VIVO home and install the new, fresh instance of VIVO
- Validate it is working as expected
- Try switching between all 8 languages (set in the runtime.properties languages.selectableLocales = en_US, de_DE, sr_Latn_RS, ru_RU, fr_CA, en_CA, es, pt_BR)
- 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
