### PR TITLE
Decouple installation and deployment

### DIFF
--- a/installer/home/pom.xml
+++ b/installer/home/pom.xml
@@ -18,81 +18,24 @@
         <default-theme>wilma</default-theme>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>install</id>
-            <activation>
-                <property><name>vivo-dir</name></property>
-            </activation>
-            <build>
-                <finalName>${app-name}</finalName>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/home.xml</descriptor>
-                            </descriptors>
-                            <appendAssemblyId>false</appendAssemblyId>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>remove-webapp</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <delete dir="${vivo-dir}/rdf" />
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>copy-resources</goal>
-                                </goals>
-                                <configuration>
-                                    <outputDirectory>${vivo-dir}</outputDirectory>
-                                    <resources>
-                                        <resource>
-                                            <directory>${project.build.directory}/${project.build.finalName}</directory>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-install-plugin</artifactId>
+                <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <descriptors>
+                        <descriptor>src/main/assembly/home.xml</descriptor>
+                    </descriptors>
+                    <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/installer/home/src/main/assembly/home.xml
+++ b/installer/home/src/main/assembly/home.xml
@@ -3,7 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>home</id>
     <formats>
-        <format>dir</format>
+        <format>tar</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -54,53 +54,19 @@
             </build>
         </profile>
         <profile>
-            <id>install</id>
+            <id>deploy</id>
             <activation>
                 <property><name>tomcat-dir</name></property>
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>remove-webapp</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <delete dir="${tomcat-dir}/webapps/${project.build.finalName}" />
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
+		    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>${project.artifactId}</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>war</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${tomcat-dir}/webapps/${project.build.finalName}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <artifactId>maven-war-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <configuration>
+                            <outputDirectory>${tomcat-dir}/webapps/</outputDirectory>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/installer/webapp/pom.xml
+++ b/installer/webapp/pom.xml
@@ -27,6 +27,34 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>include-home</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.vivoweb</groupId>
+                                            <artifactId>vivo-installer-home</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>tar</type>
+                                            <outputDirectory>
+                                                target/${app-name}/WEB-INF/resources/home-files</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
                         <configuration>
                             <archive>
@@ -60,7 +88,7 @@
             </activation>
             <build>
                 <plugins>
-		    <plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
                         <version>3.2.1</version>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3034)**
[Vitro PR](https://github.com/vivo-project/Vitro/pull/479)
# What does this pull request do?
Decoupled deployment and installation processes
Changed delivery of home directory: package it's contents as part of war artifact, update default files on home directory except rdf subdirectory on startup. 
In case tomcat directory is not provided artifact will not be copied into tomcat webapps directory

# What's new?
Changed deployment: war artifact is copied into webapp directory, not unpacked
Home directory contents are copied into war artifact
On startup path to home directory is being created if not already exists.
RDFFilesLoader and FileGraphSetup were adjusted to read rdf contents from tomcat webapp application directory

# How should this be tested?
Test update of already installed instance and installation of new instance. 
- Try standard installation method mvn install -s example-settings.xml 
- Remove tomcat directory from xml file, copy created war file manually to tomcat webapp directory, that should result in deployment of application.


# Additional Notes:
This change require documentation to be updated

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
2. Maven
# Reviewers' report template
**Please update the following template which should be used by reviewers.**
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed