### PR TITLE
Fix #3747: Switch showcase instances on frontpage from vivo:faculty a…

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/homePageDataGetters.n3
+++ b/home/src/main/resources/rdf/display/everytime/homePageDataGetters.n3
@@ -7,8 +7,9 @@
 @prefix core: <http://vivoweb.org/ontology/core#> .
 @prefix vivoweb: <http://vivoweb.org/ontology#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-# academic departments datagetter
+# organizations datagetter
 
 <freemarker:lib-home-page.ftl> display:hasDataGetter display:academicDeptsDataGetter .
 
@@ -18,11 +19,12 @@ display:academicDeptsDataGetter
     display:query """
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX vivo: <http://vivoweb.org/ontology/core#>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
     SELECT DISTINCT ?theURI ?name
     WHERE
     {
-          ?theURI a vivo:AcademicDepartment .
+          ?theURI a foaf:Organization .
           ?theURI rdfs:label ?name .
     }
 

--- a/webapp/src/main/webapp/js/homePageUtils.js
+++ b/webapp/src/main/webapp/js/homePageUtils.js
@@ -49,7 +49,7 @@ $(document).ready(function(){
             }
 
             var dataServiceUrl = urlsBase + "/dataservice?getRandomSearchIndividualsByVClass=1&vclassId=";
-            var url = dataServiceUrl + encodeURIComponent("http://vivoweb.org/ontology/core#FacultyMember");
+            var url = dataServiceUrl + encodeURIComponent("http://xmlns.com/foaf/0.1/Person");
             url += "&page=" + rowStart + "&pageSize=" + pageSize;
 
             $.getJSON(url, function(results) {
@@ -87,7 +87,7 @@ $(document).ready(function(){
                     });
                     var viewMore = "<ul id='viewMoreFac'><li><a href='"
                                 + urlsBase
-                                + "/people#http://vivoweb.org/ontology/core#FacultyMember' alt='"
+                                + "/people#http://xmlns.com/foaf/0.1/Person' alt='"
                                 + i18nStrings.viewAllFaculty + "'>"
                                 + i18nStrings.viewAllString + "</a></li></ul>";
                     $('div#research-faculty-mbrs').append(viewMore);
@@ -155,7 +155,7 @@ $(document).ready(function(){
             html += "</ul><ul style='list-style:none'>"
                     + "<li style='font-size:0.9em;text-align:right;padding: 6px 16px 0 0'><a href='"
                     + urlsBase
-                    + "/organizations#http://vivoweb.org/ontology/core#AcademicDepartment' alt='"
+                    + "/organizations#http://xmlns.com/foaf/0.1/Organization' alt='"
                     + i18nStrings.viewAllDepartments + "'>"
                     + i18nStrings.viewAllString + "</a></li></ul>";
         }

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
@@ -16,7 +16,7 @@
 <#-- Works in conjunction with the homePageUtils.js file, which contains the ajax call. -->
 <#macro facultyMbrHtml>
     <section id="home-faculty-mbrs" class="home-sections"  >
-        <h4>${i18n().faculty_capitalized}</h4>
+        <h4>${i18n().people_capitalized}</h4>
         <div id="tempSpacing">
             <span>${i18n().loading_faculty}&nbsp;&nbsp;&nbsp;
                 <img  src="${urls.images}/indicatorWhite.gif">
@@ -36,7 +36,7 @@
     <#list classGroups as group>
         <#if (group.individualCount > 0) && group.uri?contains("people") >
             <#list group.classes as class>
-                <#if (class.uri?contains("FacultyMember")) >
+                <#if (class.uri?contains("Person")) >
                     <#assign foundClassGroup = true />
                     <#if (class.individualCount > 0) >
                         <script>var facultyMemberCount = ${class.individualCount?string?replace("[^\\d]", "", "r")};</script>
@@ -173,7 +173,7 @@
 <#-- Works in conjunction with the homePageUtils.js file -->
 <#macro academicDeptsHtml>
     <section id="home-academic-depts" class="home-sections">
-        <h4>${i18n().departments}</h4>
+        <h4>${i18n().organizations}</h4>
         <div id="academic-depts">
         </div>
     </section>

--- a/webapp/src/main/webapp/themes/nemo/js/homePageUtils.js
+++ b/webapp/src/main/webapp/themes/nemo/js/homePageUtils.js
@@ -50,8 +50,8 @@ $(document).ready(function(){
             }
 
             var dataServiceUrl = urlsBase + "/dataservice?getRandomSearchIndividualsByVClass=1&vclassId=";
-            //var url = dataServiceUrl + encodeURIComponent("http://xmlns.com/foaf/0.1/Person");
-            var url = dataServiceUrl + encodeURIComponent("http://vivoweb.org/ontology/core#FacultyMember");
+            var url = dataServiceUrl + encodeURIComponent("http://xmlns.com/foaf/0.1/Person");
+            //var url = dataServiceUrl + encodeURIComponent("http://vivoweb.org/ontology/core#FacultyMember");
             url += "&page=" + rowStart + "&pageSize=" + pageSize;
 
             $.getJSON(url, function(results) {
@@ -111,16 +111,16 @@ $(document).ready(function(){
                             });
                         }
                     });
-                    var viewMore = "<ul id='viewMoreFac' style='list-style:none;margin:0;padding:0;'><li><a href='"
-                                + urlsBase
-                                + "/people#http://vivoweb.org/ontology/core#FacultyMember' alt='" 
-                                + i18nStrings.viewAllFaculty + "'>"
-                                + i18nStrings.viewAllString + "</a></li></ul>";
                     //var viewMore = "<ul id='viewMoreFac' style='list-style:none;margin:0;padding:0;'><li><a href='"
-                    //    + urlsBase
-                    //    + "/people#http://xmlns.com/foaf/0.1/Person' alt='" 
-                    //    + i18nStrings.viewAllFaculty + "'>"
-                    //    + i18nStrings.viewAllString + "</a></li?</ul>";                    
+                    //            + urlsBase
+                    //            + "/people#http://vivoweb.org/ontology/core#FacultyMember' alt='" 
+                    //            + i18nStrings.viewAllFaculty + "'>"
+                    //            + i18nStrings.viewAllString + "</a></li></ul>";
+                    var viewMore = "<ul id='viewMoreFac' style='list-style:none;margin:0;padding:0;'><li><a href='"
+                        + urlsBase
+                        + "/people#http://xmlns.com/foaf/0.1/Person' alt='" 
+                        + i18nStrings.viewAllFaculty + "'>"
+                        + i18nStrings.viewAllString + "</a></li></ul>";                    
                     $('div#research-faculty-mbrs').append(viewMore);
                 }
             });
@@ -198,7 +198,7 @@ $(document).ready(function(){
 //              + i18nStrings.viewAllString + "</a>"
 //              + "</li></ul>";
           html += "<a href='" + urlsBase 
-              + "/organizations#http://vivoweb.org/ontology/core#AcademicDepartment' alt='" 
+              + "/organizations#http://xmlns.com/foaf/0.1/Organization' alt='" 
               + i18nStrings.viewAllDepartments + "'>" 
               + i18nStrings.viewAllString + "</a>"
               + "</div>"

--- a/webapp/src/main/webapp/themes/nemo/templates/lib-home-page.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/lib-home-page.ftl
@@ -200,7 +200,7 @@
 <#-- Works in conjunction with the homePageUtils.js file -->
 <#macro academicDeptsHtml>
     <section id="home-academic-depts" class="home-sections">
-        <h4>${i18n().departments}</h4>
+        <h4>${i18n().organizations}</h4>
         <div id="academic-depts">
         </div>
     </section>        

--- a/webapp/src/main/webapp/themes/nemo/templates/page-home.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/page-home.ftl
@@ -131,7 +131,7 @@
 			<div class="row faculty-home">
 				<div class="container">
 					<div class="col-md-12">
-						<h2 class="h1">Meet our faculty</h2>
+						<h2 class="h1">Meet our people</h2>
 						<div class="gap20"></div>
 						<p>${i18n().home_faculty_para1}</p>
 						<!-- Use bootstrap carousel to showcase faculty members, edited in lib-home-page.ftl and homePageUtils.js -->
@@ -173,7 +173,7 @@
 						-->
 						<div class="row department-count">
 							<div class="col-md-6">
-								<h2 class="h1">Departments</h2>
+								<h2 class="h1">Organizations</h2>
 								<div class="gap20"></div>
 								<p>${i18n().home_departments_para1}</p>
 							</div>


### PR DESCRIPTION
# Pull Request: Switch showcase instances on frontpage from vivo:faculty and vivo:department to foaf:person and foaf:organization

**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/3747)**: #3747 Switch showcase instances on frontpage from vivo:faculty and vivo:department to foaf:person and foaf:organization

# What does this pull request do?
This PR addresses issue #3747 by changing the homepage showcase to use the broader classes `foaf:Person` and `foaf:Organization` instead of the more specific `vivo:FacultyMember` and `vivo:AcademicDepartment`. This change makes the homepage more inclusive by displaying all persons and organizations rather than just faculty members and academic departments.

# What's new?
* Changed the SPARQL query in homePageDataGetters.n3 to use `foaf:Organization` instead of `vivo:AcademicDepartment`
* Updated JavaScript files (homePageUtils.js and theme-specific versions) to use `foaf:Person` instead of `vivo:FacultyMember`
* Updated "View All" links in both standard and theme-specific JavaScript files to point to the more general classes
* Updated the faculty member count logic in lib-home-page.ftl to check for `Person` instead of `FacultyMember`
* Updated section headers in templates to reflect the broader classes (People instead of Faculty, Organizations instead of Departments)

# How should this be tested?
1. Run VIVO with these changes and view the homepage
2. Verify that the "Meet our people" section now displays a broader range of individuals, not just faculty members
3. Verify that the "Organizations" section shows all organizations, not just academic departments
4. Click the "View All" links to confirm they go to the correct URLs using `foaf:Person` and `foaf:Organization`
5. Check the network requests in browser developer tools to confirm the data service calls are using the correct class URIs

# Additional Notes:
* This change may affect the content displayed on the homepage, as it will now include all persons and organizations, not just faculty and departments
* The section headers have been updated for consistency with the broader classes being used
* No additional dependencies are required for this change
* The theme-specific versions of the files have also been updated to maintain consistency

