### PR TITLE
Codeql action upgrade

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, rel-1.12.1-RC, rel-1.12.0-maint ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3902](https://github.com/vivo-project/VIVO/issues/3902)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
    * https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

# What does this pull request do?
Upgrading the codeql-action version (v1 is deprecated, it is upgraded to v2)

# What's new?
codeql-analysis.yml files is slightly changed

# How should this be tested?
https://github.com/vivo-project/VIVO/actions/runs/5690776782 there shouldn't be errors present in the previous running of codeql action, such as https://github.com/vivo-project/VIVO/actions/runs/5630429939


# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
