### PR TITLE
[3850] fixing not closed if statement

### DIFF
--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-visualizationFoafPerson.ftl
@@ -160,7 +160,7 @@
                             ${i18n().map_of_science_capitalized}
                         </a>
                     </div>
-                <#/if>
+                </#if>
 
                 <#if isInvestigator>
                     <#assign coInvestigatorVisUrl = individual.coInvestigatorVisUrl()>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3850](https://github.com/vivo-project/VIVO/issues/3850)

# What does this pull request do?
Fix a small issue with non-closed if statement in an ftl file.

# What's new?
Fixed closing statement for tenderfoot individual-visualizationFoarPerson.ftl

# How should this be tested?

- build VIVO
- switch to tenderfoot theme (VIVO_HOME/rdf/applicationMetadata/firsttime/initialSiteConfig.rdf, replace wilma with tenderfoot)
- run VIVO
- ingest sample data
- click on Bogart Andrew (person)
- the person profile page should be displayed without any error


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
