### PR TITLE
Escape html values

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-contactInfo.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-contactInfo.ftl
@@ -46,7 +46,7 @@
             <ul id="${listId}" class="individual-emails" role="list" <#if editable>style="list-style:none;margin-left:0;"</#if>>
                 <#list email.statements as statement>
                     <li role="listitem">
-                        <a itemprop="email" class="email" href="mailto:${statement.emailAddress!}" title="${i18n().email}">${statement.emailAddress!}</a>
+                        <a itemprop="email" class="email" href="mailto:${statement.emailAddress!?html}" title="${i18n().email}">${statement.emailAddress!?html}</a>
                         <@p.editingLinks "${email.localName}" "${email.name}" statement editable email.rangeUri />
                     </li>
                 </#list>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
@@ -33,7 +33,7 @@
     </#if>
 
     <p>
-		<input class="acSelector" size="50"  type="text" id="literal" name="literal" value="${literalValues}" />
+		<input class="acSelector" size="50"  type="text" id="literal" name="literal" value="${literalValues!?html}" />
 	</p>
 
 	<div class="acSelection">

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEmailAddress.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEmailAddress.ftl
@@ -58,7 +58,7 @@
 
         <p>
             <label for="additionalEmail">${i18n().email_address} ${requiredHint}</label>
-            <input  size="35"  type="text" id="emailAddress" name="emailAddress" value="${emailAddressValue}" />
+            <input  size="35"  type="text" id="emailAddress" name="emailAddress" value="${emailAddressValue!?html}" />
         </p>
 
         <input type="hidden" id="editKey" name="editKey" value="${editKey}"/>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3869)**
[Vitro PR](https://github.com/vivo-project/Vitro/pull/388)
# What does this pull request do?
Fixes some freemarker templates to avoid invalid html.

# How should this be tested?

1. Create  individual with Label `Create data property with value </div>"</div>`
2. Add primary email address to a profile with a text `</div>"</div>`
3. Verify that profile page is not broken
4. Try to delete email address, verify that delete page is not broken.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
