### PR TITLE
VIVO-4056 Avoid forced capitalization of property group labels

### DIFF
--- a/home/src/main/resources/rdf/applicationMetadata/firsttime/propertygroups.rdf
+++ b/home/src/main/resources/rdf/applicationMetadata/firsttime/propertygroups.rdf
@@ -14,7 +14,6 @@
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" >
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupaffiliation">
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T09:47:01</vitro:modTime>
-    <rdfs:label xml:lang="en-US">affiliation</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Affiliations and other informal associations between people and organizations</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">30</vitro:displayRank>
@@ -23,7 +22,6 @@
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupidentifiers">
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">200</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T09:16:01</vitro:modTime>
-    <rdfs:label xml:lang="en-US">identity</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">properties holding unique and non-unique identifiers, names, and other identification information</vitro:publicDescriptionAnnot>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
@@ -32,13 +30,11 @@
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">properties related to postal and email addresses</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">120</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T09:15:07</vitro:modTime>
-    <rdfs:label xml:lang="en-US">contact</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGrouplinks">
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T14:00:43</vitro:modTime>
-    <rdfs:label xml:lang="en-US">links</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">link relationships</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">99</vitro:displayRank>
@@ -48,19 +44,16 @@
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primary bibliographic properties of publications to prioritize in display</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">40</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T09:12:36</vitro:modTime>
-    <rdfs:label xml:lang="en-US">publications</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupteaching">
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T15:37:48</vitro:modTime>
-    <rdfs:label xml:lang="en-US">teaching</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">60</vitro:displayRank>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupresearch">
-    <rdfs:label xml:lang="en-US">research</rdfs:label>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T15:30:25</vitro:modTime>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">50</vitro:displayRank>
@@ -68,7 +61,6 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupoutreach">
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T15:38:51</vitro:modTime>
-    <rdfs:label xml:lang="en-US">service</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">70</vitro:displayRank>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
@@ -77,14 +69,12 @@
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">10</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-12T07:11:40</vitro:modTime>
-    <rdfs:label xml:lang="en-US">overview</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline">
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reference information to online content, translations, etc.</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">190</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T16:50:29</vitro:modTime>
-    <rdfs:label xml:lang="en-US">related documents</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
@@ -92,7 +82,6 @@
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biographical information about a person, past or present</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">80</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T12:36:28</vitro:modTime>
-    <rdfs:label xml:lang="en-US">background</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
@@ -100,12 +89,10 @@
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bibliographic properties in other namespaces mapped within VIVO core</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2033</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T21:12:31</vitro:modTime>
-    <rdfs:label xml:lang="en-US">bib mapping</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupmapping">
-    <rdfs:label xml:lang="en-US">mapping</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Properties included in VIVO core to support mappings to other ontologies</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2034</vitro:displayRank>
@@ -116,13 +103,11 @@
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">195</vitro:displayRank>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dates and times for events, employment, etc.</vitro:publicDescriptionAnnot>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T13:54:45</vitro:modTime>
-    <rdfs:label xml:lang="en-US">time</rdfs:label>
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGroupbibobscure">
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
-    <rdfs:label xml:lang="en-US">additional document info</rdfs:label>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-01-10T16:55:11</vitro:modTime>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2032</vitro:displayRank>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obscure bibontology properties not likely to be used in VIVO</vitro:publicDescriptionAnnot>
@@ -130,7 +115,6 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://vivoweb.org/ontology#vitroPropertyGrouplocation">
     <rdf:type rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#PropertyGroup"/>
-    <rdfs:label xml:lang="en-US">location</rdfs:label>
     <vitro:publicDescriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Relationships of place</vitro:publicDescriptionAnnot>
     <vitro:displayRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">96</vitro:displayRank>
     <vitro:modTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-12-28T13:05:00</vitro:modTime>

--- a/home/src/main/resources/rdf/i18n/en_CA/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/en_CA/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,18 +1,18 @@
 # baseURI: http://vivoweb.org/ontology/propertygroups_labels_en_CA
 
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "identity"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "links"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "bib mapping"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "location"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "background"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "contact"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "time"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "additional document info"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "mapping"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "teaching"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "research"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "affiliation"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "related documents"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "publications"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "overview"@en-CA .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "service"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identity"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Links"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Bib mapping"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "Location"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Background"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Contact"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Time"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Additional document info"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Mapping"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Teaching"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Research"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Affiliation"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Related documents"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Publications"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Overview"@en-CA .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Service"@en-CA .

--- a/home/src/main/resources/rdf/i18n/en_US/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/en_US/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,16 +1,16 @@
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "affiliation"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "identity"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "contact"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "links"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "publications"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "teaching"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "research"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "service"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "overview"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "related documents"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "background"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "bib mapping"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "mapping"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "time"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "additional document info"@en-US .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "location"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Affiliation"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identity"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Contact"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Links"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Publications"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Teaching"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Research"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Service"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Overview"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Related documents"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Background"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Bib mapping"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Mapping"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Time"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Additional document info"@en-US .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "Location"@en-US .

--- a/home/src/main/resources/rdf/i18n/es/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/es/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,16 +1,16 @@
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "identidad"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "documentos relacionados"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "antecedentes"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "servicio"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identidad"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Documentos relacionados"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Antecedentes"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Servicio"@es .
 <http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Informaci\u00F3n adicional de documento"@es .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "enlaces"@es .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "ubicaci\u00F3n"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "asignaci\u00F3n bib"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "visi\u00F3n general"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "ense\u00F1anza"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "afiliaci\u00F3n"@es .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "tiempo"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "publicaciones"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "investigaci\u00F3n"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "contacto"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "asignaci\u00F3n"@es .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Enlaces"@es .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "Ubicaci\u00F3n"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Asignaci\u00F3n bib"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Visi\u00F3n general"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Ense\u00F1anza"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Afiliaci\u00F3n"@es .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Tiempo"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Publicaciones"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Investigaci\u00F3n"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Contacto"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Asignaci\u00F3n"@es .

--- a/home/src/main/resources/rdf/i18n/pt_BR/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/pt_BR/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,16 +1,16 @@
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "identidade"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "documentos relacionados"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identidade"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Documentos relacionados"@pt-BR .
 <http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Fundo"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "serviço"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Serviço"@pt-BR .
 <http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Informação adicional documento"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "ligações"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "location"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "mapeamento bib"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "visão geral"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "ensino"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "filiação"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "tempo"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "publicações"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "pesquisas"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "contato"@pt-BR .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "mapeamento"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Ligações"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label> "Location"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Mapeamento bib"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Visão geral"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Ensino"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Filiação"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Tempo"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Publicações"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Pesquisas"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Contato"@pt-BR .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Mapeamento"@pt-BR .

--- a/home/src/main/resources/rdf/i18n/ru_RU/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/ru_RU/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,16 +1,16 @@
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "аффилиация"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "идентификаторы"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "адрес"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "связи"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "публикации"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "преподавание"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "исследования"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "информационно-просветительская работа"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "описание"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "связанные документы"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "задел"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "библиографическое картирование"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "картирование"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "время"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "дополнительная информация о документе"@ru-RU .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "местоположение"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Аффилиация"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Идентификаторы"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Адрес"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Связи"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Публикации"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Преподавание"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Исследования"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Информационно-просветительская работа"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Описание"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Связанные документы"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Задел"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Библиографическое картирование"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Картирование"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Время"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Дополнительная информация о документе"@ru-RU .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "Местоположение"@ru-RU .

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,16 +1,16 @@
-<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "afilijacija"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "identitet"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "kontakt"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "veze"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "publikacije"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "učiti"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "istraživanje"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "servisi"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "pregled"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "povezani dokumenti"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "pozadina"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "bib mapiranja"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "mapiranje"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "vreme"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "dodatne informacije o dokumentu"@sr-Latn-RS .
-<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "lokacija"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> <http://www.w3.org/2000/01/rdf-schema#label> "Afilijacija"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identitet"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupaddress> <http://www.w3.org/2000/01/rdf-schema#label> "Kontakt"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Veze"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographic> <http://www.w3.org/2000/01/rdf-schema#label> "Publikacije"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupteaching> <http://www.w3.org/2000/01/rdf-schema#label> "Učiti"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupresearch> <http://www.w3.org/2000/01/rdf-schema#label> "Istraživanje"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Servisi"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupoverview> <http://www.w3.org/2000/01/rdf-schema#label> "Pregled"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Povezani dokumenti"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Pozadina"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Bib mapiranja"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupmapping> <http://www.w3.org/2000/01/rdf-schema#label> "Mapiranje"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGrouptime> <http://www.w3.org/2000/01/rdf-schema#label> "Vreme"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Dodatne informacije o dokumentu"@sr-Latn-RS .
+<http://vivoweb.org/ontology#vitroPropertyGrouplocation> <http://www.w3.org/2000/01/rdf-schema#label>  "Lokacija"@sr-Latn-RS .

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-property-group-tabs.ftl
@@ -24,15 +24,15 @@
 				</#if>
 				<#if tabCount = 1 >
 					<li id="${groupNameHtmlId?replace("/","-")}Tab" role="presentation" class="active">
-					   <a href="#${groupNameHtmlId?replace("/","-")}" aria-controls="${groupName?capitalize}" role="tab" data-toggle="tab">
-						   ${groupName?capitalize}
+					   <a href="#${groupNameHtmlId?replace("/","-")}" aria-controls="${groupName}" role="tab" data-toggle="tab">
+						   ${groupName}
 					   </a>
 					</li>
 					<#assign tabCount = 2>
 				<#else>
 					<li id="${groupNameHtmlId?replace("/","-")}Tab" role="presentation">
-					   <a href="#${groupNameHtmlId?replace("/","-")}" aria-controls="${groupName?capitalize}" role="tab" data-toggle="tab">
-						   ${groupName?capitalize}
+					   <a href="#${groupNameHtmlId?replace("/","-")}" aria-controls="${groupName}" role="tab" data-toggle="tab">
+						   ${groupName}
 					   </a>
 					</li>
 				</#if>

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-property-group-tabs.ftl
@@ -23,22 +23,22 @@
 					<#if tabCount = 1 >
 						<li role="presentation" class="active">
 							<a 	href="#${groupNameHtmlId?replace("/","-")}" 
-								aria-controls="${groupName?capitalize}" 
+								aria-controls="${groupName}" 
 								role="tab" 
 								data-toggle="tab">
 								
-								${groupName?capitalize}
+								${groupName}
 							</a>
 						</li>
 						<#assign tabCount = 2>
 					<#else>
 						<li role="presentation">
 							<a 	href="#${groupNameHtmlId?replace("/","-")}" 
-								aria-controls="${groupName?capitalize}" 
+								aria-controls="${groupName}" 
 								role="tab" 
 								data-toggle="tab">
 								
-								${groupName?capitalize}
+								${groupName}
 							</a>
 						</li>
 					</#if>
@@ -48,10 +48,10 @@
 				<#if (propertyGroups.all?size > 1) >
 					<li role="presentation">
 						<a href="#${groupNameHtmlId?replace("/","-")}" 
-							aria-controls="${groupName?capitalize}" 
+							aria-controls="${groupName}" 
 							role="tab" data-toggle="tab">
 							
-							${groupName?capitalize}
+							${groupName}
 						</a>
 					</li>
 				</#if>

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-property-group-tabs.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/partials/individual/individual-property-group-tabs.ftl
@@ -21,10 +21,10 @@
 					<#assign groupNameHtmlId = "${i18n().properties}" >
 				</#if>
 				<#if tabCount = 1 >
-                    <li data-toggle="tab" groupName="${groupNameHtmlId?replace("/","-")}" class="active" href="#${groupNameHtmlId?replace("/","-")}Group"><a href="#">${groupName?capitalize}</a></li>
+                    <li data-toggle="tab" groupName="${groupNameHtmlId?replace("/","-")}" class="active" href="#${groupNameHtmlId?replace("/","-")}Group"><a href="#">${groupName}</a></li>
 					<#assign tabCount = 2>
 				<#else>
-                    <li data-toggle="tab" groupName="${groupNameHtmlId?replace("/","-")}" href="#${groupNameHtmlId?replace("/","-")}Group"><a href="#">${groupName?capitalize}</a></li>
+                    <li data-toggle="tab" groupName="${groupNameHtmlId?replace("/","-")}" href="#${groupNameHtmlId?replace("/","-")}Group"><a href="#">${groupName}</a></li>
 				</#if>
 			</#if>
 		</#list>
@@ -49,7 +49,7 @@
 					<#if groupName?has_content>
 						<#--the function replaces spaces in the name with underscores, also called for the property group menu-->
 						<#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
-                        <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${groupName?capitalize}</h2>
+                        <h2 id="${groupNameHtmlId?replace("/","-")}" pgroup="tabs" class="hidden">${groupName}</h2>
 					<#else>
                         <h2 id="properties" pgroup="tabs" class="hidden">${i18n().properties_capitalized}</h2>
 					</#if>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4056)**
[Vitro PR](https://github.com/vivo-project/Vitro/pull/495)

# What does this pull request do?
Removed capitalization of property groups in Freemarker code.
Applied capitalization to 'Other' property group option.

# How should this be tested?
* Rename a property group
* Verify that new property group label is displayed without modification in profile

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. FreeMarker
1. Natural language knowledge
    1. English
    2. German
    3. Spanish
    4. French
    5. Portuguese
    6. Russian
    7. Serbian

# Reviewers' report template
## General comment
A reviewer should provide here comments and suggestions for requested changes if any.
## Testing
A reviewer should briefly describe here how it was tested
## Code reviewing
A reviewer should briefly describe here which part was code reviewed