### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Maven Build
         run: |
           cd ../VIVO
-          mvn clean package -s installer/example-settings.xml
+          mvn clean install


### PR DESCRIPTION
# What does this pull request do?
Removed example settings from maven build to prevent deployment in the environment where tomcat destination directory doesn't exist.

# Interested parties
@VIVO-project/vivo-committers