### PR TITLE
Fix for VIVO-3949

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditWebpageFormGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditWebpageFormGenerator.java
@@ -3,6 +3,7 @@ package edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -60,6 +61,7 @@ public class AddEditWebpageFormGenerator extends BaseEditConfigurationGenerator 
 
 	    config.setVarNameForSubject("subject");
 	    config.setVarNameForObject("vcard");
+	    config.addFormSpecificData("fauxContextUri", vreq.getParameter("fauxContextUri"));
 
 	    config.addNewResource("vcard", DEFAULT_NS_FOR_NEW_RESOURCE);
 	    config.addNewResource("link", DEFAULT_NS_FOR_NEW_RESOURCE);
@@ -238,6 +240,7 @@ public class AddEditWebpageFormGenerator extends BaseEditConfigurationGenerator 
 		String rangeUri = (String) vreq.getParameter("rangeUri");
 		String generatorName = "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManageWebpagesForIndividualGenerator";
 		String editUrl = EditConfigurationUtils.getEditUrlWithoutContext(vreq);
+		String fauxContextUri = vreq.getParameter("fauxContextUri");
 		String returnPath =  editUrl + "?subjectUri=" + UrlBuilder.urlEncode(subjectUri) +
 		"&predicateUri=" + UrlBuilder.urlEncode(predicateUri) +
 		"&editForm=" + UrlBuilder.urlEncode(generatorName);
@@ -246,6 +249,9 @@ public class AddEditWebpageFormGenerator extends BaseEditConfigurationGenerator 
 		}
 		if(rangeUri != null && !rangeUri.isEmpty()) {
 			returnPath += "&rangeUri=" + UrlBuilder.urlEncode(rangeUri);
+		}
+		if (StringUtils.isNotBlank(fauxContextUri)) {
+		    returnPath += "&fauxContextUri=" + UrlBuilder.urlEncode(fauxContextUri);
 		}
 		return returnPath;
 

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
@@ -38,6 +38,8 @@ import edu.cornell.mannlib.vitro.webapp.rdfservice.RDFService;
  * This mainly sets up pageData for the template to use.
  */
 public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationGenerator implements EditConfigurationGenerator {
+    private static final String OBO_HAS_CONTACT_INFO_URI = "http://purl.obolibrary.org/obo/ARG_2000028";
+
     public static Log log = LogFactory.getLog(ManageWebpagesForIndividualGenerator.class);
 
     @Override
@@ -59,10 +61,12 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
         config.addFormSpecificData("rankPredicate", "http://vivoweb.org/ontology/core#rank" );
         config.addFormSpecificData("reorderUrl", "/edit/reorder" );
         config.addFormSpecificData("deleteWebpageUrl", "/edit/primitiveDelete");
+        String fauxContextUri = vreq.getParameter("fauxContextUri");
 
         ParamMap paramMap = new ParamMap();
         paramMap.put("subjectUri", config.getSubjectUri());
         paramMap.put("editForm", this.getEditForm());
+        paramMap.put("fauxContextUri", fauxContextUri);
         paramMap.put("view", "form");
         String path = UrlBuilder.getUrl( UrlBuilder.Route.EDIT_REQUEST_DISPATCH ,paramMap);
 
@@ -76,6 +80,8 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
         paramMap.put("predicateUri", config.getPredicateUri());
         paramMap.put("editForm" , this.getEditForm() );
         paramMap.put("cancelTo", "manage");
+        paramMap.put("fauxContextUri", fauxContextUri);
+
         if(domainUri != null && !domainUri.isEmpty()) {
         	paramMap.put("domainUri", domainUri);
         }

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
@@ -50,6 +50,7 @@
 <form class="customForm" action ="${submitUrl}">
 	<input type="hidden" name="rangeUri" value="${editConfiguration.rangeUri!}">
 	<input type="hidden" name="domainUri" value="${editConfiguration.domainUri!}">
+	<input type="hidden" name="fauxContextUri" value="${editConfiguration.pageData.fauxContextUri!}">
 
     <label for="urlType">${i18n().url_type}${requiredHint}</label>
     <#assign urlTypeOpts = editConfiguration.pageData.urlType />


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3949)**: (please link to issue)

# What does this pull request do?
Fixes authorization checks on website forms by providing information about faux property

# How should this be tested?
* Reproduce the problem in the issue
* Check that users with admin role are allowed to add and edit webpage faux object property with domain Person
* Try to add/create webpage as admin user
* Remove edit permission in faux object property configuration
* Try edit website, should not be authorized
* Remove add permission in faux object property configuration
* Try add website, should not be authorized

# Interested parties
@VIVO-project/vivo-committers
