### PR TITLE
Set faux property 'participant' domain to obo:Process

### DIFF
--- a/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
+++ b/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
@@ -1910,6 +1910,7 @@ local:addressLocationConfig a :ObjectPropertyDisplayConfig ;
 local:bfo_0000055Context a :ConfigContext ;
     :hasConfiguration local:bfo_0000055Config ;
     :configContextFor <http://purl.obolibrary.org/obo/BFO_0000055> ;
+    :qualifiedByDomain <http://purl.obolibrary.org/obo/BFO_0000015> ;
     :qualifiedBy      <http://purl.obolibrary.org/obo/BFO_0000023> .
 
 local:bfo_0000055Config a :ObjectPropertyDisplayConfig ;


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3865)**

# What does this pull request do?
Sets domain for participant faux property to obo:Process.

# How should this be tested?
A description of what steps someone could take to:
* Create a project, at least one person
* Click add participant in project, select person.
* Verify that person is saved, list view is showing person.

# Interested parties
@tawahle  @brianjlowe @chenejac 
