### PR TITLE
Update vivo_UiLabel_wilma.ttl

### DIFF
--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_wilma.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_wilma.ttl
@@ -1,4 +1,4 @@
-vitro/ui-label/@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix uil-data: <http://vivoweb.org/ontology/vitro/ui-label/individual#> .
 @prefix uil:  <http://vivoweb.org/ontology/vitro/ui-label//vocabulary#> .


### PR DESCRIPTION
Ontology bug blocking loading on Tomcat startup

# What does this pull request do?
Deletes a string that should not be part of the ontology

# How should this be tested?
Before the correction, the following trace appeared when tomcat started up
`
2023-05-29 11:59:44,493 INFO  [RDFFilesLoader] Loading rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel.ttl
2023-05-29 11:59:44,554 INFO  [RDFFilesLoader] Loading rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_tenderfoot.ttl
2023-05-29 11:59:44,558 INFO  [RDFFilesLoader] Loading rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_wilma.ttl
2023-05-29 11:59:44,560 WARN  [RDFFilesLoader] Could not load file '....../vivo/home/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel_wilma.ttl' as TURTLE. Check that it contains valid data.
org.apache.jena.riot.RiotException: [line: 1, col: 1 ] Out of place: [KEYWORD:vitro]
        at org.apache.jena.riot.system.ErrorHandlerFactory$ErrorHandlerStd.fatal(ErrorHandlerFactory.java:153)
        at org.apache.jena.riot.lang.LangEngine.raiseException(LangEngine.java:148)
        at org.apache.jena.riot.lang.LangEngine.exceptionDirect(LangEngine.java:143)
        at org.apache.jena.riot.lang.LangEngine.exception(LangEngine.java:137)
        at org.apache.jena.riot.lang.LangTurtleBase.triplesSameSubject(LangTurtleBase.java:235)
        at org.apache.jena.riot.lang.LangTurtle.oneTopLevelElement(LangTurtle.java:46)
        at org.apache.jena.riot.lang.LangTurtleBase.runParser(LangTurtleBase.java:79)
        at org.apache.jena.riot.lang.LangBase.parse(LangBase.java:41)
        at org.apache.jena.riot.RDFParserRegistry$ReaderRIOTLang.read(RDFParserRegistry.java:184)
        at org.apache.jena.riot.RDFParser.read(RDFParser.java:353)
        at org.apache.jena.riot.RDFParser.parseNotUri(RDFParser.java:343)
        at org.apache.jena.riot.RDFParser.parse(RDFParser.java:292)
        at org.apache.jena.riot.RDFParserBuilder.parse(RDFParserBuilder.java:540)
        at org.apache.jena.riot.RDFDataMgr.parseFromInputStream(RDFDataMgr.java:901)
        at org.apache.jena.riot.RDFDataMgr.read(RDFDataMgr.java:299)
        at org.apache.jena.riot.RDFDataMgr.read(RDFDataMgr.java:285)
        at org.apache.jena.riot.adapters.RDFReaderRIOT.read(RDFReaderRIOT.java:69)
        at org.apache.jena.rdf.model.impl.ModelCom.read(ModelCom.java:283)
        at edu.cornell.mannlib.vitro.webapp.servlet.setup.RDFFilesLoader.readOntologyFileIntoModel(RDFFilesLoader.java:200)
        at edu.cornell.mannlib.vitro.webapp.servlet.setup.RDFFilesLoader.loadFirstTimeFiles(RDFFilesLoader.java:97)
`
# Interested parties
@chenejac 
