### PR TITLE
fixed export_qr_codes translation

### DIFF
--- a/webapp/src/main/webapp/js/individual/individualUtils.js
+++ b/webapp/src/main/webapp/js/individual/individualUtils.js
@@ -64,7 +64,7 @@ $(document).ready(function(){
 							}
 							vcard += "END:VCARD";
 
-							spanStr = "<a title='${i18n().export_qr_codes?js_string}' href='"
+							spanStr = "<a title='" + i18nStrings.exportQrCodes + "' href='"
 							          + exportQrCodeUrl + "'>"
 							          + "<img id='codeImage' src='https://chart.googleapis.com/chart?cht=qr&amp;chs=125x125&amp;chl="
 									  + vcard

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-2column.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-2column.ftl
@@ -175,6 +175,7 @@ var i18nStrings = {
     displayMoreEllipsis: '${i18n().display_more_ellipsis?js_string}',
     showMoreContent: '${i18n().show_more_content?js_string}',
     verboseTurnOff: '${i18n().verbose_turn_off?js_string}',
+    exportQrCodes: '${i18n().export_qr_codes?js_string}',
     standardviewTooltipOne: '${i18n().standardview_tooltip_one?js_string}',
     standardviewTooltipTwo: '${i18n().standardview_tooltip_two?js_string}',
     researchAreaTooltipOne: '${i18n().research_area_tooltip_one?js_string}',

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
@@ -192,6 +192,7 @@ Add divs and wrapper to create funnelback basket controls. MUST BE REMOVED BEFOR
 		displayMoreEllipsis: '${i18n().display_more_ellipsis}',
 		showMoreContent: '${i18n().show_more_content}',
 		verboseTurnOff: '${i18n().verbose_turn_off}',
+                exportQrCodes: '${i18n().export_qr_codes?js_string}',
 		researchAreaTooltipOne: '${i18n().research_area_tooltip_one}',
 		researchAreaTooltipTwo: '${i18n().research_area_tooltip_two}'
 		};

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
@@ -166,6 +166,7 @@
         displayMoreEllipsis: '${i18n().display_more_ellipsis?js_string}',
         showMoreContent: '${i18n().show_more_content?js_string}',
         verboseTurnOff: '${i18n().verbose_turn_off?js_string}',
+        exportQrCodes: '${i18n().export_qr_codes?js_string}',
         researchAreaTooltipOne: '${i18n().research_area_tooltip_one?js_string}',
         researchAreaTooltipTwo: '${i18n().research_area_tooltip_two?js_string}'
     };

--- a/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
@@ -169,6 +169,7 @@
         displayMoreEllipsis: '${i18n().display_more_ellipsis?js_string}',
         showMoreContent: '${i18n().show_more_content?js_string}',
         verboseTurnOff: '${i18n().verbose_turn_off?js_string}',
+        exportQrCodes: '${i18n().export_qr_codes?js_string}',
         researchAreaTooltipOne: '${i18n().research_area_tooltip_one?js_string}',
         researchAreaTooltipTwo: '${i18n().research_area_tooltip_two?js_string}'
     };


### PR DESCRIPTION
# What does this pull request do?
Fixes export_qr_code translation on hover of qr code image

# How should this be tested?
For vitro, wilma, nemo, tenderfoot themes:
* Open person profile
* Click on qr code icon image
* Hover over enlarged qr code image
* Verify that Export qr code hint is shown

# Interested parties
@chenejac 
