### PR TITLE
Use local Noto Sans in Tenderfoot theme

### DIFF
--- a/webapp/src/main/webapp/themes/tenderfoot/css/screen.css
+++ b/webapp/src/main/webapp/themes/tenderfoot/css/screen.css
@@ -31,5 +31,5 @@ VIVO tenderfoot theme: screen styles
 @import url("page-login.css");
 @import url("page-menu.css");
 @import url("page-createAndLink.css");
-@import url("https://fonts.googleapis.com/css?family=Noto+Sans");
+@import url("../../../webjars/fonts/noto-sans/index.css");
 @import url("../../../local/css/local.css");


### PR DESCRIPTION
[Vitro PR](https://github.com/vivo-project/Vitro/pull/465)

# What does this pull request do?
Updated Tenderfoot theme to use local fonts instead of retrieving from cloud.

# How should this be tested?
* Select Tenderfoot theme
* Open home page
* Open web instruments, reload page, see that local fonts are being downloaded

# Interested parties
@hauschke 

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Web development
# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed