### PR TITLE
fixing the issue with non-existing VIVO_HOME/rdf directory

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -56,9 +56,9 @@
                                 <configuration>
                                     <target>
                                         <delete includeemptydirs="true">
-                                            <fileset dir="${vivo-dir}/rdf">
-                                                <include name="**/*"/>
-                                                <exclude name="**/i18n/*_x_*/**"/>
+                                            <fileset dir="${vivo-dir}">
+                                                <include name="rdf/**/*"/>
+                                                <exclude name="rdf/**/i18n/*_x_*/**"/>
                                             </fileset>
                                         </delete>
                                     </target>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3855](https://github.com/vivo-project/VIVO/issues/3855)

# What does this pull request do?
Fixing a bug introduced by this [PR](https://github.com/vivo-project/VIVO/pull/3802/files#diff-f6ff34b05a4edd01967c9fec8efcb5430bbd24a181cf95af2f75ddd600c82c2f). It will be probably irrelevant after merging this [PR](https://github.com/vivo-project/Vitro/pull/370), but we should fix this meanwhile.

# How should this be tested?

- configure setting.xml (for instance VIVO/installer/example-settings.xml) to point to an empty VIVO_HOME directory
`<vivo-dir>/opt/VIVO/home1111</vivo-dir>`

- mvn clean install -s installer/example-settings.xml

- it should be successfully completed

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
