### PR TITLE
 Browse filter results on page

### DIFF
--- a/api/src/main/java/org/vivoweb/webapp/startup/DataGetterN3Setup.java
+++ b/api/src/main/java/org/vivoweb/webapp/startup/DataGetterN3Setup.java
@@ -1,6 +1,18 @@
 package org.vivoweb.webapp.startup;
 
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessClassGroupDataGetterN3;
 import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessDataGetterN3Map;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessFixedHTMLN3;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessInternalClassDataGetterN3;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSearchFilterValuesDataGetterN3;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSearchIndividualsDataGetterN3;
+import edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSparqlDataGetterN3;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.InternalClassesDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchIndividualsDataGetter;
+import edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -9,12 +21,13 @@ import java.util.HashMap;
 public class DataGetterN3Setup implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
-        HashMap<String, String> map = new HashMap<String, String>();
-        map.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSparqlDataGetterN3");
-        map.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessClassGroupDataGetterN3");
-        map.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.InternalClassesDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessInternalClassDataGetterN3");
-        map.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessFixedHTMLN3");
-        map.put("edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchIndividualsDataGetter", "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.preprocessors.utils.ProcessSearchIndividualsDataGetterN3");
+        HashMap<String, Class> map = new HashMap<String, Class>();
+        map.put(SparqlQueryDataGetter.class.getCanonicalName(), ProcessSparqlDataGetterN3.class);
+        map.put(ClassGroupPageData.class.getCanonicalName(), ProcessClassGroupDataGetterN3.class);
+		map.put(SearchFilterValuesDataGetter.class.getCanonicalName(), ProcessSearchFilterValuesDataGetterN3.class);
+        map.put(InternalClassesDataGetter.class.getCanonicalName(), ProcessInternalClassDataGetterN3.class);
+        map.put(FixedHTMLDataGetter.class.getCanonicalName(), ProcessFixedHTMLN3.class);
+        map.put(SearchIndividualsDataGetter.class.getCanonicalName(), ProcessSearchIndividualsDataGetterN3.class);
 
         ProcessDataGetterN3Map.replaceDataGetterMap(map);
     }

--- a/home/src/main/resources/rdf/display/firsttime/search_individuals_vivo.n3
+++ b/home/src/main/resources/rdf/display/firsttime/search_individuals_vivo.n3
@@ -14,7 +14,6 @@
 
 :field_persons  a                  vitro-search:SearchField ;
         vitro-search:indexField   "persons_ss" ;
-        vitro-search:isLanguageSpecific true ;
         vitro-search:multivalued  true .
 
 :range_filter_dates  a            vitro-search:RangeFilter ;

--- a/webapp/src/main/webapp/js/menupage/processDataGetterUtils.js
+++ b/webapp/src/main/webapp/js/menupage/processDataGetterUtils.js
@@ -8,6 +8,7 @@
 
 var processDataGetterUtils = {
 		dataGetterProcessorMap:{"browseClassGroup": processClassGroupDataGetterContent,
+								"searchFilterValues": processSearchFilterValuesDataGetterContent,
 								"sparqlQuery": processSparqlDataGetterContent,
 								"fixedHtml":processFixedHTMLDataGetterContent,
 								"internalClass":processInternalClassDataGetterContent,

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/shortview/view-browse-people.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/shortview/view-browse-people.ftl
@@ -20,7 +20,7 @@
 <#if (extra[0].pt)?? >
     <span class="title">${extra[0].pt}</span>
 <#else>
-    <#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass) />
+    <#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass!"") />
     <#if cleanTypes?size == 1>
         <span class="title">${cleanTypes[0]}</span>
     <#elseif (cleanTypes?size > 1) >

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--customDataScript.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--customDataScript.ftl
@@ -31,6 +31,7 @@ scripts list.-->
       dataGetterLabelToURI:{
       		//maps labels to URIs
       		"browseClassGroup": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.ClassGroupPageData",
+		"searchFilterValues": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SearchFilterValuesDataGetter",
       		"internalClass": "java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.InternalClassesDataGetter",
       		"sparqlQuery":"java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.SparqlQueryDataGetter",
       		"fixedHtml":"java:edu.cornell.mannlib.vitro.webapp.utils.dataGetter.FixedHTMLDataGetter",

--- a/webapp/src/main/webapp/themes/nemo/templates/search.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/search.ftl
@@ -6,7 +6,7 @@
     <fieldset>
         <legend>${i18n().search_form}</legend>
 
-        <form id="search-form" action="${urls.search}" name="search" role="search" accept-charset="UTF-8" method="GET"> 
+        <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET"> 
             <div id="search-field">
                 <input type="text" name="querytext" id="filter_input_querytext" class="search-vivo" value="${querytext!?html}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="search">

--- a/webapp/src/main/webapp/themes/nemo/templates/view-browse-default.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/view-browse-default.ftl
@@ -17,7 +17,7 @@
     </h2>
 </#if>
 
-<#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass) />
+<#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass!"") />
 <#if cleanTypes?size == 1>
     <span class="title">${cleanTypes[0]}</span>
 <#elseif (cleanTypes?size > 1) >

--- a/webapp/src/main/webapp/themes/nemo/templates/view-browse-people.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/view-browse-people.ftl
@@ -20,7 +20,7 @@
 <#if (extra[0].pt)?? >
     <span class="title">${extra[0].pt}</span>
 <#else>
-    <#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass) />
+    <#assign cleanTypes = 'edu.cornell.mannlib.vitro.webapp.web.TemplateUtils$DropFromSequence'?new()(individual.mostSpecificTypes, vclass!"") />
     <#if cleanTypes?size == 1>
         <span class="title">${cleanTypes[0]}</span>
     <#elseif (cleanTypes?size > 1) >

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/page/partials/search.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/page/partials/search.ftl
@@ -6,7 +6,7 @@
     <fieldset>
         <legend>${i18n().search_form}</legend>
 
-        <form id="search-form" action="${urls.search}" name="search" role="search" accept-charset="UTF-8" method="GET">
+        <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET">
             <div id="search-field">
                 <input type="text" id="filter_input_querytext" name="querytext" class="search-vivo" value="${querytext!?html}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="search">

--- a/webapp/src/main/webapp/themes/wilma/templates/search.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/search.ftl
@@ -6,7 +6,7 @@
     <fieldset>
         <legend>${i18n().search_form}</legend>
 
-        <form id="search-form" action="${urls.search}" name="search" role="search" accept-charset="UTF-8" method="GET">
+        <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET">
             <div id="search-field">
                 <input type="text" id="filter_input_querytext" name="querytext" class="search-vivo" value="${querytext!?html}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="search">


### PR DESCRIPTION
[Vitro PR](https://github.com/vivo-project/Vitro/pull/473)

# What does this pull request do?
Adds an option to select search filter to display filtered results on custom page.

# What's new?
Please take a look at Vitro PR first.
Updated PageManagement entry form files to align with Vitro PR.

# How should this be tested?
A description of what steps someone could take to:
* Create a new page in PageManagement menu. use type filter as an example
* Browse page, try selecting facets, alphabetical index, pagination
* Test the same in non i18n VIVO
 
# Additional Notes:
This change require documentation to be updated.

# Interested parties
@hauschke @VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. Freemarker

# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed