### PR TITLE
Support self editor profile matching by using External Auth ID

### DIFF
--- a/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
@@ -64,14 +64,14 @@ access-individual:PersonProfileProximityToResourceUri a access:SparqlSelectValue
         {
           ?profileUri <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
           ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
-          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?roleUri <http://vivoweb.org/ontology/core#roleContributesTo> ?resourceUri .
           ?resourceUri a <http://vivoweb.org/ontology/core#Project> .
         }
         UNION
         {
           ?profileUri <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
           ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
-          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?roleUri <http://vivoweb.org/ontology/core#roleContributesTo> ?resourceUri .
           ?resourceUri a <http://vivoweb.org/ontology/core#Service> .
         }
         UNION
@@ -137,14 +137,14 @@ access-individual:ExternalIdMatchProfileProximityToResourceUri a access:SparqlSe
         {
           ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
           ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
-          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?roleUri <http://vivoweb.org/ontology/core#roleContributesTo> ?resourceUri .
           ?resourceUri a <http://vivoweb.org/ontology/core#Project> .
         }
         UNION
         {
           ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
           ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
-          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?roleUri <http://vivoweb.org/ontology/core#roleContributesTo> ?resourceUri .
           ?resourceUri a <http://vivoweb.org/ontology/core#Service> .
         }
         UNION

--- a/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/profile_proximity_query.n3
@@ -3,6 +3,12 @@
 @prefix access-individual: <https://vivoweb.org/ontology/vitro-application/auth/individual/> .
 @prefix access: <https://vivoweb.org/ontology/vitro-application/auth/vocabulary/> .
 
+# Reserved variable names:
+# profileUri - user account associated profile
+# objectUri - access object uri
+# externalAuthId - user account external auth id (should match with profile external auth id)
+# matchingPropertyUri - uri of property used for auth id matching, selfEditing.idMatchingProperty defined in runtime.properties 
+
 access-individual:PersonProfileProximityToResourceUri a access:SparqlSelectValuesQuery ;
     access:id """
     SELECT ?resourceUri WHERE {
@@ -70,8 +76,81 @@ access-individual:PersonProfileProximityToResourceUri a access:SparqlSelectValue
         }
         UNION
         { 
-          BIND ( ?profileUri as ?resourceUri)
+          BIND (?profileUri as ?resourceUri)
         }
     }
     """ .
 
+access-individual:ExternalIdMatchProfileProximityToResourceUri a access:SparqlSelectValuesQuery ;
+    access:id """
+    SELECT ?resourceUri WHERE {
+        ?profile ?matchingPropertyUri ?externalAuthId .
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#AdvisorRole> .
+          ?roleUri <http://vivoweb.org/ontology/core#relatedBy> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#AdvisingRelationship> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#TeacherRole> .
+          ?roleUri <http://purl.obolibrary.org/obo/BFO_0000054> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Course> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#PrincipalInvestigatorRole> .
+          ?roleUri <http://vivoweb.org/ontology/core#relatedBy> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Grant> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#CoPrincipalInvestigatorRole> .
+          ?roleUri <http://vivoweb.org/ontology/core#relatedBy> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Grant> .
+        }
+        UNION
+        {
+          ?profile <http://vivoweb.org/ontology/core#relatedBy> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#Authorship> .
+          ?roleUri <http://vivoweb.org/ontology/core#relates> ?resourceUri .
+          ?resourceUri a <http://purl.obolibrary.org/obo/IAO_0000030> .
+        }
+        UNION
+        {
+          ?profile <http://vivoweb.org/ontology/core#relatedBy> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#Editorship> .
+          ?roleUri <http://vivoweb.org/ontology/core#relates> ?resourceUri .
+          ?resourceUri a <http://purl.obolibrary.org/obo/IAO_0000030> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#PresenterRole> .
+          ?roleUri <http://purl.obolibrary.org/obo/BFO_0000054> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Presentation> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
+          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Project> .
+        }
+        UNION
+        {
+          ?profile <http://purl.obolibrary.org/obo/RO_0000053> ?roleUri .
+          ?roleUri a <http://vivoweb.org/ontology/core#ClinicalRole> .
+          ?roleUri <http://vivoweb.org/ontology/core#contributesTo> ?resourceUri .
+          ?resourceUri a <http://vivoweb.org/ontology/core#Service> .
+        }
+        UNION
+        {
+          ?profile ?matchingPropertyUri ?externalAuthId .
+          BIND (?profile as ?resourceUri)
+        }
+    }
+    """ .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3945)**

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
[Vitro PR](https://github.com/vivo-project/Vitro/pull/444)

# What does this pull request do?
Fixes broken profile linking made by using External Auth ID.

# What's new?

- Refactored PolicyHelper and AuthorizationRequest to use UserAccount instead of of IdentifierBundle.
- Modified SparqlSelectQueryResultsChecker to support queries that contain externalAuthId and matchingPropertyUri
- Modified existing policies to find related profiles by using External Auth ID

# How should this be tested?
* Reproduce the problem described in the issue
* Apply Vitro PR and this PR, build VIVO
* Create a self editor user account and 2 profiles, link user account with one of created profiles by using External Auth ID
* In both profiles add/create one new publication.
* Log in as a self edtor, check that user can edit his own profile and can't edit not related profile
* As a self editor check that publication related to owned profile is editable and publication not related to the profile is not editable
* As a root user on Property Editing Form of the property that is used to show publication in the profile click checkbox "Suppress Display for this property in unrelated individuals".
* As a self editor check that property is still visible in owned profile and not visible in not related profile
* As a root user on Class Editing Form of the publication class click checkbox "Suppress Display for not related individual pages of class".
* As a self editor check that related publication profile is still accessible and editable and not related publication profile is not accessible (redirects to home page)

# Interested parties
@VIVO-project/vivo-committers
