### PR TITLE
VIVO-3992 Reversed order of URL type options

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
@@ -55,7 +55,7 @@
     <label for="urlType">${i18n().url_type}${requiredHint}</label>
     <#assign urlTypeOpts = editConfiguration.pageData.urlType />
     <select name="urlType" style="margin-top:-2px" >
-        <#list urlTypeOpts?keys as key>
+        <#list urlTypeOpts?keys?reverse as key>
             <option value="${key}" >
                 <#if urlTypeOpts[key] == "F1000 Link">
                     ${i18n().faculty_of_1000}


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3992)**

# What does this pull request do?
Sets URL as default URL Type by reversion options order.

# How should this be tested?
* Reproduce the problem in the issue
* Test that the pull request fixes the issue

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
1. FreeMarker

# Reviewers' report template

## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed