### PR TITLE
VIVO 3821: Add configuration to disable or enable Map of Science visualization.

### DIFF
--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -404,6 +404,14 @@ http.createCacheHeaders = true
 visualization.temporal = enabled
 
   #
+  # The Map of Science visualization is limited in the number of supported journals.
+  # This will generally only be useful for institutions that specifically want this.
+  # This is disabled by default.
+  # Set this to either "disabled" to not utilize or "enabled" to utilize.
+  #
+visualization.mapOfScience = disabled
+
+  #
   # Types of individual for which we can create proxy editors.
   # If this is omitted, defaults to http://www.w3.org/2002/07/owl#Thing
   #

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -406,10 +406,10 @@ visualization.temporal = enabled
   #
   # The Map of Science visualization is limited in the number of supported journals.
   # This will generally only be useful for institutions that specifically want this.
-  # This is disabled by default.
+  # This is enabled by default.
   # Set this to either "disabled" to not utilize or "enabled" to utilize.
   #
-visualization.mapOfScience = disabled
+visualization.mapOfScience = enabled
 
   #
   # Types of individual for which we can create proxy editors.

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-organization.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-organization.ftl
@@ -4,11 +4,15 @@
 
 <#-- Do not show the link for temporal visualization unless it's enabled -->
 
-<#if temporalVisualizationEnabled>
+<#if temporalVisualizationEnabled || mapOfScienceVisualizationEnabled>
     <#assign classSpecificExtension>
         <section id="right-hand-column" role="region">
-            <#include "individual-visualizationTemporalGraph.ftl">
-            <#include "individual-visualizationMapOfScience.ftl">
+            <#if temporalVisualizationEnabled>
+                <#include "individual-visualizationTemporalGraph.ftl">
+            </#if>
+            <#if mapOfScienceVisualizationEnabled>
+                <#include "individual-visualizationMapOfScience.ftl">
+            </#if>
         </section> <!-- #right-hand-column -->
     </#assign>
 </#if>

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-organization.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-organization.ftl
@@ -4,11 +4,15 @@
 
 <#-- Do not show the link for temporal visualization unless it's enabled -->
 
-<#if temporalVisualizationEnabled>
+<#if temporalVisualizationEnabled || mapOfScienceVisualizationEnabled>
     <#assign classSpecificExtension>
         <section id="right-hand-column" role="region">
-            <#include "individual-visualizationTemporalGraph.ftl">
-            <#include "individual-visualizationMapOfScience.ftl">
+            <#if temporalVisualizationEnabled>
+                <#include "individual-visualizationTemporalGraph.ftl">
+            </#if>
+            <#if mapOfScienceVisualizationEnabled>
+                <#include "individual-visualizationMapOfScience.ftl">
+            </#if>
         </section> <!-- #right-hand-column -->
     </#assign>
 </#if>

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-custom-visualizationFoafPerson.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-custom-visualizationFoafPerson.ftl
@@ -20,10 +20,13 @@
         <h5><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span> <strong>Visualizations</strong></h5>
         <#if isAuthor>
             <#assign coAuthorIcon = "${urls.images}/visualization/coauthorship/co_author_icon.png">
-            <#assign mapOfScienceIcon = "${urls.images}/visualization/mapofscience/scimap_icon.png">
             <#assign coAuthorVisUrl = individual.coAuthorVisUrl()>
-            <#assign mapOfScienceVisUrl = individual.mapOfScienceUrl()>
-            
+
+            <#if mapOfScienceVisualizationEnabled>
+                <#assign mapOfScienceIcon = "${urls.images}/visualization/mapofscience/scimap_icon.png">
+                <#assign mapOfScienceVisUrl = individual.mapOfScienceUrl()>
+            </#if>
+
             <#assign googleJSAPI = "https://www.google.com/jsapi?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22visualization%22%2C%22version%22%3A%221%22%2C%22packages%22%3A%5B%22imagesparkline%22%5D%7D%5D%7D"> 
             
             <#-- <h5 id="sparklineHeading">${i18n().publications_in_vivo}</h5> -->
@@ -44,15 +47,17 @@
             <#-- Another useless div -->
             <#-- <div class="collaboratorship-link-separator"></div> -->
             
-  	      	<div id="mapofscience_link_container" class="collaboratorship-link-container">
-            	<#-- Replaced map of science icon with glyphicon -->
-                <div class="collaboratorship-link">
-                    <a href="${mapOfScienceVisUrl}" title="${i18n().map_of_science}" class="btn btn-default btn-block">
-                        <#-- <span class="glyphicon glyphicon-globe" aria-hidden="true"></span> -->
-                        ${i18n().map_of_science_capitalized}
-                    </a>
+            <#if mapOfScienceVisualizationEnabled>
+                <div id="mapofscience_link_container" class="collaboratorship-link-container">
+                    <#-- Replaced map of science icon with glyphicon -->
+                    <div class="collaboratorship-link">
+                        <a href="${mapOfScienceVisUrl}" title="${i18n().map_of_science}" class="btn btn-default btn-block">
+                            <#-- <span class="glyphicon glyphicon-globe" aria-hidden="true"></span> -->
+                            ${i18n().map_of_science_capitalized}
+                        </a>
+                    </div>
                 </div>
-            </div>
+            </#if>
             
             ${scripts.add('<script type="text/javascript" src="${googleJSAPI}"></script>',
                           '<script type="text/javascript" src="${urls.base}/js/visualization/visualization-helper-functions.js"></script>',

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
@@ -21,9 +21,12 @@
             ${scripts.add('<script type="text/javascript" src="${urls.base}/js/d3.min.js"></script>')}
 
             <#assign coAuthorIcon = "${urls.images}/visualization/coauthorship/co_author_icon.png">
-            <#assign mapOfScienceIcon = "${urls.images}/visualization/mapofscience/scimap_icon.png">
             <#assign coAuthorVisUrl = individual.coAuthorVisUrl()>
-            <#assign mapOfScienceVisUrl = individual.mapOfScienceUrl()>
+
+            <#if mapOfScienceVisualizationEnabled>
+                <#assign mapOfScienceIcon = "${urls.images}/visualization/mapofscience/scimap_icon.png">
+                <#assign mapOfScienceVisUrl = individual.mapOfScienceUrl()>
+            </#if>
 
             <span id="publicationsHeading">${i18n().publications_in_vivo}</span>
 
@@ -150,12 +153,14 @@
                     </a>
                 </div>
 
-                <div id="mapofscience_link_container" class="collaboratorship-link-container">
-                    <a href="${mapOfScienceVisUrl}" title="${i18n().map_of_science}" class="btn btn-info" role="button">
-                        <img src="${mapOfScienceIcon}" alt="${i18n().map_of_science}" width="25px" height="25px" />
-                        ${i18n().map_of_science_capitalized}
-                    </a>
-                </div>
+                <#if mapOfScienceVisualizationEnabled>
+                    <div id="mapofscience_link_container" class="collaboratorship-link-container">
+                        <a href="${mapOfScienceVisUrl}" title="${i18n().map_of_science}" class="btn btn-info" role="button">
+                            <img src="${mapOfScienceIcon}" alt="${i18n().map_of_science}" width="25px" height="25px" />
+                            ${i18n().map_of_science_capitalized}
+                        </a>
+                    </div>
+                <#/if>
 
                 <#if isInvestigator>
                     <#assign coInvestigatorVisUrl = individual.coInvestigatorVisUrl()>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3821](https://github.com/vivo-project/VIVO/issues/3821)

Other Relevant Links (Mailing list discussion, related pull requests, etc.)
* Requires [Vitro PR 373](https://github.com/vivo-project/Vitro/pull/373)

# What does this pull request do?
Add an option to not show (disable) Map of Science Visualization link in the same manner as done with the Temporal Visualization link.

All themes and base template are updated accordingly.

# What's new?
* A new runtime property `visualization.mapOfScience` is added with the default set to `disabled`.
* Each theme is updated to handle either Map of Science Visualization or Temporal Visualization being `enabled` or `disabled` via the runtime configuration.

# How should this be tested?
Change the setting to enabled and disabled and check each theme to confirm behavior is consistent.

# Additional Notes:
This requires the Vitro PR linked above to properly process the new settings.

# Interested parties
@VIVO-project/vivo-committers
