### PR TITLE
Upgrade codeql to version 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: [4089](https://github.com/vivo-project/VIVO/issues/4089)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
[The official instructions for upgrade](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/)

# What does this pull request do?
This PR is upgrading codeql by following instructions available at this [link](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/#exactly-what-do-i-need-to-change)

# How should this be tested?
Open PR Analyze log and check if there is any error in the Annotations section. 
For instance, compare PR error log before:

- https://github.com/vivo-project/VIVO/actions/runs/15633658215/job/44043533432?pr=4084 and 
- https://github.com/vivo-project/VIVO/actions/runs/15633658215/job/44043533440?pr=4084

with error logs after the upgrade (this PR):
- https://github.com/vivo-project/VIVO/actions/runs/16848246800/job/47730849074?pr=4090 and
- https://github.com/vivo-project/VIVO/actions/runs/16848246800/job/47730849072?pr=4090

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers

