### PR TITLE
Disallow forms (with CAPTCHA) to bots

### DIFF
--- a/webapp/src/main/webapp/robots.txt
+++ b/webapp/src/main/webapp/robots.txt
@@ -16,6 +16,9 @@ Disallow: /fedsearch/         # Vitro
 Disallow: /comments.jsp       # Vitro
 Disallow: /dataservice/       # Vitro
 Disallow: /listrdf/           # Vitro
+Disallow: /contact            # Vitro
+Disallow: /submitFeedback     # Vitro
+Disallow: /forgot-password    # Vitro
 Disallow: /visualizationfm/   # VIVO addition
 Disallow: /visualization/     # VIVO addition
 Disallow: /vis/               # VIVO addition

--- a/webapp/src/main/webapp/robots.txt
+++ b/webapp/src/main/webapp/robots.txt
@@ -18,7 +18,7 @@ Disallow: /dataservice/       # Vitro
 Disallow: /listrdf/           # Vitro
 Disallow: /contact            # Vitro
 Disallow: /submitFeedback     # Vitro
-Disallow: /forgot-password    # Vitro
+Disallow: /forgotPassword     # Vitro
 Disallow: /visualizationfm/   # VIVO addition
 Disallow: /visualization/     # VIVO addition
 Disallow: /vis/               # VIVO addition


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [3935](https://github.com/vivo-project/VIVO/issues/3935)

[Linked Vitro PR](https://github.com/vivo-project/Vitro/pull/438)


# What does this pull request do?
Disallow access to /contact and /forgot-password to bots (at least to bots which respect robots.txt)

# What's new?
robots.txt is updated

# How should this be tested?
Run VIVO and try to access to /contact and /forgotPassword from the web browser (this should work), and then testing robots.txt file by using some validator such as [this one](https://technicalseo.com/tools/robots-txt/). Please note that you run VIVO at some public address as a root application (meaning it should not be http://somedomain.com/vivo, it should be http://somedomain.com)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers
