### PR TITLE
Fixed jquery selector for capability map tabs

### DIFF
--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -388,7 +388,7 @@ FullResultQueryUnit.prototype.fetch = function() {
 
 var showPanel = function(name) {
     $(".titles li").removeClass("activeTab");
-    $(".titles li a[href=#" + name + "]").parent().addClass("activeTab");
+    $(".titles li a[href='#" + name + "']").parent().addClass("activeTab");
     $(".result_section").css("display", "none");
     $("#" + name).css("display", "block");
 }


### PR DESCRIPTION
# What does this pull request do?
Fixes the unresponsive behavior of capability map nodes in the Nemo theme when clicked. The issue stemmed from an incorrect jQuery selector used in the theme's jQuery version.

# What's new?
Resolved the jQuery selector issue by adding single quotes to the value of the href attribute:
    $(".titles li a[href='#" + name + "']")...
    

# How should this be tested?
1. Open the Capability Map tab.
2. Search for an item.
3. Click on a node to verify if it opens the information tab on the right side.
4. Test this across all themes for thorough validation.

![image](https://github.com/vivo-project/VIVO/assets/18060127/e7a36605-9bff-4b32-a123-cd6ad19c2e45)
