### PR TITLE
Migrating from OSSRH to Central Publisher Portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -250,16 +250,22 @@
             <name>VIVO Dependencies</name>
             <url>https://raw.github.com/vivo-project/dependencies/main/</url>
         </repository>
+
         <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <name>Sonatype Central Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+
+        <repository>
+            <id>central-maven</id>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         </developer>
     </developers>
 
-    <!-- The SCM repository location is used by Continuum to update against 
-        when changes have occurred. This spawns a new build cycle and releases snapshots 
+    <!-- The SCM repository location is used by Continuum to update against
+        when changes have occurred. This spawns a new build cycle and releases snapshots
         into the snapshot repository below. -->
     <scm>
         <connection>scm:git:git@github.com:vivo-project/VIVO.git</connection>
@@ -189,14 +189,10 @@
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -332,7 +328,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Used to validate all code style rules in source code using 
+            <!-- Used to validate all code style rules in source code using
                 Checkstyle -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -341,7 +337,7 @@
                 <executions>
                     <execution>
                         <id>verify-style</id>
-                        <!-- Bind to verify so it runs after package & unit 
+                        <!-- Bind to verify so it runs after package & unit
                             tests, but before install -->
                         <phase>verify</phase>
                         <goals>
@@ -443,8 +439,8 @@
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.7</version>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -477,10 +473,10 @@
                         </reports>
                     </reportSet>
                     <reportSet>
-                        <!-- aggregate reportSet, to define in poms 
+                        <!-- aggregate reportSet, to define in poms
                             having modules -->
                         <id>aggregate</id>
-                        <inherited>false</inherited> <!-- don't run aggregate 
+                        <inherited>false</inherited> <!-- don't run aggregate
                             in child modules -->
                         <reports>
                             <report>aggregate</report>
@@ -505,8 +501,8 @@
         </plugins>
     </reporting>
 
-    <!-- Add a custom repository, which is actually just a simple GitHub 
-        project in order to distribute some dependencies that aren't part of Maven 
+    <!-- Add a custom repository, which is actually just a simple GitHub
+        project in order to distribute some dependencies that aren't part of Maven
         central -->
     <repositories>
         <repository>
@@ -516,15 +512,20 @@
         </repository>
 
         <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <name>Sonatype Central Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+
+        <repository>
+            <id>central-maven</id>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
 
@@ -534,12 +535,15 @@
             <url>https://vivo-project.github.io/</url>
         </site>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <name>Sonatype Central Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
**[4082](https://github.com/vivo-project/VIVO/issues/4082)**

[linked Vitro PR](https://github.com/vivo-project/Vitro/pull/499)

# What does this pull request do?
Fixing the issue with deploying VIVO/Vitro artefacts into the Maven central repository. It is done via Central Publisher Portal. So far it works over OSSRH which support will be discontinued (see [here](https://central.sonatype.org/publish/publish-maven/)). 

# What's new?
Sonatype plugin was replaced as well as configuration for publisher portal. 

# How should this be tested?
Please follow the testing instructions in the linked [issue](https://github.com/vivo-project/VIVO/issues/4082)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers

# Reviewers' expertise
**Please add any new expertise in the list which might be needed for reviewing your PR or remove any of the listed if it is not needed.**

Candidates for reviewing this PR should have some of the following expertises:
1. Maven
