### PR TITLE
Update year in license to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2025, Lyrasis
+Copyright (c) 2026, Lyrasis
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4130)**

# What does this pull request do?
Only updates 2025 to 2026 in the license file