### PR TITLE
Audit module (Change Tracking)

### DIFF
--- a/api/src/main/java/org/vivoweb/webapp/controller/freemarker/CreateAndLinkResourceController.java
+++ b/api/src/main/java/org/vivoweb/webapp/controller/freemarker/CreateAndLinkResourceController.java
@@ -21,6 +21,7 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.Tem
 import edu.cornell.mannlib.vitro.webapp.dao.IndividualDao;
 import edu.cornell.mannlib.vitro.webapp.dao.InsertException;
 import edu.cornell.mannlib.vitro.webapp.dao.NewURIMakerVitro;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.VTwo.N3EditUtils;
 import edu.cornell.mannlib.vitro.webapp.modelaccess.ModelNames;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.ChangeSet;
 import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
@@ -391,7 +392,7 @@ public class CreateAndLinkResourceController extends FreemarkerHttpServlet {
                 }
 
                 // Finished processing confirmation, write the differences between the existing and updated model
-                writeChanges(vreq.getRDFService(), existingModel, updatedModel);
+                writeChanges(vreq.getRDFService(), existingModel, updatedModel, N3EditUtils.getEditorUri(vreq));
             }
 
             // Get any IDs that have not yet been processed from the form
@@ -1815,8 +1816,9 @@ public class CreateAndLinkResourceController extends FreemarkerHttpServlet {
      * @param rdfService
      * @param existingModel
      * @param updatedModel
+     * @param editroUri 
      */
-    protected void writeChanges(RDFService rdfService, Model existingModel, Model updatedModel) {
+    protected void writeChanges(RDFService rdfService, Model existingModel, Model updatedModel, String editorUri) {
         Model removeModel = existingModel.difference(updatedModel);
         Model addModel = updatedModel.difference(existingModel);
 
@@ -1829,12 +1831,12 @@ public class CreateAndLinkResourceController extends FreemarkerHttpServlet {
 
             if (!addModel.isEmpty()) {
                 addStream = makeN3InputStream(addModel);
-                changeSet.addAddition(addStream, RDFService.ModelSerializationFormat.N3, ModelNames.ABOX_ASSERTIONS);
+                changeSet.addAddition(addStream, RDFService.ModelSerializationFormat.N3, ModelNames.ABOX_ASSERTIONS, editorUri);
             }
 
             if (!removeModel.isEmpty()) {
                 removeStream = makeN3InputStream(removeModel);
-                changeSet.addRemoval(removeStream, RDFService.ModelSerializationFormat.N3, ModelNames.ABOX_ASSERTIONS);
+                changeSet.addRemoval(removeStream, RDFService.ModelSerializationFormat.N3, ModelNames.ABOX_ASSERTIONS, editorUri);
             }
 
             try {

--- a/home/src/main/resources/config/example.applicationSetup.n3
+++ b/home/src/main/resources/config/example.applicationSetup.n3
@@ -26,9 +26,21 @@
     :hasSearchIndexer             :basicSearchIndexer ;
     :hasImageProcessor            :iioImageProcessor ;
     :hasFileStorage               :ptiFileStorage ;
+#    :hasAuditModule               :tdbAuditModule ;
     :hasContentTripleSource       :tdbContentTripleSource ;
     :hasConfigurationTripleSource :tdbConfigurationTripleSource ;
     :hasTBoxReasonerModule        :jfactTBoxReasonerModule .
+
+# ----------------------------
+#
+# Audit module: 
+#
+
+#:tdbAuditModule
+#    a   <java:edu.cornell.mannlib.vitro.webapp.audit.TDBAuditModule> ,
+#        <java:edu.cornell.mannlib.vitro.webapp.audit.AuditModule> ;
+#    :hasTdbDirectory "tdbAuditModels" .
+
 
 # ----------------------------
 #

--- a/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
+++ b/webapp/src/main/webapp/WEB-INF/resources/startup_listeners.txt
@@ -92,3 +92,6 @@ edu.cornell.mannlib.vitro.webapp.controller.individual.VIVOIndividualResponseBui
 
 # This should be near the end, because it will issue a warning if the connection to the SearchEngine times out.
 edu.cornell.mannlib.vitro.webapp.servlet.setup.SearchEngineSmokeTest
+
+edu.cornell.mannlib.vitro.webapp.audit.AuditSetup
+


### PR DESCRIPTION
**[VIVO GitHub issue 1](https://github.com/vivo-project/VIVO/issues/3135)**
**[VIVO GitHub issue 2](https://github.com/vivo-project/VIVO/issues/3832)**

[Vitro PR](https://github.com/vivo-project/Vitro/pull/390)

# What does this pull request do?
The pull request adds a module that enables tracking of changes being made in the triple store by users and non-person entitites.
Changes are recorded in a triple store, with the users ID (URI), the time, and the changes that have been made.
A user interface (/audit) is also provided that, when logged in, displays the changes.

# What's new?
Adds a new AuditModule application module
TDBAuditModule can be configured / enabled via the applicationSetup.n3
RDFService change listener capture any changes made to the content and configuration stores, and record those changes in a dedicated audit store.
Tests included

# How should this be tested?
* Enable AuditModule in applicationSetup.n3 (uncomment :hasAuditModule and :tdbAuditModule section)
* Login as admin or root user, open /audit page, 
* View changes presented on the page.
* Try different filters

# Supersedes
https://github.com/vivo-project/Vitro/pull/369
https://github.com/vivo-project/Vitro/pull/81

# Interested parties
@chenejac @brianjlowe 
