### PR TITLE
Use fallbacks for concept labels with en-US, en, and without language…

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/utilities/VisualizationCaches.java
@@ -433,8 +433,23 @@ final public class VisualizationCaches {
                                     "    ?person a foaf:Person .\n" +
                                     "    ?person core:hasResearchArea ?concept .\n" +
                                     "    ?concept a skos:Concept .\n" +
-                                    "    ?concept rdfs:label ?label .\n" +
-                                    "    FILTER (lang(?label) = '" + langCtx+"' )  \n" +
+                                    "  OPTIONAL {  "  +
+                                    "       ?concept rdfs:label ?labelPrimary . \n" +
+                                    "       FILTER (LANG(?labelPrimary) = '" + langCtx + "') \n" +
+                                    "  } \n" +
+                                    "  OPTIONAL {  "  +
+                                    "       ?concept rdfs:label ?labelFallback1 . \n" +
+                                    "       FILTER (LANG(?labelFallback1) = 'en-US') \n" +
+                                    "  } \n" +
+                                    "  OPTIONAL {  "  +
+                                    "       ?concept rdfs:label ?labelFallback2 . \n" +
+                                    "       FILTER (LANG(?labelFallback2) = 'en') \n" +
+                                    "  } \n" +
+                                    "  OPTIONAL {  "  +
+                                    "       ?concept rdfs:label ?labelFallback3 . \n" +
+                                    "       FILTER (LANG(?labelFallback3) = '') \n" +
+                                    "  } \n" +
+                                    "BIND(COALESCE(?labelPrimary, ?labelFallback1, ?labelFallback2, ?labelFallback3) AS ?label) \n" +
                                     "}\n";
 
 //                            final Map<String, String> map = new HashMap<>();


### PR DESCRIPTION
# What does this pull request do?
If concept doesn't have label with language tag it can't be used in capability map.
This is a fix for capability map regression from i18n sprint.

# What's new?
Use fallbacks for concept labels with en-US, en, and without language tag in visualization caches.

# How should this be tested?
- Use a concept with label without language tag.
- Search for concept in capability map.
- Concept should be shown on the map.

# Interested parties
@chenejac @bkampe 
