### PR TITLE
WCAG - Keyboard Navigation

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddAuthorsToInformationResourceGenerator.java
@@ -11,6 +11,9 @@ import java.util.Map.Entry;
 
 import javax.servlet.http.HttpSession;
 
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.Model;
@@ -101,6 +104,14 @@ public class AddAuthorsToInformationResourceGenerator extends VivoBaseGenerator 
 
         //NOITCE this generator does not run prepare() since it
         //is never an update and has no SPARQL for existing
+
+        I18nBundle i18n = I18n.bundle(vreq);
+        String title = i18n.text("manage_authors");
+        Individual subject = vreq.getWebappDaoFactory().getIndividualDao().getIndividualByURI(editConfiguration.getSubjectUri());
+        if( subject != null && subject.getName() != null ){
+            title += " - " + subject.getName();
+        }
+        editConfiguration.addNewResource("pageTitle", title);
 
         return editConfiguration;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/AddEditorsToInformationResourceGenerator.java
@@ -11,6 +11,9 @@ import java.util.Map.Entry;
 
 import javax.servlet.http.HttpSession;
 
+import edu.cornell.mannlib.vitro.webapp.beans.Individual;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.rdf.model.Model;
@@ -103,6 +106,14 @@ public class AddEditorsToInformationResourceGenerator extends VivoBaseGenerator 
 
         // NOITCE this generator does not run prepare() since it
         // is never an update and has no SPARQL for existing
+
+        I18nBundle i18n = I18n.bundle(vreq);
+        String title = i18n.text("manage_editors");
+        Individual subject = vreq.getWebappDaoFactory().getIndividualDao().getIndividualByURI(editConfiguration.getSubjectUri());
+        if( subject != null && subject.getName() != null ){
+            title += " - " + subject.getName();
+        }
+        editConfiguration.addNewResource("pageTitle", title);
 
         return editConfiguration;
     }

--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/edit/n3editing/configuration/generators/ManageWebpagesForIndividualGenerator.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpSession;
 
+import edu.cornell.mannlib.vitro.webapp.i18n.I18n;
+import edu.cornell.mannlib.vitro.webapp.i18n.I18nBundle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.query.ParameterizedSparqlString;
@@ -98,6 +100,15 @@ public class ManageWebpagesForIndividualGenerator extends BaseEditConfigurationG
         }else{
             config.addFormSpecificData("subjectName", null);
         }
+
+        String name = (String) config.getFormSpecificData().get("subjectName");
+        I18nBundle i18n = I18n.bundle(vreq);
+        String title = i18n.text("manage_web_pages");;
+        if (name != null && !name.isEmpty()) {
+            title += " - " + name;
+        }
+        config.addNewResource("pageTitle", title);
+
         prepare(vreq, config);
         return config;
     }

--- a/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/de_DE/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5926,6 +5926,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Verwenden Sie die Pfeiltasten zur Navigation und Shift + Pfeiltasten, um Elemente nach oben oder unten zu verschieben."@de-DE ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} wurde an die Position {1} verschoben."@de-DE ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_CA/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Use Arrow keys to navigate, and Shift + Arrow keys to move items up or down."@en-CA ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} moved to position {1}."@en-CA ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -925,6 +925,22 @@ uil-data:qr_icon.VIVO
         uil:hasKey      "qr_icon" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:uri_icon_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Open sharing options for this profile"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "uri_icon_label" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:qr_icon_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Open individual URI QR code"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "qr_icon_label" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:label_type.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -3074,6 +3090,14 @@ uil-data:research_areas.VIVO
         rdfs:label       "research areas"@en-US ;
         uil:hasApp      "VIVO" ;
         uil:hasKey      "research_areas" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:research_areas_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "research areas icon"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "research_areas_icon" ;
         uil:hasPackage  "VIVO-languages" .
 
 uil-data:missing_grant.VIVO

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Use Arrow keys to navigate, and Shift + Arrow keys to move items up or down."@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} moved to position {1}."@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/es/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Usa las teclas de flecha para navegar y Shift + flechas para mover los elementos hacia arriba o hacia abajo."@es ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} se movió a la posición {1}."@es ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/fr_CA/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Aucune page web n'est associée à cette personne. Ajouter une page web en cliquant sur le bouton ci-dessous."@fr-CA ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} a été déplacé à la position {1}."@fr-CA ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/pt_BR/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Use as teclas de seta para navegar e Shift + setas para mover os itens para cima ou para baixo."@pt-BR ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} foi movido para a posição {1}."@pt-BR ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/ru_RU/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5923,6 +5923,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Используйте клавиши со стрелками для навигации, а Shift + стрелки — для перемещения элементов вверх или вниз."@ru-RU ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} перемещён на позицию {1}."@ru-RU ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/sr_Latn_RS/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -5922,6 +5922,22 @@ uil-data:has_no_webpages.VIVO
         uil:hasKey      "has_no_webpages" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:arrow_key_reorder_note.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Koristite tastere sa strelicama za navigaciju, a Shift + strelice za pomeranje stavki nagore ili nadole."@sr-Latn-RS ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "arrow_key_reorder_note" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:reorder_action_info.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "{0} je pomeren na poziciju {1}."@sr-Latn-RS ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "reorder_action_info" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:through_today.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;

--- a/webapp/src/main/webapp/js/individual/propertyGroupControls.js
+++ b/webapp/src/main/webapp/js/individual/propertyGroupControls.js
@@ -26,30 +26,34 @@ $(document).ready(function(){
         var groupName = $(this).attr("groupName");
         var $propertyGroupLi = $(this);
 
-        $(this).on("click", function() {
+        $(this).on('click keydown', function(e) {
+            if (e.type === 'click' || (e.type === 'keydown' && (e.key === 'Enter' || e.keyCode === 13))) {
 
-            if ( $propertyGroupLi.attr("class") == "nonSelectedGroupTab clickable" ) {
-                $.each($('li.selectedGroupTab'), function() {
-                    $(this).removeClass("selectedGroupTab clickable");
-                    $(this).addClass("nonSelectedGroupTab clickable");
-                });
-                $propertyGroupLi.removeClass("nonSelectedGroupTab clickable");
-                $propertyGroupLi.addClass("selectedGroupTab clickable");
-            }
-            if ( $propertyGroupLi.attr("groupname") == "viewAll" ) {
-                processViewAllTab();
-            }
-            else {
-                padSectionBottoms();
-                var $visibleSection = $('section.property-group:visible');
-                $visibleSection.hide();
-                $('h2[pgroup=tabs]').addClass("hidden");
-                $('nav#scroller').addClass("hidden");
-                $('section#' + groupName).show();
-            }
+                if ( $propertyGroupLi.attr("class") == "nonSelectedGroupTab clickable" ) {
+                    $.each($('li.selectedGroupTab'), function() {
+                        $(this).removeClass("selectedGroupTab clickable");
+                        $(this).addClass("nonSelectedGroupTab clickable");
+                        $(this).attr("aria-selected", "false");
+                    });
+                    $propertyGroupLi.removeClass("nonSelectedGroupTab clickable");
+                    $propertyGroupLi.addClass("selectedGroupTab clickable");
+                    $propertyGroupLi.attr("aria-selected", "true");
+                }
+                if ( $propertyGroupLi.attr("groupname") == "viewAll" ) {
+                    processViewAllTab();
+                }
+                else {
+                    padSectionBottoms();
+                    var $visibleSection = $('section.property-group:visible');
+                    $visibleSection.hide();
+                    $('h2[pgroup=tabs]').addClass("hidden");
+                    $('nav#scroller').addClass("hidden");
+                    $('section#' + groupName).show();
+                }
 
-            manageLocalStorage();
-            return false;
+                manageLocalStorage();
+                return false;
+            }
         });
     });
 

--- a/webapp/src/main/webapp/js/visualization/entitycomparison/jquery_plugins/datatable/demo_table.css
+++ b/webapp/src/main/webapp/js/visualization/entitycomparison/jquery_plugins/datatable/demo_table.css
@@ -57,7 +57,7 @@
     clear: both;
 }
 
-.datatablewrapper th {
+.datatablewrapper th:not(.ignore-th) {
     border-top: 1px #3D454E solid;
     background:#F1F2ee;
     font-weight:bold;

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
@@ -64,12 +64,14 @@ var ComparisonDataTableWidget = Class.extend({
 		/* Create filter */
 		var dom = me.dom;
 		var filter = $('<div class="science-areas-filter">' +
-	    	'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span>'+
-	    	/* This is temporary removed due to the person's publications mapping rate is too low to be displayed.
-		    	' | ' +
-		    	'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
-	    	*/
-	    	'<img class="' + dom.filterInfoIconClass + '" id="comparisonImageIconTwo" src="'+ infoIconUrl +'" alt="' + i18nStrings.infoIconString + '" title="" /></div>');
+			'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span>'+
+			/* This is temporary removed due to the person's publications mapping rate is too low to be displayed.
+				' | ' +
+				'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
+			*/
+			'<button id="comparisonImageIconTwo" aria-label="' + i18nStrings.infoIconString + '" class="nostyle">' +
+				'<img class="' + dom.filterInfoIconClass + '" src="'+ infoIconUrl +'" alt="' + i18nStrings.infoIconString + '" title="" aria-hidden="true" />' +
+			'</button></div>');
 		me.tableDiv.append(filter);
 
 		const tooltipDataComparisonImageIconTwo = {
@@ -208,8 +210,12 @@ var ComparisonDataTableWidget = Class.extend({
 		/* Create search box */
 		var searchInputBox = $("." + me.dom.searchBarParentContainerClass).find("input[type=text]");
 		searchInputBox.css("width", "140px");
-		searchInputBox.after("<span id='comparison-reset-search' title='" + i18nStrings.clearSearchQuery + "'>X</span>"
-								+ "<img class='comparisonFilterInfoIcon' id='comparisonSearchInfoIcon' src='" + infoIconUrl + "' alt='" + i18nStrings.infoIconString + "' title='' />");
+		searchInputBox.after(
+			"<span id='comparison-reset-search' title='" + i18nStrings.clearSearchQuery + "'>X</span>"
+			+ "<button id='comparisonSearchInfoIcon' aria-label='" + i18nStrings.infoIconString + "' class='nostyle'>"
+			+ "<img class='comparisonFilterInfoIcon' src='" + infoIconUrl + "' alt='" + i18nStrings.infoIconString + "' title='' aria-hidden='true' />"
+			+ "</button>"
+		);
 		$( document ).on('click', "#comparison-reset-search", function() {
 			me.widget.fnFilter("");
 		});

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
@@ -69,8 +69,8 @@ var ComparisonDataTableWidget = Class.extend({
 				' | ' +
 				'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
 			*/
-			'<button id="comparisonImageIconTwo" aria-label="' + i18nStrings.infoIconString + '" class="nostyle">' +
-				'<img class="' + dom.filterInfoIconClass + '" src="'+ infoIconUrl +'" alt="' + i18nStrings.infoIconString + '" title="" aria-hidden="true" />' +
+			'<button id="comparisonImageIconTwo" aria-label="' + i18nStrings.infoIconString + '" class="nostyle ' + dom.filterInfoIconClass + '">' +
+				'<img src="'+ infoIconUrl +'" alt="' + i18nStrings.infoIconString + '" title="" aria-hidden="true" />' +
 			'</button></div>');
 		me.tableDiv.append(filter);
 
@@ -248,8 +248,8 @@ var ComparisonDataTableWidget = Class.extend({
 		searchInputBox.css("width", "140px");
 		searchInputBox.after(
 			"<span id='comparison-reset-search' title='" + i18nStrings.clearSearchQuery + "'>X</span>"
-			+ "<button id='comparisonSearchInfoIcon' aria-label='" + i18nStrings.infoIconString + "' class='nostyle'>"
-			+ "<img class='comparisonFilterInfoIcon' src='" + infoIconUrl + "' alt='" + i18nStrings.infoIconString + "' title='' aria-hidden='true' />"
+			+ "<button id='comparisonSearchInfoIcon' aria-label='" + i18nStrings.infoIconString + "' class='nostyle comparisonFilterInfoIcon'>"
+			+ "<img src='" + infoIconUrl + "' alt='" + i18nStrings.infoIconString + "' title='' aria-hidden='true' />"
 			+ "</button>"
 		);
 		$( document ).on('click', "#comparison-reset-search", function() {

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
@@ -74,6 +74,12 @@ var ComparisonDataTableWidget = Class.extend({
 			'</button></div>');
 		me.tableDiv.append(filter);
 
+		$("#" + dom.firstFilterID + ", #" + dom.secondFilterID).on("keydown", function(e) {
+			if (e.key === "Enter" || e.keyCode === 13) {
+				$(this).trigger("click");
+			}
+		});
+
 		const tooltipDataComparisonImageIconTwo = {
 			title: $('#comparisonToolTipTwo').html(),
 			customClass: "vitroTooltip vitroTooltip-yellow",
@@ -207,6 +213,36 @@ var ComparisonDataTableWidget = Class.extend({
 		    }
 		});
 
+		$('#datatable_paginate').attr('role', 'list')
+		const $paginationList = $('<div role="list" class="pagination-wrapper" style="display:inline"></div>');
+
+		['#datatable_first', '#datatable_previous', '#datatable_next', '#datatable_last'].forEach(selector => {
+			const $button = $(selector)
+				.attr('tabindex', 0)
+				.attr('role', 'button')
+				.wrap('<div role="listitem" class="pagination-item" style="display:inline"></div>');
+
+			// Attach keyboard support
+			$button.on('keydown', function(e) {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					$(this).trigger("click");
+				}
+			});
+
+			// Move each listitem into the list container
+			$paginationList.append($button.closest('[role="listitem"]'));
+		});
+
+		// Replace the old container with the new accessible structure
+		$('#datatable_paginate').empty().append($paginationList);
+
+		table.find('tbody > tr').each(function() {
+			var $firstTd = $(this).children('td').first();
+			var th = $('<th class="ignore-th"></th>').html($firstTd.html());
+			$firstTd.replaceWith(th);
+		});
+		
 		/* Create search box */
 		var searchInputBox = $("." + me.dom.searchBarParentContainerClass).find("input[type=text]");
 		searchInputBox.css("width", "140px");

--- a/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
@@ -106,8 +106,10 @@ var DataTableWidget = Class.extend({
 		var dom = me.dom;
 		var filter = $('<div class="science-areas-filter">' +
 				'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span> | ' +
-		    	'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
-		    	'<img class="'+ dom.filterInfoIconClass +'" id="imageIconTwo" src="'+ infoIconUrl +'" alt="information icon" title="" /></div>');
+				'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
+				'<button class="nostyle" id="imageIconTwo" aria-label="information icon">' +
+					'<img class="'+ dom.filterInfoIconClass +'" src="'+ infoIconUrl +'" alt="information icon" title="" aria-hidden="true" />' +
+				'</button></div>');
 		me.tableDiv.append(filter);
 
 		const tooltipDataImageIconTwo = {
@@ -238,8 +240,12 @@ var DataTableWidget = Class.extend({
 
 		var searchInputBox = $("." + me.dom.searchBarParentContainerClass).find("input[type=search]");
 		searchInputBox.css("width", "140px");
-		searchInputBox.after("<img class='filterInfoIcon' id='searchInfoIcon' src='" + infoIconUrl
-								+ "' alt='" + i18nStrings.infoIconString + "' title='' />");
+		searchInputBox.after(
+			"<button class='nostyle' id='searchInfoIcon' aria-label='"+ i18nStrings.infoIconString +"'>" +
+				"<img class='filterInfoIcon' src='" + infoIconUrl
+				+ "' alt='" + i18nStrings.infoIconString + "' title='' aria-hidden='true' />" +
+			"</button>"
+		);
 		$( document ).on('click', "#reset-search", function() {
 			me.widget.fnFilter("");
 		});

--- a/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
@@ -107,8 +107,8 @@ var DataTableWidget = Class.extend({
 		var filter = $('<div class="science-areas-filter">' +
 				'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span> | ' +
 				'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
-				'<button class="nostyle" id="imageIconTwo" aria-label="information icon">' +
-					'<img class="'+ dom.filterInfoIconClass +'" src="'+ infoIconUrl +'" alt="information icon" title="" aria-hidden="true" />' +
+				'<button class="nostyle ' + dom.filterInfoIconClass + '" id="imageIconTwo" aria-label="information icon">' +
+					'<img src="'+ infoIconUrl +'" alt="information icon" title="" aria-hidden="true" />' +
 				'</button></div>');
 		me.tableDiv.append(filter);
 
@@ -276,8 +276,8 @@ var DataTableWidget = Class.extend({
 		var searchInputBox = $("." + me.dom.searchBarParentContainerClass).find("input[type=search]");
 		searchInputBox.css("width", "140px");
 		searchInputBox.after(
-			"<button class='nostyle' id='searchInfoIcon' aria-label='"+ i18nStrings.infoIconString +"'>" +
-				"<img class='filterInfoIcon' src='" + infoIconUrl
+			"<button class='nostyle filterInfoIcon' id='searchInfoIcon' aria-label='"+ i18nStrings.infoIconString +"'>" +
+				"<img src='" + infoIconUrl
 				+ "' alt='" + i18nStrings.infoIconString + "' title='' aria-hidden='true' />" +
 			"</button>"
 		);

--- a/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
@@ -112,6 +112,12 @@ var DataTableWidget = Class.extend({
 				'</button></div>');
 		me.tableDiv.append(filter);
 
+		$("#" + dom.firstFilterID + ", #" + dom.secondFilterID).on("keydown", function(e) {
+			if (e.key === "Enter" || e.keyCode === 13) {
+				$(this).trigger("click");
+			}
+		});
+
 		const tooltipDataImageIconTwo = {
 			title: "<div>" + $('#toolTipTwo').html() + "</div>",
 			customClass: "vitroTooltip vitroTooltip-yellow",
@@ -237,6 +243,35 @@ var DataTableWidget = Class.extend({
 		    }
 		});
 
+		$('#datatable_paginate').attr('role', 'list')
+		const $paginationList = $('<div role="list" class="pagination-wrapper"></div>');
+
+		['#datatable_first', '#datatable_previous', '#datatable_next', '#datatable_last'].forEach(selector => {
+			const $button = $(selector)
+				.attr('tabindex', 0)
+				.attr('role', 'button')
+				.wrap('<div role="listitem" class="pagination-item" style="display:inline"></div>');
+
+			// Attach keyboard support
+			$button.on('keydown', function(e) {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					$(this).trigger("click");
+				}
+			});
+
+			// Move each listitem into the list container
+			$paginationList.append($button.closest('[role="listitem"]'));
+		});
+
+		// Replace the old container with the new accessible structure
+		$('#datatable_paginate').empty().append($paginationList);
+
+		table.find('tbody > tr').each(function() {
+			var $firstTd = $(this).children('td').first();
+			var th = $('<th class="ignore-th"></th>').html($firstTd.html());
+			$firstTd.replaceWith(th);
+		});
 
 		var searchInputBox = $("." + me.dom.searchBarParentContainerClass).find("input[type=search]");
 		searchInputBox.css("width", "140px");

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-2column.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-2column.ftl
@@ -130,8 +130,8 @@
 
 <#if profilePageTypesEnabled && (targetedView?has_content || user.loggedIn) >
 <span id="quickViewLink" >
-    <a href="${urls.base}/display/${individual.localName}?destination=quickView" >
-        <img id="quickViewIcon" src="${urls.images}/individual/quickViewIcon.png" alt="${i18n().quick_view_icon}"/>
+    <a id="quickViewIcon" href="${urls.base}/display/${individual.localName}?destination=quickView" aria-label="${i18n().quick_view_icon}" >
+        <img src="${urls.images}/individual/quickViewIcon.png" alt="${i18n().quick_view_icon}" aria-hidden="true" />
     </a>
 </span>
 </#if>

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-quickview.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual--foaf-person-quickview.ftl
@@ -180,8 +180,8 @@
     <br />
 </p>
 <span id="fullViewLink">
-    <a href="${urls.base}/display/${individual.localName}?destination=standardView" >
-        <img id="fullViewIcon" src="${urls.images}/individual/fullViewIcon.png" alt="${i18n().full_view_icon}"/>
+    <a id="fullViewIcon" href="${urls.base}/display/${individual.localName}?destination=standardView" aria-label="${i18n().full_view_icon}" >
+        <img src="${urls.images}/individual/fullViewIcon.png" alt="${i18n().full_view_icon}" aria-hidden="true" />
     </a>
 </span>
 <#if !editable>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-iconControls.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-iconControls.ftl
@@ -2,9 +2,13 @@
 
 <#-- Icon controls displayed in upper-right corner -->
 
-<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/share-uri-icon.png" alt="${i18n().share_the_uri}" />
+<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+	<img title="${individual.uri}" src="${urls.images}/individual/share-uri-icon.png" alt="${i18n().share_the_uri}" aria-hidden="true" />
+</button>
 <#if checkNamesResult?has_content >
-	<img id="qrIcon"  src="${urls.images}/individual/qr-code-icon.png" alt="${i18n().qr_icon}" />
+    <button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+		<img src="${urls.images}/individual/qr-code-icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+	</button>
 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
 		<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
 	</span>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-researchAreas.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-researchAreas.ftl
@@ -7,7 +7,9 @@
     <#assign localName = researchAreas.localName>
     <h2 id="${localName}" class="mainPropGroup" title="${researchAreas.publicDescription!}">
         ${researchAreas.name}
-        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas}" />
+        <button id="researchAreaIcon" class="nostyle" aria-label="${i18n().research_areas_icon}">
+            <img src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas_icon}" aria-hidden="true" />
+        </button>
         <@p.addLink researchAreas editable />
     </h2>
     <@p.verboseDisplay researchAreas />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addAuthorsToInformationResource.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addAuthorsToInformationResource.ftl
@@ -51,6 +51,11 @@
 
 <h3>${i18n().manage_authors}</h3>
 
+<div id="reorder-instructions" class="sr-only">
+    ${i18n().arrow_key_reorder_note}
+</div>
+<div id="live-region" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
 <ul id="dragDropList" ${ulClass}>
 
 <script type="text/javascript">
@@ -64,7 +69,7 @@
 	<#assign authorUri = authorship.authorUri/>
 	<#assign authorName = authorship.authorName/>
 
-	<li class="authorship">
+	<li class="authorship" tabindex="0">
 			<#-- span.author will be used in the next phase, when we display a message that the author has been
 			removed. That text will replace the a.authorName, which will be removed. -->
 			<span class="authorship">
@@ -201,7 +206,9 @@ var i18nStrings = {
     authorTypeText: '${i18n().author_capitalized?js_string}',
     organizationTypeText: '${i18n().organization_capitalized?js_string}',
     helpTextSelect: '${i18n().select_an_existing?js_string}',
-    helpTextAdd: '${i18n().or_add_new_one?js_string}'
+    helpTextAdd: '${i18n().or_add_new_one?js_string}',
+    errorRemovingWebpage: '${i18n().error_removing_webpage?js_string}',
+    reorderActionInfo: '${i18n().reorder_action_info?js_string}'
 };
 
 $(document).ready(function () {

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorsToInformationResource.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorsToInformationResource.ftl
@@ -49,6 +49,11 @@
 
 <h3>${i18n().manage_editors}</h3>
 
+<div id="reorder-instructions" class="sr-only">
+    ${i18n().arrow_key_reorder_note}
+</div>
+<div id="live-region" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
 <ul id="dragDropList" ${ulClass}>
 
 <script type="text/javascript">
@@ -62,7 +67,7 @@
 	<#assign editorUri = editorship.editorUri/>
 	<#assign editorName = editorship.editorName/>
 
-	<li class="editorship">
+	<li class="editorship" tabindex="0">
 			<#-- span.editor will be used in the next phase, when we display a message that the editor has been
 			removed. That text will replace the a.editorName, which will be removed. -->
 			<span class="editor">
@@ -196,7 +201,9 @@ var i18nStrings = {
     editorTypeText: '${i18n().editor_capitalized?js_string}',
     organizationTypeText: '${i18n().organization_capitalized?js_string}',
     helpTextSelect: '${i18n().select_an_existing?js_string}',
-    helpTextAdd: '${i18n().or_add_new_one?js_string}'
+    helpTextAdd: '${i18n().or_add_new_one?js_string}',
+    errorRemovingWebpage: '${i18n().error_removing_webpage?js_string}',
+    reorderActionInfo: '${i18n().reorder_action_info?js_string}'
 };
 
 $(document).ready(function () {

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/addAuthorsToInformationResource.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/addAuthorsToInformationResource.js
@@ -382,10 +382,70 @@ var addAuthorForm = {
 
         authorshipList.sortable({
             cursor: 'move',
-            update: function(event, ui) {
-                addAuthorForm.reorderAuthors(event, ui);
+        });
+
+        authorshipList.on('sortupdate', (event, ui) => {
+            addAuthorForm.reorderAuthors(event, ui);
+        });
+
+        authorshipList.on('keydown', 'li', (e) => {
+            const $focused = $(e.currentTarget);
+            const $allItems = authorshipList.children('li');
+            const index = $allItems.index($focused);
+            const key = e.key;
+
+            const moveItem = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+
+                if (direction === -1) {
+                    $focused.insertBefore($allItems.eq(targetIndex));
+                } else {
+                    $focused.insertAfter($allItems.eq(targetIndex));
+                }
+
+                $focused.focus();
+                triggerUpdateEvent();
+
+                const itemName = $focused.find('.itemName').text().trim() || $focused.text().trim();
+                const newIndex = targetIndex + 1;
+
+                $('#live-region').text(
+                    i18nStrings.reorderActionInfo
+                        .replace("{0}", itemName)
+                        .replace("{1}", newIndex)
+                );
+            };
+
+            const moveFocus = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+                $allItems.eq(targetIndex).focus();
+            };
+
+            if (e.shiftKey || e.ctrlKey) {
+                if (key === 'ArrowUp') {
+                    moveItem(-1);
+                } else if (key === 'ArrowDown') {
+                    moveItem(1);
+                }
+            } else {
+                if (key === 'ArrowUp') {
+                    moveFocus(-1);
+                } else if (key === 'ArrowDown') {
+                    moveFocus(1);
+                }
             }
         });
+
+        function triggerUpdateEvent() {
+            authorshipList.sortable('refresh');
+            authorshipList.trigger('sortupdate');
+        }
     },
 
     // Reorder authors. Called on page load and after author drag-and-drop and remove.

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/addEditorsToInformationResource.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/addEditorsToInformationResource.js
@@ -382,10 +382,71 @@ var addEditorForm = {
 
         editorshipList.sortable({
             cursor: 'move',
-            update: function(event, ui) {
-                addEditorForm.reorderEditors(event, ui);
+        });
+
+        editorshipList.on('sortupdate', (event, ui) => {
+            addEditorForm.reorderEditors(event, ui);
+        });
+
+        editorshipList.on('keydown', 'li', (e) => {
+            const $focused = $(e.currentTarget);
+            const $allItems = editorshipList.children('li');
+            const index = $allItems.index($focused);
+            const key = e.key;
+
+            const moveItem = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+
+                if (direction === -1) {
+                    $focused.insertBefore($allItems.eq(targetIndex));
+                } else {
+                    $focused.insertAfter($allItems.eq(targetIndex));
+                }
+
+                $focused.focus();
+                triggerUpdateEvent();
+
+                const itemName = $focused.find('.itemName').text().trim() || $focused.text().trim();
+                const newIndex = targetIndex + 1;
+
+                $('#live-region').text(
+                    i18nStrings.reorderActionInfo
+                        .replace("{0}", itemName)
+                        .replace("{1}", newIndex)
+                );
+            };
+
+            const moveFocus = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+                $allItems.eq(targetIndex).focus();
+            };
+
+            if (e.shiftKey || e.ctrlKey) {
+                if (key === 'ArrowUp') {
+                    moveItem(-1);
+                } else if (key === 'ArrowDown') {
+                    moveItem(1);
+                }
+            } else {
+                if (key === 'ArrowUp') {
+                    moveFocus(-1);
+                } else if (key === 'ArrowDown') {
+                    moveFocus(1);
+                }
             }
         });
+
+        function triggerUpdateEvent() {
+            editorshipList.sortable('refresh');
+            editorshipList.trigger('sortupdate');
+        }
+
     },
 
     // Reorder editors. Called on page load and after editor drag-and-drop and remove.

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/js/manageWebpagesForIndividual.js
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/js/manageWebpagesForIndividual.js
@@ -74,10 +74,70 @@ var manageWebpages = {
 
         webpages.sortable({
             cursor: 'move',
-            update: function(event, ui) {
-                manageWebpages.reorder(event, ui);
+        });
+
+        webpages.on('sortupdate', (event, ui) => {
+            manageWebpages.reorder(event, ui);
+        });
+
+        webpages.on('keydown', 'li', (e) => {
+            const $focused = $(e.currentTarget);
+            const $allItems = webpages.children('li');
+            const index = $allItems.index($focused);
+            const key = e.key;
+
+            const moveItem = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+
+                if (direction === -1) {
+                    $focused.insertBefore($allItems.eq(targetIndex));
+                } else {
+                    $focused.insertAfter($allItems.eq(targetIndex));
+                }
+
+                $focused.focus();
+                triggerUpdateEvent();
+
+                const itemName = $focused.find('.itemName').text().trim() || $focused.text().trim();
+                const newIndex = targetIndex + 1;
+
+                $('#live-region').text(
+                    i18nStrings.reorderActionInfo
+                        .replace("{0}", itemName)
+                        .replace("{1}", newIndex)
+                );
+            };
+
+            const moveFocus = (direction) => {
+                const targetIndex = index + direction;
+                if (targetIndex < 0 || targetIndex >= $allItems.length) return;
+
+                e.preventDefault();
+                $allItems.eq(targetIndex).focus();
+            };
+
+            if (e.shiftKey || e.ctrlKey) {
+                if (key === 'ArrowUp') {
+                    moveItem(-1);
+                } else if (key === 'ArrowDown') {
+                    moveItem(1);
+                }
+            } else {
+                if (key === 'ArrowUp') {
+                    moveFocus(-1);
+                } else if (key === 'ArrowDown') {
+                    moveFocus(1);
+                }
             }
         });
+
+        function triggerUpdateEvent() {
+            webpages.sortable('refresh');
+            webpages.trigger('sortupdate');
+        }
     },
 
     // Reorder webpages. Called on page load and after drag-and-drop and remove.

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/manageWebpagesForIndividual.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/manageWebpagesForIndividual.ftl
@@ -26,9 +26,14 @@
     <p>${i18n().has_no_webpages}</p>
 </#if>
 
+<div id="reorder-instructions" class="sr-only">
+    ${i18n().arrow_key_reorder_note}
+</div>
+<div id="live-region" class="sr-only" aria-live="polite" aria-atomic="true"></div>
+
 <ul id="dragDropList" ${ulClass} role="list">
     <#list editConfiguration.pageData.webpages as webpage>
-        <li class="webpage" role="listitem">
+        <li class="webpage" tabindex="0" role="listitem">
             <#if webpage.label??>
                 <#assign anchor=webpage.label >
             <#else>
@@ -73,7 +78,8 @@ var i18nStrings = {
     dragDropToReorderWebpages: '${i18n().drag_drop_to_reorder_webpages?js_string}',
     webpageReorderingFailed: '${i18n().webpage_reordering_failed?js_string}',
     confirmWebpageDeletion: '${i18n().confirm_webpage_deletion?js_string}',
-    errorRemovingWebpage: '${i18n().error_removing_webpage?js_string}'
+    errorRemovingWebpage: '${i18n().error_removing_webpage?js_string}',
+    reorderActionInfo: '${i18n().reorder_action_info?js_string}'
 };
 </script>
 

--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
@@ -21,7 +21,7 @@ corresponding changes in the included Templates. -->
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines}
 	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
-        <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png"
+        <img class="filterInfoIcon" src="${urls.images}/iconInfo.png"
 		    alt="${i18n().info_icon}" aria-hidden="true" />
     </button>
 </div>
@@ -49,13 +49,13 @@ corresponding changes in the included Templates. -->
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
         
         <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
         </button>
         <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
 
         <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
         </button>
         <br><br>
     </div>
@@ -72,7 +72,7 @@ corresponding changes in the included Templates. -->
 		${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
 
         <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" aria-hidden="true"/>
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true"/>
         </button>
 
 		<div id="download-unlocated-journal-info">

--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
@@ -20,8 +20,8 @@ corresponding changes in the included Templates. -->
 <h2 id="header-entity-label" class="hide-dom-on-init"><span><a id="entityMoniker" href="${entityVivoProfileURL}" title="${i18n().entity_label}">${entityLabel}</a></span></h2>
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines}
-	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
-        <img class="filterInfoIcon" src="${urls.images}/iconInfo.png"
+	<button id="imageIconOne" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+        <img src="${urls.images}/iconInfo.png"
 		    alt="${i18n().info_icon}" aria-hidden="true" />
     </button>
 </div>
@@ -48,14 +48,14 @@ corresponding changes in the included Templates. -->
     <div id="view-type-filter" style="display:${viewTypeFilterDisplay};">
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
         
-        <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+        <button id="exploreInfoIcon" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+    	    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
         </button>
         <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
 
-        <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+        <button id="compareInfoIcon" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+    	    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
         </button>
         <br><br>
     </div>
@@ -71,8 +71,8 @@ corresponding changes in the included Templates. -->
 	<div id="percent-mapped-info">
 		${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
 
-        <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true"/>
+        <button id="imageIconThree" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+    	    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true"/>
         </button>
 
 		<div id="download-unlocated-journal-info">

--- a/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/mapOfScience/mapOfScienceStandalone.ftl
@@ -20,8 +20,10 @@ corresponding changes in the included Templates. -->
 <h2 id="header-entity-label" class="hide-dom-on-init"><span><a id="entityMoniker" href="${entityVivoProfileURL}" title="${i18n().entity_label}">${entityLabel}</a></span></h2>
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines}
-	<img class="filterInfoIcon" id="imageIconOne"  src="${urls.images}/iconInfo.png"
-		alt="${i18n().info_icon}" />
+	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
+        <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png"
+		    alt="${i18n().info_icon}" aria-hidden="true" />
+    </button>
 </div>
 
 <div id="left-column" class="hide-dom-on-init">
@@ -45,9 +47,17 @@ corresponding changes in the included Templates. -->
     <#-- VIEW TYPE FILTER -->
     <div id="view-type-filter" style="display:${viewTypeFilterDisplay};">
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
-    	<img class="filterInfoIcon" id="exploreInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" /><br>
+        
+        <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+        </button>
+        <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
-		<img class="filterInfoIcon" id="compareInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" /><br><br>
+
+        <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+        </button>
+        <br><br>
     </div>
 
     <!-- <h3>${i18n().what_to_compare}</h3> -->
@@ -60,7 +70,10 @@ corresponding changes in the included Templates. -->
 	<div id="map_area"></div>
 	<div id="percent-mapped-info">
 		${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
-		<img class="filterInfoIcon" id="imageIconThree" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}"/>
+
+        <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" aria-hidden="true"/>
+        </button>
 
 		<div id="download-unlocated-journal-info">
 			<a href="${entityMapOfScienceUnlocatedJournalsCSVURL}" title="${i18n().save_unmapped_publications}">${i18n().save_unmapped_publications}</a>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
@@ -324,7 +324,7 @@ $(document).ready(function(){
         <div class="vis_stats_full">
 
         <div class="sub_headings" id="table_heading"><h3>${i18n().tables_capitalized}</h3></div>
-            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}"><img class="filterInfoIcon" width="16px" height="16px" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" aria-hidden="true" /></button></p>
+            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<button id="imageIconThree" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}"><img width="16px" height="16px" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" aria-hidden="true" /></button></p>
 
             <div style="clear:both"></div>
 

--- a/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
@@ -324,7 +324,7 @@ $(document).ready(function(){
         <div class="vis_stats_full">
 
         <div class="sub_headings" id="table_heading"><h3>${i18n().tables_capitalized}</h3></div>
-            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}"><img class="filterInfoIcon" width="16px" height="16px" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" aria-hidden="true" /></button></p>
+            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}"><img class="filterInfoIcon" width="16px" height="16px" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" aria-hidden="true" /></button></p>
 
             <div style="clear:both"></div>
 

--- a/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/personlevel/coPIPersonLevelD3.ftl
@@ -324,7 +324,7 @@ $(document).ready(function(){
         <div class="vis_stats_full">
 
         <div class="sub_headings" id="table_heading"><h3>${i18n().tables_capitalized}</h3></div>
-            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<img class="filterInfoIcon" width="16px" height="16px" id="imageIconThree" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" /></p>
+            <p style="float:left;font-size:.9em">${i18n().grant_info_for_all_years}&nbsp;<button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}"><img class="filterInfoIcon" width="16px" height="16px" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="${i18n().grant_sparkline_note}" aria-hidden="true" /></button></p>
 
             <div style="clear:both"></div>
 

--- a/webapp/src/main/webapp/themes/nemo/i18n/vivo_all_en_US.properties
+++ b/webapp/src/main/webapp/themes/nemo/i18n/vivo_all_en_US.properties
@@ -452,6 +452,8 @@ check_pubs_to_exclude = Check those publications you want to <em>exclude</em> fr
 
 manage_web_pages = Manage Web Pages
 has_no_webpages = This individual currently has no web pages specified. Add a new web page by clicking on the button below.
+arrow_key_reorder_note = Use Arrow keys to navigate, and Shift + Arrow keys to move items up or down.
+reorder_action_info = {0} moved to position {1}.
 edit_webpage_link = edit web page link
 delete_webpage_link = delete web page link
 webpage_url = webpage url

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-academic-article.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-academic-article.ftl
@@ -87,7 +87,11 @@
 
                     <#--  Most-specific types -->
                     <@p.mostSpecificTypes individual />
-                    <span id="iconControlsVitro"><img id="uriIcon" title="${individual.uri}" class="middle" src="${urls.images}/individual/uriIcon.gif" alt="uri icon"/></span>
+                    <span id="iconControlsVitro">
+                    <button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+                        <img title="${individual.uri}" class="middle" src="${urls.images}/individual/uriIcon.gif" alt="uri icon" aria-hidden="true" />
+                    </button>
+                    </span>
                 </h1>
             </#if>
         </header>

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
@@ -98,9 +98,13 @@ Add divs and wrapper to create funnelback basket controls. MUST BE REMOVED BEFOR
 						<!-- Contact Info -->
 						<div id="individual-tools-people">
 							<span id="iconControlsLeftSide">
-								<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+								<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+									<img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true" />
+								</button>
 								<#if checkNamesResult?has_content >
-									<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+									<button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+										<img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+									</button>
 									<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!} 
 										<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">
 											${i18n().close_capitalized}

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-custom-researchAreas.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-custom-researchAreas.ftl
@@ -7,7 +7,9 @@
     <#assign localName = researchAreas.localName>
     <h3 id="${localName}" class="mainPropGroup h4" title="${researchAreas.publicDescription!}">
         ${researchAreas.name?capitalize} 
-        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas}" />
+        <button id="researchAreaIcon" class="nostyle" aria-label="${i18n().research_areas_icon}">
+            <img src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas_icon}" aria-hidden="true" />
+        </button>
         <@p.addLink researchAreas editable /> <@p.verboseDisplay researchAreas />
     </h3>
     <ul id="individual-${localName}" role="list" >

--- a/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
@@ -22,8 +22,8 @@ corresponding changes in the included Templates. -->
 <h2 id="header-entity-label" class="hide-dom-on-init"><span><a id="entityMoniker" href="${entityVivoProfileURL}" title="${i18n().entity_label}">${entityLabel}</a></span></h2>
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines} 
-	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
-        <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" 
+	<button id="imageIconOne" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+        <img src="${urls.images}/iconInfo.png" 
             alt="${i18n().info_icon}" aria-hidden="true" /> 
     </button>
 </div>
@@ -52,14 +52,14 @@ corresponding changes in the included Templates. -->
     <#-- VIEW TYPE FILTER -->
     <div id="view-type-filter" style="display:${viewTypeFilterDisplay};">
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
-        <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+        <button id="exploreInfoIcon" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+    	    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
         </button>
         <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
 
-        <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+        <button id="compareInfoIcon" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+    	    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
         </button>        
         <br><br>
     </div>
@@ -68,8 +68,8 @@ corresponding changes in the included Templates. -->
     <div id="percent-mapped-info">
                 ${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
 
-                <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
-                    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true" />
+                <button id="imageIconThree" class="nostyle filterInfoIcon" aria-label="${i18n().info_icon}">
+                    <img src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true" />
                 </button>
 
         </div>

--- a/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
@@ -22,8 +22,10 @@ corresponding changes in the included Templates. -->
 <h2 id="header-entity-label" class="hide-dom-on-init"><span><a id="entityMoniker" href="${entityVivoProfileURL}" title="${i18n().entity_label}">${entityLabel}</a></span></h2>
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines} 
-	<img class="filterInfoIcon" id="imageIconOne"  src="${urls.images}/iconInfo.png" 
-		alt="${i18n().info_icon}" /> 
+	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
+        <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" 
+            alt="${i18n().info_icon}" aria-hidden="true" /> 
+    </button>
 </div>
 </div>
 </div> <!--row-->
@@ -50,15 +52,25 @@ corresponding changes in the included Templates. -->
     <#-- VIEW TYPE FILTER -->
     <div id="view-type-filter" style="display:${viewTypeFilterDisplay};">
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
-    	<img class="filterInfoIcon" id="exploreInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" /><br>
+        <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+        </button>
+        <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
-		<img class="filterInfoIcon" id="compareInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" /><br><br>
+
+        <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+        </button>        
+        <br><br>
     </div>
     
     <!-- <h3>${i18n().what_to_compare}</h3> -->
     <div id="percent-mapped-info">
                 ${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
-                <img class="filterInfoIcon" id="imageIconThree" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}"/>
+
+                <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
+                    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" aria-hidden="true" />
+                </button>
 
         </div>
     

--- a/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/mapOfScienceStandalone.ftl
@@ -23,7 +23,7 @@ corresponding changes in the included Templates. -->
 
 <div id="map-of-science-info" class="hide-dom-on-init"> ${i18n().explore_activity} (<span id="mapped-publications" style="font-weight: bold"></span> ${i18n().publications}) ${i18n().across_subdisciplines} 
 	<button id="imageIconOne" class="nostyle" aria-label="${i18n().info_icon}">
-        <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" 
+        <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" 
             alt="${i18n().info_icon}" aria-hidden="true" /> 
     </button>
 </div>
@@ -53,13 +53,13 @@ corresponding changes in the included Templates. -->
     <div id="view-type-filter" style="display:${viewTypeFilterDisplay};">
     	<input type="radio" name="view-type" value="ENTITY"> ${i18n().explore_capitalized} ${entityLabel} </input>
         <button id="exploreInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true" />
         </button>
         <br>
 		<input type="radio" name="view-type" value="COMPARISON"> ${i18n().compare_organizations} <#--/ people --></input>
 
         <button id="compareInfoIcon" class="nostyle" aria-label="${i18n().info_icon}">
-    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
+    	    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" title="" aria-hidden="true"/>
         </button>        
         <br><br>
     </div>
@@ -69,7 +69,7 @@ corresponding changes in the included Templates. -->
                 ${i18n().mapped} <span id="percent-mapped"></span>% ${i18n().of} <span id="total-publications"></span> ${i18n().publications}
 
                 <button id="imageIconThree" class="nostyle" aria-label="${i18n().info_icon}">
-                    <img class="filterInfoIcon" src="${urls.images}/iconInfo-darkened.png" alt="${i18n().info_icon}" aria-hidden="true" />
+                    <img class="filterInfoIcon" src="${urls.images}/iconInfo.png" alt="${i18n().info_icon}" aria-hidden="true" />
                 </button>
 
         </div>

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
@@ -54,9 +54,13 @@
 			<div class="row title">
 				<div class="col-md-12">
 					<span id="iconControlsRightSide">
-						<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+						<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+							<img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true" />
+						</button>
 						<#if checkNamesResult?has_content >
-							<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+							<button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+							<img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+							</button>
 								<div id="qrCodeContainer">
 									<span id="qrCodeImage" class="bottomLeftAnchor hidden">${qrCodeLinkedImage!}
 										<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/scratch.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/scratch.ftl
@@ -17,9 +17,14 @@
         <!-- Contact Info -->
         <div id="individual-tools-people">
             <span id="iconControlsLeftSide">
-                <img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+                <button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+                    <img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true"/>
+                </button>
   				<#if checkNamesResult?has_content >
-					<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+					
+                    <button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+					    <img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+                    </button
                 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
 						<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
 					</span>

--- a/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
@@ -44,9 +44,19 @@
         <!-- Contact Info -->
         <div id="individual-tools-people">
             <span id="iconControlsLeftSide">
-                <img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+                <button id="uriIcon"
+                        title="${individual.uri}"
+                        class="nostyle"
+                        aria-label="${i18n().uri_icon_label}">
+                    <img src="${urls.images}/individual/uriIcon.gif"
+                         alt="${i18n().uri_icon}"
+                         aria-hidden="true"/>
+                </button>
   				<#if checkNamesResult?has_content >
-					<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+                    <button id="qrIcon" title="${individual.uri}" class="nostyle" aria-label="${i18n().qr_icon_label}">
+					    <img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+                    </button>
+
                 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
 						<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
 					</span>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4100)**

# What does this pull request do?
This PR adds full keyboard support for the sortable list used to reorder authors in a publication.
It improves accessibility by allowing users to reorder items without a mouse.

# What's new?
Improved focus and navigation behavior for sortable
Added missing English strings to i18n

This GIF demonstrates keyboard support for the Sortable feature, designed to be accessible for users who rely on screen readers.
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdTdzMGpzbGhkZjA4dHRkandjcHUwajJoendlejZ5Y3o4cGp3ODFmeSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/waJKi5IvdU7Z4Sayw4/giphy.gif)

# How should this be tested?
1. Open any research record that has authors.
2. Click the reorder authors icon/button.
3. Verify reordering with the mouse works fine.
4. Test reordering with the keyboard
  - Use **Arrow Up/Down** to select author
  - Use **Shift + Arrow Up/Down** to move the selected author up or down
5. Test it with the Screen Reader
  - On macOS, enable VoiceOver with **Command + F5**

# Additional Notes:
Keyboard navigation is also improved in those tooltip PR:
**[Linked Vitro PR](https://github.com/vivo-project/Vitro/pull/508)**
**[Linked Vitro PR](https://github.com/vivo-project/VIVO/pull/4133)**

# Interested parties
@VIVO-project/vivo-committers

# Reviewers' expertise
Candidates for reviewing this PR should have some of the following expertises:
1. HTML, CSS, JavaScript
