### PR TITLE
VIVO-4069 - Add javascript MIME type to ipretResults responses

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/AjaxVisualizationController.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/controller/visualization/AjaxVisualizationController.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.Syntax;
@@ -26,6 +27,10 @@ import edu.cornell.mannlib.vitro.webapp.controller.freemarker.responsevalues.Tem
 import edu.cornell.mannlib.vitro.webapp.visualization.exceptions.MalformedQueryParametersException;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.UtilityFunctions;
 import edu.cornell.mannlib.vitro.webapp.visualization.visutils.VisualizationRequestHandler;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Services a visualization request. This will return a simple error message and a 501 if
@@ -84,6 +89,11 @@ public class AjaxVisualizationController extends FreemarkerHttpServlet {
             }
 
 		} else {
+			String callback = vreq.getParameter("callback");
+			Set<String> callbackValues = new HashSet<String>(Arrays.asList("ipretFullResults", "ipretResults"));
+			if (!StringUtils.isEmpty(callback) && callbackValues.contains(callback)) {
+				response.setContentType("text/javascript");
+			}
 			response.getWriter().write(ajaxResponse.toString());
 		}
 	}
@@ -189,4 +199,3 @@ public class AjaxVisualizationController extends FreemarkerHttpServlet {
 	}
 
 }
-


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4069)**: https://github.com/vivo-project/VIVO/issues/4069

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this pull request do?
Sets the MIME type for a couple specific responses from the Ajax Visualization Controller which are formatted as javascript instead of plaintext or JSON.

# What's new?
Functionality should remain the same, but you should be able to confirm the MIME type is set correctly by looking at the response in your developer console in the browser.
![Screenshot 2025-04-16 at 16 54 43](https://github.com/user-attachments/assets/ef0a2645-232d-4e7c-ae35-7d576a646965)


# How should this be tested?
Observe the Content-Type when making a call to http://localhost:8080/vivo/visualizationAjax?vis=capabilitymap&query=Virology&callback=ipretFullResults (You will need to replace the query with a valid concept in your VIVO database)
The Content-Type before the change will be "text/html"
The Content-Type after the change will be "text/javascript"

Note that application/javascript is also a valid MIME type for javascript, but apparently text/javascript has broader compatibility.

# Additional Notes:


# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
**Please add any new expertise in the list which might be needed for reviewing your PR or remove any of the listed if it is not needed.**

Candidates for reviewing this PR should have some of the following expertises:
1. Java
2. JavaScript
