### PR TITLE
Allow self editors to modify websites on related profile pages

### DIFF
--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_add_object_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_add_object_property.n3
@@ -107,4 +107,5 @@
     <http://www.ebi.ac.uk/efo/swo/SWO_0000741> ,
     <http://www.w3.org/2004/02/skos/core#broader> ,
     <http://www.w3.org/2004/02/skos/core#narrower> ,
+    <http://purl.obolibrary.org/obo/ARG_2000028> ,
     <http://www.w3.org/2004/02/skos/core#related> .

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_drop_object_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_drop_object_property.n3
@@ -107,4 +107,5 @@
     <http://www.ebi.ac.uk/efo/swo/SWO_0000741> ,
     <http://www.w3.org/2004/02/skos/core#broader> ,
     <http://www.w3.org/2004/02/skos/core#narrower> ,
+    <http://purl.obolibrary.org/obo/ARG_2000028> ,
     <http://www.w3.org/2004/02/skos/core#related> .

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_edit_object_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_edit_object_property.n3
@@ -107,4 +107,5 @@
     <http://www.ebi.ac.uk/efo/swo/SWO_0000741> ,
     <http://www.w3.org/2004/02/skos/core#broader> ,
     <http://www.w3.org/2004/02/skos/core#narrower> ,
+    <http://purl.obolibrary.org/obo/ARG_2000028> ,
     <http://www.w3.org/2004/02/skos/core#related> .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3949)**

# What does this pull request do?
Added permissions to allow self editors add/edit/remove websites on related profile pages.

# What's new?
Added permissions to allow self editors add/edit/remove statements with object property obo:ARG_2000028

# How should this be tested?
* Reproduce the problem described in the issue
* Test that the pull request resolves the issue.


# Interested parties
@VIVO-project/vivo-committers
