### PR TITLE
Exclude context path from application generated links

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/ExportQrCodeController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/ExportQrCodeController.java
@@ -15,6 +15,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 
 import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ExceptionResponseValues;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -132,7 +133,7 @@ public class ExportQrCodeController extends FreemarkerHttpServlet {
             qrData.put("externalUrl", externalUrl);
 
             String individualUri = individual.getURI();
-            String contextPath = vreq.getContextPath();
+            String contextPath = ContextPath.getPath(vreq);
             qrData.put("exportQrCodeUrl", contextPath + "/qrcode?uri=" + UrlBuilder.urlEncode(individualUri));
 
             qrData.put("aboutQrCodesUrl", contextPath + "/about_qrcode");

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/InstitutionalInternalClassController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/freemarker/InstitutionalInternalClassController.java
@@ -23,6 +23,7 @@ import org.apache.jena.shared.Lock;
 import edu.cornell.mannlib.vitro.webapp.auth.permissions.SimplePermission;
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
 import edu.cornell.mannlib.vitro.webapp.beans.VClass;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.edit.utils.LocalNamespaceClassUtils;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.RedirectResponseValues;
@@ -81,8 +82,8 @@ public class InstitutionalInternalClassController extends FreemarkerHttpServlet 
 
     	//Check if existing local namespaces
 
-    	data.put("formUrl", vreq.getContextPath() + EDIT_FORM);
-    	data.put("cancelUrl", vreq.getContextPath() + REDIRECT_PAGE);
+    	data.put("formUrl", ContextPath.getPath(vreq) + EDIT_FORM);
+    	data.put("cancelUrl", ContextPath.getPath(vreq) + REDIRECT_PAGE);
 
     	//if no local namespaces, then provide message to display
     	//if existing namespace(s), then check

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/ShortURLVisualizationController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/ShortURLVisualizationController.java
@@ -246,7 +246,7 @@ public class ShortURLVisualizationController extends FreemarkerHttpServlet {
 	private List<String> extractShortURLParameters(VitroRequest vitroRequest) {
 
 		List<String> matchedGroups = new ArrayList<String>();
-		String subURIString = vitroRequest.getRequestURI().substring(ContextPath.getPath(vitroRequest).length()+1);
+		String subURIString = vitroRequest.getRequestURI().substring(vitroRequest.getContextPath().length()+1);
 		String[] urlParams = StringEscapeUtils.ESCAPE_HTML4.translate(subURIString).split("/");
 
 		if (urlParams.length > 1

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/ShortURLVisualizationController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/ShortURLVisualizationController.java
@@ -20,6 +20,7 @@ import org.apache.jena.query.Syntax;
 import org.apache.jena.rdf.model.Model;
 
 import edu.cornell.mannlib.vitro.webapp.auth.requestedAction.AuthorizationRequest;
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.FreemarkerHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.ResponseValues;
@@ -245,7 +246,7 @@ public class ShortURLVisualizationController extends FreemarkerHttpServlet {
 	private List<String> extractShortURLParameters(VitroRequest vitroRequest) {
 
 		List<String> matchedGroups = new ArrayList<String>();
-		String subURIString = vitroRequest.getRequestURI().substring(vitroRequest.getContextPath().length()+1);
+		String subURIString = vitroRequest.getRequestURI().substring(ContextPath.getPath(vitroRequest).length()+1);
 		String[] urlParams = StringEscapeUtils.ESCAPE_HTML4.translate(subURIString).split("/");
 
 		if (urlParams.length > 1

--- a/api/src/main/java/org/vivoweb/webapp/sitemap/SiteMapServlet.java
+++ b/api/src/main/java/org/vivoweb/webapp/sitemap/SiteMapServlet.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.QuerySolution;
-
+import edu.cornell.mannlib.vitro.webapp.config.ContextPath;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroHttpServlet;
 import edu.cornell.mannlib.vitro.webapp.controller.VitroRequest;
 import edu.cornell.mannlib.vitro.webapp.controller.freemarker.UrlBuilder;
@@ -41,7 +41,7 @@ public class SiteMapServlet extends VitroHttpServlet {
         if (requestURI != null) {
             if (requestURI.contains("robots.txt")) {
                 String robotsPath = getServletContext().getRealPath("/robots.txt");
-                String contextPath = request.getContextPath();
+                String contextPath = ContextPath.getPath(request);
 
                 StringBuilder builder = new StringBuilder("Sitemap: ");
                 builder.append(getSchemeAndServer(request));

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -32,8 +32,8 @@
   #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
-# To exclude tomcat application context name from generated links uncomment following line.
-# Default value is false
+# To exclude the Tomcat application context name from generated links uncomment following line.
+# Default value is false.
 # context.path.exclude = true
 
   #

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -32,6 +32,10 @@
   #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
+# In case VIVO is behind proxy you might want to avoid redirects by overriding
+# context path to empty string or other custom value
+# context.path=
+
   #
   # The email address of the root user for the VIVO application. The password
   # for this user is initially set to "rootPassword", but you will be asked to

--- a/home/src/main/resources/config/example.runtime.properties
+++ b/home/src/main/resources/config/example.runtime.properties
@@ -32,9 +32,9 @@
   #
 Vitro.defaultNamespace = http://vivo.mydomain.edu/individual/
 
-# In case VIVO is behind proxy you might want to avoid redirects by overriding
-# context path to empty string or other custom value
-# context.path=
+# To exclude tomcat application context name from generated links uncomment following line.
+# Default value is false
+# context.path.exclude = true
 
   #
   # The email address of the root user for the VIVO application. The password


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3846)**: (please link to issue)
[Vitro PR](https://github.com/vivo-project/Vitro/pull/475)
# What does this pull request do?
New boolean configuration property context.path.exclude to exclude tomcat application context from generated links useful in case the application is deployed with reverse proxy.

# What's new?
Created context.path.exclude configuration property to exclude context path from generated links. 
Replaced calls for context path to utility methods that allow overriding default context path.

# How should this be tested?
Default behavior when configuration property is not set should be the same.
* To test application behind proxy one would need to configure webserver and tomcat in proxy mode like described in workaround of linked issue and set  context.path.exclude = true in runtime.properties
* General navigation between application pages
* Authorization
* Edit this individual page should work the same

#Additional notes
* Duplicate tests were removed.
* This change require documentation to be updated.

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. Java

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed