### PR TITLE
Improved docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,22 @@
-LOCAL_VIVO_HOME=./vivo-home
-RESET_HOME=false
-RESET_CORE=false
-VERBOSE=no
+# Variable substitution for docker-compose.yml
+
+# solr service variable substitution
+SOLR_RESET_CORE=false
+SOLR_VERBOSE=no
+
+SOLR_HOST_PORT=8983
+SOLR_CONTAINER_PORT=8983
+
+SOLR_CORES=./vivo-cores
+
+# tomcat service variable substitution
+VIVO_RESET_HOME=false
+VIVO_VERBOSE=no
+
+VIVO_TDB_FILE_MODE=direct
+
+VIVO_HOST_VIVO_HOME=./vivo-home
+VIVO_CONTAINER_VIVO_HOME=/usr/local/vivo/home
+
+VIVO_HOST_PORT=8080
+VIVO_CONTAINER_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ utilities/rdbmigration/.work
 **/.project
 **/bin/
 
+vivo-cores/
 vivo-home/
 
 .fake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM tomcat:9-jdk11-openjdk
 
-ARG SOLR_URL=http://localhost:8983/solr/vivocore
-ARG VIVO_DIR=/usr/local/vivo/home
 ARG TDB_FILE_MODE=direct
+ARG VIVO_HOME=/usr/local/vivo/home
+ARG SOLR_URL=http://localhost:8983/solr/vivocore
 
-ENV SOLR_URL=${SOLR_URL}
 ENV JAVA_OPTS="${JAVA_OPTS} -Dtdb:fileMode=$TDB_FILE_MODE"
+ENV VIVO_HOME=${VIVO_HOME}
+ENV SOLR_URL=${SOLR_URL}
 
-RUN mkdir /usr/local/vivo
-RUN mkdir /usr/local/vivo/home
+RUN mkdir -p ${VIVO_HOME}
 
+# VIVO home onto image for backup, initial $VIVO_HOME, reset
 COPY ./installer/home/target/vivo /vivo-home
 COPY ./installer/webapp/target/vivo.war /usr/local/tomcat/webapps/ROOT.war
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV SOLR_URL=${SOLR_URL}
 
 RUN mkdir -p ${VIVO_HOME}
 
-# VIVO home onto image for backup, initial $VIVO_HOME, reset
+# Copy VIVO home onto image for backup, initialization, and reset
 COPY ./installer/home/target/vivo /vivo-home
 COPY ./installer/webapp/target/vivo.war /usr/local/tomcat/webapps/ROOT.war
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,43 @@ VIVO docker container is available at [vivoweb/vivo](https://hub.docker.com/repo
 
 ### Docker Compose
 
-Docker Compose environment variables:
+Docker Compose variable substitution:
 
 .env defaults
 ```
-LOCAL_VIVO_HOME=./vivo-home
-RESET_HOME=false
-RESET_CORE=false
+SOLR_RESET_CORE=false
+SOLR_VERBOSE=no
+
+SOLR_HOST_PORT=8983
+SOLR_CONTAINER_PORT=8983
+
+SOLR_CORES=./vivo-cores
+
+VIVO_RESET_HOME=false
+VIVO_VERBOSE=no
+
+VIVO_TDB_FILE_MODE=direct
+
+VIVO_HOST_VIVO_HOME=./vivo-home
+VIVO_CONTAINER_VIVO_HOME=/usr/local/vivo/home
+
+VIVO_HOST_PORT=8080
+VIVO_CONTAINER_PORT=8080
 ```
 
-- `LOCAL_VIVO_HOME`: VIVO home directory on your host machine which will mount to volume in docker container. Set this environment variable to persist your VIVO data on your host machine.
-- `RESET_HOME`: Convenience to reset VIVO home when starting container. **Caution**, will delete local configuration, content, and configuration model.
-- `RESET_CORE`: Convenience to reset VIVO Solr core when starting container. **Caution**, will require complete reindex.
+- `SOLR_RESET_CORE`: Convenience to reset VIVO Solr core when starting container. **Caution**, will require complete reindex.
+- `SOLR_VERBOSE`: Increase log verbosity.
+- `SOLR_HOST_PORT`: Host port binding for solr service port mapping.
+- `SOLR_CONTAINER_PORT`: Container port binding for solr service port mapping.
+- `SOLR_CORES`: Solr cores data directories on your host machine which will mount to volume in docker container. Set this environment variable to persist your Solr data on your host machine.
+
+- `VIVO_RESET_HOME`: Convenience to reset VIVO home when starting container. **Caution**, will delete local configuration, content, and configuration model.
+- `VIVO_VERBOSE`: Increase log verbosity.
+- `VIVO_TDB_FILE_MODE`: TDB file mode. See https://jena.apache.org/documentation/tdb/configuration.html#file-access-mode.
+- `VIVO_HOST_VIVO_HOME`: VIVO home directory on your host machine which will mount to volume in docker container. Set this environment variable to persist your VIVO data on your host machine.
+- `VIVO_CONTAINER_VIVO_HOME`: VIVO home directory within the container.
+- `VIVO_HOST_PORT`: Host port binding for VIVO Tomcat service port mapping.
+- `VIVO_CONTAINER_PORT`: Container port binding for VIVO Tomcat service port mapping.
 
 Before building VIVO, you will also need to clone (and switch to the same branch, if other than main) of [Vitro](https://github.com/vivo-project/Vitro). The Vitro project must be cloned to a sibling directory next to VIVO so that it can be found during the build. 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,12 @@ services:
   solr:
     image: vivoweb/vivo-solr:latest
     environment:
-      - RESET_CORE=${RESET_CORE}
-      - VERBOSE=${VERBOSE}
+      - RESET_CORE=${SOLR_RESET_CORE}
+      - VERBOSE=${SOLR_VERBOSE}
     ports:
-      - 8983:8983
+      - ${SOLR_HOST_PORT}:${SOLR_CONTAINER_PORT}
+    volumes:
+      - ${SOLR_CORES}:/opt/solr/server/solr/mycores
     networks:
       - vivo
 
@@ -19,18 +21,26 @@ services:
       context: ./
       dockerfile: Dockerfile
       args:
-        - VIVO_DIR=/usr/local/vivo/home
-        - TDB_FILE_MODE=direct
-        - SOLR_URL=http://solr:8983/solr/vivocore
+        - TDB_FILE_MODE=${VIVO_TDB_FILE_MODE}
+        - VIVO_HOME=${VIVO_CONTAINER_VIVO_HOME}
+        - SOLR_URL=http://solr:${SOLR_CONTAINER_PORT}/solr/vivocore
     environment:
-      - RESET_HOME=${RESET_HOME}
-      - VERBOSE=${VERBOSE}
+      - RESET_HOME=${VIVO_RESET_HOME}
+      - VERBOSE=${VIVO_VERBOSE}
     ports:
-      - 8080:8080
+      - ${VIVO_HOST_PORT}:${VIVO_CONTAINER_PORT}
     volumes:
-      - ${LOCAL_VIVO_HOME}:/usr/local/vivo/home
+      - ${VIVO_HOST_VIVO_HOME}:${VIVO_CONTAINER_VIVO_HOME}
     networks:
       - vivo
+    depends_on:
+      - solr
+    entrypoint:
+      - /bin/bash
+      - '-c'
+      - |
+        while (!</dev/tcp/solr/${SOLR_CONTAINER_PORT}) > /dev/null 2>&1; do sleep 1; done;
+        catalina.sh run
 
 networks:
   vivo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.2'
 
 services:
 
-  solr:
+  vivo-solr:
+    container_name: vivo-solr
     image: vivoweb/vivo-solr:latest
     environment:
       - RESET_CORE=${SOLR_RESET_CORE}
@@ -12,10 +13,16 @@ services:
     volumes:
       - ${SOLR_CORES}:/opt/solr/server/solr/mycores
     networks:
-      - vivo
+      - vivoweb
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8983/solr/vivocore/admin/ping || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
-  tomcat:
+  vivo:
     container_name: vivo
+    image: vivoweb/vivo:latest
     hostname: vivo
     build:
       context: ./
@@ -23,7 +30,7 @@ services:
       args:
         - TDB_FILE_MODE=${VIVO_TDB_FILE_MODE}
         - VIVO_HOME=${VIVO_CONTAINER_VIVO_HOME}
-        - SOLR_URL=http://solr:${SOLR_CONTAINER_PORT}/solr/vivocore
+        - SOLR_URL=http://vivo-solr:${SOLR_CONTAINER_PORT}/solr/vivocore
     environment:
       - RESET_HOME=${VIVO_RESET_HOME}
       - VERBOSE=${VIVO_VERBOSE}
@@ -32,15 +39,10 @@ services:
     volumes:
       - ${VIVO_HOST_VIVO_HOME}:${VIVO_CONTAINER_VIVO_HOME}
     networks:
-      - vivo
+      - vivoweb
     depends_on:
-      - solr
-    entrypoint:
-      - /bin/bash
-      - '-c'
-      - |
-        while (!</dev/tcp/solr/${SOLR_CONTAINER_PORT}) > /dev/null 2>&1; do sleep 1; done;
-        catalina.sh run
+      vivo-solr:
+        condition: service_healthy
 
 networks:
-  vivo:
+  vivoweb:

--- a/start.sh
+++ b/start.sh
@@ -9,51 +9,51 @@ fi
 
 # allow easier reset home with `docker run -e RESET_HOME=true`
 if [[ "$RESET_HOME" = "true" ]]; then
-  echo 'Clearing VIVO HOME /usr/local/vivo/home'
-  rm -rf /usr/local/vivo/home/*
+  echo "Clearing VIVO HOME $VIVO_HOME"
+  rm -rf "$VIVO_HOME/*"
 fi
 
 # copy home bin if not exists
-if [ ! -d /usr/local/vivo/home/bin ]; then
-  echo "Copying home bin directory to /usr/local/vivo/home/bin"
-  cp -r /vivo-home/bin /usr/local/vivo/home/bin
+if [ ! -d "$VIVO_HOME/bin" ]; then
+  echo "Copying home bin directory to $VIVO_HOME/bin"
+  cp -r /vivo-home/bin "$VIVO_HOME/bin"
 fi
 
 # copy home config if not exists
-if [ ! -d /usr/local/vivo/home/config ]; then
-  echo "Copying home config directory to /usr/local/vivo/home/config"
-  cp -r /vivo-home/config /usr/local/vivo/home/config
+if [ ! -d $VIVO_HOME/config ]; then
+  echo "Copying home config directory to $VIVO_HOME/config"
+  cp -r /vivo-home/config "$VIVO_HOME/config"
 fi
 
 # copy home rdf if not exists
-if [ ! -d /usr/local/vivo/home/rdf ]; then
-  echo "Copying home rdf directory to /usr/local/vivo/home/rdf"
-  cp -r /vivo-home/rdf /usr/local/vivo/home/rdf
+if [ ! -d $VIVO_HOME/rdf ]; then
+  echo "Copying home rdf directory to $VIVO_HOME/rdf"
+  cp -r /vivo-home/rdf "$VIVO_HOME/rdf"
 fi
 
 # copy runtime.properties if it does not already exist in target home directory
-if [ -f /usr/local/vivo/home/config/example.runtime.properties ]; then
-  if [ ! -f /usr/local/vivo/home/config/runtime.properties ]
+if [ -f "$VIVO_HOME/config/example.runtime.properties" ]; then
+  if [ ! -f "$VIVO_HOME/config/runtime.properties" ]
   then
-    echo "Copying example.runtime.properties to /usr/local/vivo/home/config/runtime.properties"
-    cp /usr/local/vivo/home/config/example.runtime.properties /usr/local/vivo/home/config/runtime.properties
+    echo "Copying example.runtime.properties to $VIVO_HOME/config/runtime.properties"
+    cp "$VIVO_HOME/config/example.runtime.properties" "$VIVO_HOME/config/runtime.properties"
 
     # template runtime.properties vitro.local.solr.url value to $SOLR_URL value
     echo "Templating runtime.properties vitro.local.solr.url = $SOLR_URL"
-    sed -i "s,http://localhost:8983/solr/vivocore,$SOLR_URL,g" /usr/local/vivo/home/config/runtime.properties
+    sed -i "s,http://localhost:8983/solr/vivocore,$SOLR_URL,g" "$VIVO_HOME/config/runtime.properties"
   else
-    echo "Using existing /usr/local/vivo/home/config/runtime.properties"
+    echo "Using existing $VIVO_HOME/config/runtime.properties"
   fi
 fi
 
 # copy applicationSetup.n3 if it does not already exist in target home directory
-if [ -f /usr/local/vivo/home/config/example.applicationSetup.n3 ]; then
-  if [ ! -f /usr/local/vivo/home/config/applicationSetup.n3 ]
+if [ -f "$VIVO_HOME/config/example.applicationSetup.n3" ]; then
+  if [ ! -f "$VIVO_HOME/config/applicationSetup.n3" ]
   then
-    echo "Copying example.applicationSetup.n3 to /usr/local/vivo/home/config/applicationSetup.n3"
-    cp /usr/local/vivo/home/config/example.applicationSetup.n3 /usr/local/vivo/home/config/applicationSetup.n3
+    echo "Copying example.applicationSetup.n3 to $VIVO_HOME/config/applicationSetup.n3"
+    cp "$VIVO_HOME/config/example.applicationSetup.n3" "$VIVO_HOME/config/applicationSetup.n3"
   else
-    echo "Using existing /usr/local/vivo/home/config/applicationSetup.n3"
+    echo "Using existing $VIVO_HOME/config/applicationSetup.n3"
   fi
 fi
 


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: https://github.com/vivo-project/VIVO/issues/3939

# What does this pull request do?
This PR provides more configurability for docker compose and build of the VIVO docker image. Primarily addressing port mapping configuration via `.env` file for `docker-compose.yml` variable substitution.

# What's new?

1. solr and tomcat service port mapping configurable via `.env`
2. ability to specify VIVO home path within the container
3. local mount for VIVO solr core data to persist through container restarts

# How should this be tested?

This can be tested by following https://github.com/wwelling/VIVO/blob/issue-3939/README.md#docker-compose. For more exhaustive testing the `.env` file can be modified between container restarts for desired effect.

# Interested parties
@chenejac, @isl3
