### PR TITLE
Fix for dates document modifier

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/searchFieldsConfigurationVivo.n3
+++ b/home/src/main/resources/rdf/display/everytime/searchFieldsConfigurationVivo.n3
@@ -152,6 +152,6 @@
                   )
                   BIND( CONCAT("[", STR(?cleanDateValue)," TO ", STR(?cleanDateValue),"]") as ?result )
 		}
-	}
+	} LIMIT 1
 """ .
 


### PR DESCRIPTION

# What does this pull request do?
In case data contain multiple ranges it prevents document modifier from sending multiple ranges to the same search field, which doesn't support multiple ranges.

# Interested parties
@VIVO-project/vivo-committers
