### PR TITLE
Limit callback to only ipretFullResults and ipretResults values

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/capabilitymap/CapabilityMapRequestHandler.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/visualization/capabilitymap/CapabilityMapRequestHandler.java
@@ -31,12 +31,18 @@ import edu.cornell.mannlib.vitro.webapp.visualization.utilities.VisualizationCac
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.VisualizationRequestHandler;
 import org.apache.commons.logging.Log;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class CapabilityMapRequestHandler implements VisualizationRequestHandler {
+    
+    private static final String IPRET_FULL_RESULTS = "ipretFullResults";
+    private static final String IPRET_RESULTS = "ipretResults";
+    private static Set<String> callbackValues = new HashSet<String>(Arrays.asList(IPRET_FULL_RESULTS, IPRET_RESULTS));
+    
     @Override
     public AuthorizationRequest getRequiredPrivileges() {
         return null;
@@ -109,7 +115,7 @@ public class CapabilityMapRequestHandler implements VisualizationRequestHandler 
             ObjectMapper mapper = new ObjectMapper();
 
             String callback = vitroRequest.getParameter("callback");
-            if (!StringUtils.isEmpty(callback)) {
+            if (!StringUtils.isEmpty(callback) && callbackValues.contains(callback)) {
                 return callback + "(" + mapper.writeValueAsString(response) + ");";
             }
             return mapper.writeValueAsString(response);
@@ -162,7 +168,7 @@ public class CapabilityMapRequestHandler implements VisualizationRequestHandler 
 
             ObjectMapper mapper = new ObjectMapper();
             String callback = vitroRequest.getParameter("callback");
-            if (!StringUtils.isEmpty(callback)) {
+            if (!StringUtils.isEmpty(callback) && callbackValues.contains(callback)) {
                 return callback + "(" + mapper.writeValueAsString(response) + ");";
             }
             return mapper.writeValueAsString(response);


### PR DESCRIPTION
# What does this pull request do?
Limits callback to only ipretFullResults and ipretResults values

# How should this be tested?
A description of what steps someone could take to:
* Build and install VIVO
* Load sample data
* Open capability map
* Enter Civil War Reconstruction
* Capability map should work
* Try using the url described in the slack thread
/visualizationAjax?vis=capabilitymap&query=291822&callback=ipretResultsoesic<script>alert(1)<%2fscript>cwz3i&noCacheIE=1687235208332
* Alert in the browser shouldn't appear.

# Additional Notes:
Slack discussion https://vivo-project.slack.com/archives/C8RL9L98A/p1687378615914659

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
