### PR TITLE
WCAG - Aria Attributes

### DIFF
--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -925,6 +925,22 @@ uil-data:qr_icon.VIVO
         uil:hasKey      "qr_icon" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:uri_icon_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Open sharing options for this profile"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "uri_icon_label" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:qr_icon_label.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Open individual URI QR code"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "qr_icon_label" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:label_type.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -3074,6 +3090,14 @@ uil-data:research_areas.VIVO
         rdfs:label       "research areas"@en-US ;
         uil:hasApp      "VIVO" ;
         uil:hasKey      "research_areas" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:research_areas_icon.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "research areas icon"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "research_areas_icon" ;
         uil:hasPackage  "VIVO-languages" .
 
 uil-data:missing_grant.VIVO

--- a/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
+++ b/home/src/main/resources/rdf/i18n/en_US/interface-i18n/firsttime/vivo_UiLabel.ttl
@@ -3491,6 +3491,14 @@ uil-data:manage_editors.VIVO
         uil:hasKey      "manage_editors" ;
         uil:hasPackage  "VIVO-languages" .
 
+uil-data:manage_positions.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Manage Positions"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "manage_positions" ;
+        uil:hasPackage  "VIVO-languages" .
+
 uil-data:the_capitalized.VIVO
         rdf:type         owl:NamedIndividual ;
         rdf:type         uil:UILabel ;
@@ -5137,6 +5145,14 @@ uil-data:capability_map.VIVO
         rdfs:label       "Capability Map"@en-US ;
         uil:hasApp      "VIVO" ;
         uil:hasKey      "capability_map" ;
+        uil:hasPackage  "VIVO-languages" .
+
+uil-data:capability_map_input.VIVO
+        rdf:type         owl:NamedIndividual ;
+        rdf:type         uil:UILabel ;
+        rdfs:label       "Capability Map search input"@en-US ;
+        uil:hasApp      "VIVO" ;
+        uil:hasKey      "capability_map_input" ;
         uil:hasPackage  "VIVO-languages" .
 
 uil-data:search_info_tool_tip_text_the_first_part.VIVO

--- a/webapp/src/main/webapp/css/visualization/capabilitymap/graph.css
+++ b/webapp/src/main/webapp/css/visualization/capabilitymap/graph.css
@@ -311,6 +311,15 @@ hr {
 .tabs ul.titles li.activeTab a:hover {
     background-color: #fff;
 }
+
+/* Focus styles for tab links */
+.tabs ul.titles li a:focus {
+    outline: 2px solid #0078d7; /* 2px box around focused element */
+    font-weight: bold;          /* Make text bold */
+    position: relative;
+    z-index: 1;
+}
+
 .smalllogo {
     margin-left:-5px;
     vertical-align:middle;

--- a/webapp/src/main/webapp/js/homePageUtils.js
+++ b/webapp/src/main/webapp/js/homePageUtils.js
@@ -76,7 +76,7 @@ $(document).ready(function(){
 
                     $.each($('div#research-faculty-mbrs ul#facultyThumbs li.individual'), function() {
                         if ( $(this).children('img').length == 0 ) {
-                            var imgHtml = "<img width='60' alt='" + i18nStrings.placeholderImage + "' src='" + urlsBase + "/images/placeholders/person.bordered.thumbnail.jpg'>";
+                            var imgHtml = "<img width='60' alt='' src='" + urlsBase + "/images/placeholders/person.bordered.thumbnail.jpg'>";
                             $(this).prepend(imgHtml);
                         }
                         else {
@@ -89,7 +89,7 @@ $(document).ready(function(){
                                 + urlsBase
                                 + "/people#http://vivoweb.org/ontology/core#FacultyMember' alt='"
                                 + i18nStrings.viewAllFaculty + "'>"
-                                + i18nStrings.viewAllString + "</a></li></ul>";
+                                + i18nStrings.viewAllFaculty.charAt(0).toUpperCase() + i18nStrings.viewAllFaculty.slice(1) + "...</a></li></ul>";
                     $('div#research-faculty-mbrs').append(viewMore);
                 }
             });
@@ -157,7 +157,7 @@ $(document).ready(function(){
                     + urlsBase
                     + "/organizations#http://vivoweb.org/ontology/core#AcademicDepartment' alt='"
                     + i18nStrings.viewAllDepartments + "'>"
-                    + i18nStrings.viewAllString + "</a></li></ul>";
+                    + i18nStrings.viewAllDepartments.charAt(0).toUpperCase() + i18nStrings.viewAllDepartments.slice(1) + "...</a></li></ul>";
         }
         $('div#academic-depts').html(html);
     }

--- a/webapp/src/main/webapp/js/individual/propertyGroupControls.js
+++ b/webapp/src/main/webapp/js/individual/propertyGroupControls.js
@@ -32,9 +32,11 @@ $(document).ready(function(){
                 $.each($('li.selectedGroupTab'), function() {
                     $(this).removeClass("selectedGroupTab clickable");
                     $(this).addClass("nonSelectedGroupTab clickable");
+                    $(this).attr("aria-selected", "false");
                 });
                 $propertyGroupLi.removeClass("nonSelectedGroupTab clickable");
                 $propertyGroupLi.addClass("selectedGroupTab clickable");
+                $propertyGroupLi.attr("aria-selected", "true");
             }
             if ( $propertyGroupLi.attr("groupname") == "viewAll" ) {
                 processViewAllTab();
@@ -126,9 +128,12 @@ $(document).ready(function(){
     function swapTabs(tabName, currentTab) {
         $('li[groupName="' + tabName + '"]').removeClass("nonSelectedGroupTab clickable");
         $('li[groupName="' + tabName + '"]').addClass("selectedGroupTab clickable");
+        $('li[groupName="' + tabName + '"]').attr("aria-selected", "true");
+
         // deselect the first tab
         $('li[groupName="' + currentTab + '"]').removeClass("selectedGroupTab clickable");
         $('li[groupName="' + currentTab + '"]').addClass("nonSelectedGroupTab clickable");
+        $('li[groupName="' + currentTab + '"]').attr("aria-selected", "false");
 
         if ( tabName == 'viewAll'){
             processViewAllTab();
@@ -212,9 +217,11 @@ $(document).ready(function(){
                     var $firstTab = $('li.clickable').first();
                     $firstTab.removeClass("selectedGroupTab clickable");
                     $firstTab.addClass("nonSelectedGroupTab clickable");
+                    $firstTab.attr("aria-selected", "false");
                     // select the stored tab
                     $("li[groupName='" + groupName + "']").removeClass("nonSelectedGroupTab clickable");
                     $("li[groupName='" + groupName + "']").addClass("selectedGroupTab clickable");
+                    $("li[groupName='" + groupName + "']").attr("aria-selected", "true");
                     // hide the first tab section
                     $('section.property-group:visible').hide();
 

--- a/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
+++ b/webapp/src/main/webapp/js/visualization/capabilitymap/graph_new.js
@@ -385,8 +385,8 @@ FullResultQueryUnit.prototype.fetch = function() {
 }
 
 var showPanel = function(name) {
-    $(".titles li").removeClass("activeTab");
-    $(".titles li a[href='#" + name + "']").parent().addClass("activeTab");
+    $(".titles li").removeClass("activeTab").find("a").attr("aria-selected", "false");
+    $(".titles li a[href='#" + name + "']").parent().addClass("activeTab").attr("aria-selected", "true");
     $(".result_section").css("display", "none");
     $("#" + name).css("display", "block");
 }
@@ -400,7 +400,7 @@ DetailsPanel.prototype.clearDetails = function() {
     $(this.panel).empty();
 }
 DetailsPanel.prototype.showDetails = function(mode, id) {
-    showPanel("logg");
+    showPanel("tabpanel-logg");
 
     var that = this;
     var departments = {};
@@ -964,7 +964,7 @@ var restoreDefaults = function() {
 }
 var finish = function() {
     render();
-    showPanel("demo");
+    showPanel("tabpanel-demo");
     enableSubButton();
     fullResultsQueue = [];
     $.each(g.groups, function(key, group) {

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ComparisonDataTableWidget.js
@@ -63,11 +63,11 @@ var ComparisonDataTableWidget = Class.extend({
 
 		/* Create filter */
 		var dom = me.dom;
-		var filter = $('<div class="science-areas-filter">' +
-	    	'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span>'+
+		var filter = $('<div class="science-areas-filter" role="tablist" aria-orientation="horizontal">' +
+	    	'<span id="' + dom.firstFilterID + '" role="tab" aria-selected="true" aria-controls="comparisonDatatable" tabindex="0" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span>'+
 	    	/* This is temporary removed due to the person's publications mapping rate is too low to be displayed.
 		    	' | ' +
-		    	'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
+		    	'<span id="' + dom.secondFilterID + '" role="tab" aria-selected="false" aria-controls="comparisonDatatable" tabindex="-1" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
 	    	*/
 	    	'<img class="' + dom.filterInfoIconClass + '" id="comparisonImageIconTwo" src="'+ infoIconUrl +'" alt="' + i18nStrings.infoIconString + '" title="" /></div>');
 		me.tableDiv.append(filter);
@@ -131,6 +131,7 @@ var ComparisonDataTableWidget = Class.extend({
 
 		tbody.append(rowsToInsert.join(''));
 
+		table.attr('aria-labelledby', dom.firstFilterID + ' ' + dom.secondFilterID);
 		table.append(tbody);
 		me.tableDiv.append(table);
 

--- a/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
@@ -104,9 +104,9 @@ var DataTableWidget = Class.extend({
 		var me = this;
 
 		var dom = me.dom;
-		var filter = $('<div class="science-areas-filter">' +
-				'<span id="' + dom.firstFilterID + '" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span> | ' +
-		    	'<span id="' + dom.secondFilterID + '" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
+		var filter = $('<div class="science-areas-filter" role="tablist" aria-orientation="horizontal">' +
+				'<span id="' + dom.firstFilterID + '" role="tab" aria-selected="true" aria-controls="datatable" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span> | ' +
+		    	'<span id="' + dom.secondFilterID + '" role="tab" aria-selected="false" aria-controls="datatable" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
 		    	'<img class="'+ dom.filterInfoIconClass +'" id="imageIconTwo" src="'+ infoIconUrl +'" alt="information icon" title="" /></div>');
 		me.tableDiv.append(filter);
 
@@ -179,6 +179,8 @@ var DataTableWidget = Class.extend({
 		tbody.append(rowsToInsert.join(''));
 
 		table.append(tbody);
+		// Add aria-labelledby to the table for accessibility
+		table.attr('aria-labelledby', dom.firstFilterID + ' ' + dom.secondFilterID);
 		me.tableDiv.append(table);
 
 		table.children("tbody").children("tr").on("mouseenter", function() {

--- a/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/DataTableWidget.js
@@ -105,8 +105,8 @@ var DataTableWidget = Class.extend({
 
 		var dom = me.dom;
 		var filter = $('<div class="science-areas-filter" role="tablist" aria-orientation="horizontal">' +
-				'<span id="' + dom.firstFilterID + '" role="tab" aria-selected="true" aria-controls="datatable" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '">' + dom.firstFilterLabel + '</span> | ' +
-		    	'<span id="' + dom.secondFilterID + '" role="tab" aria-selected="false" aria-controls="datatable" class="' + dom.filterOptionClass + '">' + dom.secondFilterLabel + '</span>' +
+				'<span id="' + dom.firstFilterID + '" role="tab" aria-selected="true" aria-controls="datatable" class="' + dom.filterOptionClass + ' ' + dom.activeFilterClass + '" tabindex="0">' + dom.firstFilterLabel + '</span> | ' +
+		    	'<span id="' + dom.secondFilterID + '" role="tab" aria-selected="false" aria-controls="datatable" class="' + dom.filterOptionClass + '" tabindex="0">' + dom.secondFilterLabel + '</span>' +
 		    	'<img class="'+ dom.filterInfoIconClass +'" id="imageIconTwo" src="'+ infoIconUrl +'" alt="information icon" title="" /></div>');
 		me.tableDiv.append(filter);
 

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ScimapWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ScimapWidget.js
@@ -226,6 +226,7 @@ var ScimapWidget = Class.extend({
 				sliderDiv.attr('role', 'presentation')				
 			}
 			if (handle) {
+				handle.style.background = '#13739d';
 				handle.setAttribute('tabindex', '0');
 				handle.setAttribute('role', 'slider');
 				handle.setAttribute('aria-valuenow', slider.getValue());

--- a/webapp/src/main/webapp/js/visualization/mapofscience/ScimapWidget.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/ScimapWidget.js
@@ -210,9 +210,33 @@ var ScimapWidget = Class.extend({
 			} else {
 				slider.setTypeString(i18nStrings.subdisciplinesLower);
 			}
-			slider.setMin(Math.min(1, length));
+			const minValue = Math.min(1, length); 
+			slider.setMin(minValue);
 			slider.setMax(length);
 			slider.setValue(length);
+			
+			var sliderDiv = slider.sliderDiv;
+			var sliderLabel = slider.labelDiv;
+
+			sliderLabel.attr('id', 'scimap-slider-description');
+
+			var handle = sliderDiv && sliderDiv.children()[0];
+
+			if (sliderDiv) {
+				sliderDiv.attr('role', 'presentation')				
+			}
+			if (handle) {
+				handle.setAttribute('tabindex', '0');
+				handle.setAttribute('role', 'slider');
+				handle.setAttribute('aria-valuenow', slider.getValue());
+				handle.setAttribute('aria-valuemin', minValue);
+				handle.setAttribute('aria-valuemax', length);
+				handle.setAttribute('aria-labelledby', 'scimap-slider-description');
+				$(handle).on('keydown mouseup touchend', function() {
+					handle.setAttribute('aria-valuenow', slider.getValue());
+				});
+			}
+			
 		}
 	},
 	changeFilter: function(filterType) {

--- a/webapp/src/main/webapp/js/visualization/mapofscience/VisCommonControl.js
+++ b/webapp/src/main/webapp/js/visualization/mapofscience/VisCommonControl.js
@@ -56,15 +56,19 @@ function initFilter(dom) {
 		if (!obj.hasClass(dom.activeFilterClass)) {
 			var checked = obj.attr('id');
 			if (checked === dom.secondFilterID) {
-				$("#" + dom.firstFilterID).removeClass(dom.activeFilterClass);
+				$("#" + dom.firstFilterID)
+					.removeClass(dom.activeFilterClass)
+					.attr('aria-selected', 'false');
 				currentController.changeFilter(2);
 
 			} else if (checked === dom.firstFilterID) {
-				$("#" + dom.secondFilterID).removeClass(dom.activeFilterClass);
+				$("#" + dom.secondFilterID)
+					.removeClass(dom.activeFilterClass)
+					.attr('aria-selected', 'false');
 				currentController.changeFilter(1);
 			}
 
-			obj.addClass(dom.activeFilterClass);
+			obj.addClass(dom.activeFilterClass).attr('aria-selected', 'true');
 		}
 	});
 

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/manageLabelsForIndividualAddForm.ftl
@@ -31,7 +31,7 @@
 
  			<input type="hidden" name="editKey" id="editKey" value="${editKey}"/>
 
-        	<input type="submit" class="submit" id="submit" value="${i18n().save_button}" role="button" role="input" />
+        	<input type="submit" class="submit" id="submit" value="${i18n().save_button}" role="button" />
 			${i18n().or}
 			<a href="${urls.referringPage}" class="cancel" title="${i18n().cancel_title}" >${i18n().cancel_link}</a>
 

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-iconControls.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-iconControls.ftl
@@ -2,9 +2,13 @@
 
 <#-- Icon controls displayed in upper-right corner -->
 
-<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/share-uri-icon.png" alt="${i18n().share_the_uri}" />
+<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+	<img title="${individual.uri}" src="${urls.images}/individual/share-uri-icon.png" alt="${i18n().share_the_uri}" aria-hidden="true" />
+</button>
 <#if checkNamesResult?has_content >
-	<img id="qrIcon"  src="${urls.images}/individual/qr-code-icon.png" alt="${i18n().qr_icon}" />
+    <button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+		<img src="${urls.images}/individual/qr-code-icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+	</button>
 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
 		<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
 	</span>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-researchAreas.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-researchAreas.ftl
@@ -7,7 +7,7 @@
     <#assign localName = researchAreas.localName>
     <h2 id="${localName}" class="mainPropGroup" title="${researchAreas.publicDescription!}">
         ${researchAreas.name}
-        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas}" />
+        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas_icon}" />
         <@p.addLink researchAreas editable />
     </h2>
     <@p.verboseDisplay researchAreas />

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-visualizationMapOfScience.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/individual-visualizationMapOfScience.ftl
@@ -3,5 +3,5 @@
 <#-- Map Of Science visualization -->
 
 <div id="map-of-science">
-    <h3><img src="${urls.images}/visualization/mapofscience/scimap_icon.png" width="25" height="25"/><a href="${individual.mapOfScienceUrl()}" title="${i18n().map_of_science}">${i18n().map_of_science_capitalized}</a></h3>
+    <h3><img src="${urls.images}/visualization/mapofscience/scimap_icon.png" alt="${i18n().map_of_science}" width="25" height="25"/><a href="${individual.mapOfScienceUrl()}" title="${i18n().map_of_science}">${i18n().map_of_science_capitalized}</a></h3>
 </div>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addAuthorsToInformationResource.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addAuthorsToInformationResource.ftl
@@ -119,16 +119,16 @@
     		should be visible even when first name/middle name are not, the parents should be separate for each field-->
     		<p class="inline">
         <label for="lastName">${i18n().last_name} <span class='requiredHint'> *</span></label>
-        <input class="acSelector" size="35"  type="text" id="lastName" name="lastName" value="${lastNameValue}" role="input" />
+        <input class="acSelector" size="35"  type="text" id="lastName" name="lastName" value="${lastNameValue}" />
         </p>
 
         <p class="inline">
             <label for="firstName">${i18n().first_name} ${requiredHint} ${initialHint}</label>
-            <input  size="20"  type="text" id="firstName" name="firstName" value="${firstNameValue}"  role="input" />
+            <input  size="20"  type="text" id="firstName" name="firstName" value="${firstNameValue}" />
         </p>
         <p class="inline">
             <label for="middleName">${i18n().middle_name} <span class='hint'>(${i18n().initial_okay})</span></label>
-            <input  size="20"  type="text" id="middleName" name="middleName" value="${middleNameValue}"  role="input" />
+            <input  size="20"  type="text" id="middleName" name="middleName" value="${middleNameValue}" />
         </p>
         
         <div>
@@ -144,7 +144,7 @@
                 <label>${i18n().selected_author}:&nbsp;</label>
                 <span class="acSelectionInfo" id="selectedAuthorName"></span>
                 <a href="${urls.base}/individual?uri=" id="personLink" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized})</a>
-                <input type="hidden" id="personUri" name="personUri" value=""  role="input" /> <!-- Field value populated by JavaScript -->
+                <input type="hidden" id="personUri" name="personUri" value="" /> <!-- Field value populated by JavaScript -->
             </p>
         </div>
         
@@ -153,7 +153,7 @@
     <section id="organizationFields" role="organization">
     		<p class="inline">
         <label for="orgName">${i18n().organization_name_capitalized} <span class='requiredHint'> *</span></label>
-        <input size="38"  type="text" id="orgName" name="orgName" value="${orgNameValue}" role="input" />
+        <input size="38"  type="text" id="orgName" name="orgName" value="${orgNameValue}" />
         </p>
 
         <div id="selectedOrg" class="acSelection">
@@ -161,19 +161,19 @@
                 <label>${i18n().selected_organization}:&nbsp;</label>
                 <span  id="selectedOrgName"></span>
                 <a href="${urls.base}/individual?uri=" id="orgLink"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized})</a>
-                <input type="hidden" id="orgUri" name="orgUri" value=""  role="input" /> <!-- Field value populated by JavaScript -->
+                <input type="hidden" id="orgUri" name="orgUri" value="" /> <!-- Field value populated by JavaScript -->
             </p>
         </div>
     </section>
 
-    <input type="hidden" id="label" name="label" value=""  role="input" />  <!-- Field value populated by JavaScript -->
+    <input type="hidden" id="label" name="label" value="" />  <!-- Field value populated by JavaScript -->
 
 
-        <input type="hidden" name="rank" id="rank" value="${newRank}" role="input" />
+        <input type="hidden" name="rank" id="rank" value="${newRank}" />
 
         <p class="submit">
-            <input type="hidden" name = "editKey" value="${editKey}" role="input" />
-            <input type="submit" id="submit" value="${i18n().add_author}" role="button" role="input" />
+            <input type="hidden" name = "editKey" value="${editKey}" />
+            <input type="submit" id="submit" value="${i18n().add_author}" role="button" />
 
             <span class="or"> ${i18n().or} </span>
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyAutoComplete.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyAutoComplete.ftl
@@ -51,7 +51,7 @@
 <#if editConfiguration.propertySelectFromExisting = true>
     <#if rangeOptionsExist  = true >
         <form class="customForm" action = "${submitUrl}">
-            <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+            <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
             <#if editConfiguration.propertyPublicDescription?has_content>
                 <p>${editConfiguration.propertyPublicDescription}</p>
              </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyCreateNew.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyCreateNew.ftl
@@ -14,11 +14,11 @@
 	 </#if>
 
 	<#assign typesList = editConfiguration.pageData.createNewTypes/>
-	<form class="editForm" action="${editConfiguration.mainEditUrl}" role="input" />
-	    <input type="hidden" value="${editConfiguration.subjectUri}" name="subjectUri" role="input" />
-	    <input type="hidden" value="${editConfiguration.predicateUri}" name="predicateUri" role="input" />
-	    <input type="hidden" value="${objectUri}" name="objectUri" role="input" />
-	    <input type="hidden" value="create" name="cmd" role="input" />
+	<form class="editForm" action="${editConfiguration.mainEditUrl}" />
+	    <input type="hidden" value="${editConfiguration.subjectUri}" name="subjectUri" />
+	    <input type="hidden" value="${editConfiguration.predicateUri}" name="predicateUri" />
+	    <input type="hidden" value="${objectUri}" name="objectUri" />
+	    <input type="hidden" value="create" name="cmd" />
 
 	    <select id="typeOfNew" name="typeOfNew" role="selection">
 	    <#assign typeKeys = typesList?keys />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addConceptThroughObjectPropertyForm.ftl
@@ -13,7 +13,7 @@
     <#if rangeOptionsExist  = true >
         <#assign rangeOptionKeys = rangeOptions?keys />
         <form class="editForm" action = "${submitUrl}">
-            <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+            <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
             <#if editConfiguration.propertyPublicDescription?has_content>
                 <p>${editConfiguration.propertyPublicDescription}</p>
              </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditWebpageForm.ftl
@@ -66,10 +66,10 @@
         </#list>
     </select>
     <label for="url">URL ${requiredHint}</label>
-    <input  size="70"  type="text" id="url" name="url" value="${url}" role="input" />
+    <input  size="70"  type="text" id="url" name="url" value="${url}" />
 
     <label for="label">${i18n().webpage_name}</label>
-    <input  size="70"  type="text" id="label" name="label" value="${label?html}" role="input" />
+    <input  size="70"  type="text" id="label" name="label" value="${label?html}" />
 
     <#if editMode="add">
         <input type="hidden" name="rank" value="${newRank}" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorsToInformationResource.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorsToInformationResource.ftl
@@ -114,17 +114,17 @@
     		should be visible even when first name/middle name are not, the parents should be separate for each field-->
         <p class="inline">
             <label for="lastName">${i18n().last_name} <span class='requiredHint'> *</span></label>
-            <input class="acSelector" size="35"  type="text" id="lastName" name="lastName" value="${lastNameValue}" role="input" />
+            <input class="acSelector" size="35"  type="text" id="lastName" name="lastName" value="${lastNameValue}" />
         </p>
 
         <p class="inline">
             <label for="firstName">${i18n().first_name} ${requiredHint} ${initialHint}</label>
-            <input  size="20"  type="text" id="firstName" name="firstName" value="${firstNameValue}"  role="input" />
+            <input  size="20"  type="text" id="firstName" name="firstName" value="${firstNameValue}" />
         </p>
 
         <p class="inline">
             <label for="middleName">${i18n().middle_name} <span class='hint'>(${i18n().initial_okay})</span></label>
-            <input  size="20"  type="text" id="middleName" name="middleName" value="${middleNameValue}"  role="input" />
+            <input  size="20"  type="text" id="middleName" name="middleName" value="${middleNameValue}" />
         </p>
 
         <div>
@@ -140,7 +140,7 @@
                 <label>${i18n().selected_editor}:&nbsp;</label>
                 <span class="acSelectionInfo" id="selectedEditorName"></span>
                 <a href="${urls.base}/individual?uri=" id="personLink" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized})</a>
-                <input type="hidden" id="personUri" name="personUri" value=""  role="input" /> <!-- Field value populated by JavaScript -->
+                <input type="hidden" id="personUri" name="personUri" value="" /> <!-- Field value populated by JavaScript -->
             </p>
         </div>
     </section>
@@ -148,7 +148,7 @@
     <section id="organizationFields" role="organization">
     		<p class="inline">
         <label for="orgName">${i18n().organization_name_capitalized} <span class='requiredHint'> *</span></label>
-        <input size="38"  type="text" id="orgName" name="orgName" value="${orgNameValue}" role="input" />
+        <input size="38"  type="text" id="orgName" name="orgName" value="${orgNameValue}" />
         </p>
 
         <div id="selectedOrg" class="acSelection">
@@ -156,19 +156,19 @@
                 <label>${i18n().selected_organization}:&nbsp;</label>
                 <span  id="selectedOrgName"></span>
                 <a href="${urls.base}/individual?uri=" id="orgLink"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized})</a>
-                <input type="hidden" id="orgUri" name="orgUri" value=""  role="input" /> <!-- Field value populated by JavaScript -->
+                <input type="hidden" id="orgUri" name="orgUri" value="" /> <!-- Field value populated by JavaScript -->
             </p>
         </div>
     </section>
 
-    <input type="hidden" id="label" name="label" value=""  role="input" />  <!-- Field value populated by JavaScript -->
+    <input type="hidden" id="label" name="label" value="" />  <!-- Field value populated by JavaScript -->
 
 
-        <input type="hidden" name="rank" id="rank" value="${newRank}" role="input" />
+        <input type="hidden" name="rank" id="rank" value="${newRank}" />
 
         <p class="submit">
-            <input type="hidden" name = "editKey" value="${editKey}" role="input" />
-            <input type="submit" id="submit" value="${i18n().add_editor}" role="button" role="input" />
+            <input type="hidden" name = "editKey" value="${editKey}" />
+            <input type="submit" id="submit" value="${i18n().add_editor}" role="button" />
 
             <span class="or"> ${i18n().or} </span>
 

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/addUserDefinedConcept.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/addUserDefinedConcept.ftl
@@ -16,7 +16,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 <@lvf.unsupportedBrowser urls.base />
 
 <form id="addUserDefinedConceptForm" class="customForm noIE67" action = "${submitUrl}" method="post">
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
    <#--Autocomplete for looking up existing skos concepts -->
 						<p>
 		            <label for="relatedIndLabel">${i18n().concept_capitalized} <span class='requiredHint'> *</span></label>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteDataPropForm.ftl
@@ -27,7 +27,7 @@
 <#assign literalValues = "${editConfiguration.dataLiteralValuesAsString}" />
 
 <form class="customForm" action = "${submitUrl}" method="post">
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
     <#if editConfiguration.dataPredicatePublicDescription?has_content>
        <label for="${editConfiguration.dataLiteral}"><p class="propEntryHelpText">${editConfiguration.dataPredicatePublicDescription}</p></label>
     </#if>

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/defaultAddMissingIndividualForm.ftl
@@ -70,7 +70,7 @@ ${i18n().new_entry_for(editConfiguration.propertyPublicDomainTitle, editConfigur
         <input size="30"  type="text" id="label" name="label" value="${labelValue}" />
     </p>
 </#if>
-    <input type="hidden" name="editKey" id="editKey" value="${editKey}" role="input" />
+    <input type="hidden" name="editKey" id="editKey" value="${editKey}" />
 
     <p class="submit">
         <input type="submit" id="submit" value="${submitLabel}" role="submit" />

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/institutionalInternalClassForm.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/institutionalInternalClassForm.ftl
@@ -54,7 +54,7 @@ edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.Institu
             <h3>${i18n().create_new_class}</h3>
 
             <label for="localClassName">${i18n().name_capitalized}<span class="requiredHint"> *</span></label>
-            <input type="text" id="localClassName" name="localClassName" value="" role="input" />
+            <input type="text" id="localClassName" name="localClassName" value="" />
             <p class="note">${i18n().use_capitals_each_word}</p>
 
             <#--If more than one local namespace, generate select-->

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/manageWebpagesForIndividual.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/manageWebpagesForIndividual.ftl
@@ -53,7 +53,7 @@
     </#list>
 </ul>
 
-<section id="addAndCancelLinks" role="section">
+<section id="addAndCancelLinks">
     <#-- There is no editConfig at this stage, so we don't need to go through postEditCleanup.jsp on cancel.
          These can just be ordinary links, rather than a v:input element, as in
          addAuthorsToInformationResource.jsp. -->

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement--classIntersections.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/menuManagement--classIntersections.ftl
@@ -9,7 +9,7 @@
         <#assign disableClass = 'class="disable inline" disabled="disabled"' />
     </#if>
 
-                <input type="checkbox" ${disableClass} name="display-internalClass" value="${internalClassUri}" id="display-internalClass" <#if internalClass?has_content && isInternal?has_content>checked</#if> role="input" />
+                <input type="checkbox" ${disableClass} name="display-internalClass" value="${internalClassUri}" id="display-internalClass" <#if internalClass?has_content && isInternal?has_content>checked</#if> />
     <label ${disableClass} class="inline" for="display-internalClass">${i18n().only_display} <em>${associatedPage}</em> ${i18n().within_my_institution}</label>
 
     ${enableInternalClass}

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--classIntersections.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/pageManagement--classIntersections.ftl
@@ -10,7 +10,7 @@
         <#assign disableClass = 'class="disable inline" disabled="disabled"' />
     </#if>
 
-                <input type="checkbox" ${disableClass} name="display-internalClass" value="${internalClassUri}" id="display-internalClass" <#if editConfiguration.pageData.internalClass?has_content && editConfiguration.pageData.isInternal?has_content>checked</#if> role="input" />
+                <input type="checkbox" ${disableClass} name="display-internalClass" value="${internalClassUri}" id="display-internalClass" <#if editConfiguration.pageData.internalClass?has_content && editConfiguration.pageData.isInternal?has_content>checked</#if> />
     <label ${disableClass} class="inline" for="display-internalClass">${i18n().only_display} <em> </em> ${i18n().within_my_institution}</label>
 
     ${enableInternalClass}

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
@@ -157,7 +157,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     	<#--End draw elements-->
 
-      <input type="hidden" name = "editKey" value="${editKey}" role="input"/>
+      <input type="hidden" name = "editKey" value="${editKey}"/>
 
       <p class="submit">
         <#if editMode == "edit">

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
@@ -96,7 +96,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
 <form class="customForm" action ="${submitUrl}" class="customForm noIE67" aria-label="${formAction} position entry">
   <p class="inline">
-    <label for="orgType">${i18n().org_type_capitalized}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+    <label for="typeSelector">${i18n().org_type_capitalized}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
     <#assign orgTypeOpts = editConfiguration.pageData.orgType />
 <#--
     <#if editMode == "edit">
@@ -119,7 +119,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
   <p>
     <label for="orgLabel">${i18n().organization_capitalized} ${i18n().name_capitalized} ${requiredHint}</label>
-    <input type="text" name="orgLabel" id="orgLabel" acGroupName="organization" size="50" class="acSelector" value="${orgLabelValue}" >
+    <input type="text" name="orgLabel" id="orgLabel" acGroupName="organization" size="62" class="acSelector" value="${orgLabelValue}" >
     <input class="display" type="hidden" id="orgDisplay" acGroupName="organization" name="orgLabelDisplay" value="${orgLabelDisplayValue}">
   </p>
     <div class="acSelection" acGroupName="organization">

--- a/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasPositionHistory.ftl
@@ -94,7 +94,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
 <@lvf.unsupportedBrowser urls.base />
 
-<form class="customForm" action ="${submitUrl}" class="customForm noIE67" role="${formAction} position entry">
+<form class="customForm" action ="${submitUrl}" class="customForm noIE67" aria-label="${formAction} position entry">
   <p class="inline">
     <label for="orgType">${i18n().org_type_capitalized}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
     <#assign orgTypeOpts = editConfiguration.pageData.orgType />
@@ -109,7 +109,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <#else>
     </#if>
 -->
-<select id="typeSelector" name="orgType" acGroupName="organization">
+<select id="typeSelector" name="orgType" id="orgType" acGroupName="organization">
     <option value="" selected="selected">${i18n().select_one}</option>
     <#list orgTypeOpts?keys as key>
         <option value="${key}"  <#if orgTypeValue = key>selected</#if>>${orgTypeOpts[key]}</option>
@@ -118,7 +118,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
   </p>
 
   <p>
-    <label for="relatedIndLabel">${i18n().organization_capitalized} ${i18n().name_capitalized} ${requiredHint}</label>
+    <label for="orgLabel">${i18n().organization_capitalized} ${i18n().name_capitalized} ${requiredHint}</label>
     <input type="text" name="orgLabel" id="orgLabel" acGroupName="organization" size="50" class="acSelector" value="${orgLabelValue}" >
     <input class="display" type="hidden" id="orgDisplay" acGroupName="organization" name="orgLabelDisplay" value="${orgLabelDisplayValue}">
   </p>
@@ -133,11 +133,11 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     </div>
 
     <label for="positionTitle">${i18n().position_title} ${requiredHint}</label>
-    <input  size="30"  type="text" id="positionTitle" name="positionTitle" value="${positionTitleValue}" role="input" />
+    <input  size="30"  type="text" id="positionTitle" name="positionTitle" value="${positionTitleValue}" />
 
       <label for="positionType">${i18n().position_type} ${requiredHint}</label>
       <#assign posnTypeOpts = editConfiguration.pageData.positionType />
-      <select name="positionType" style="margin-top:-2px" >
+      <select name="positionType" id="positionType" style="margin-top:-2px" >
           <option value="" <#if positionTypeValue == "">selected</#if>>${i18n().select_one}</option>
           <#list posnTypeOpts?keys as key>
               <option value="${key}"  <#if positionTypeValue == key>selected</#if>>${posnTypeOpts[key]}</option>
@@ -146,12 +146,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
       <p></p>
       <#--Need to draw edit elements for dates here-->
        <#if htmlForElements?keys?seq_contains("startField")>
-  			<label class="dateTime" for="startField">${i18n().start_capitalized}</label>
+  			<label for="startField-year" class="dateTime" for="startField">${i18n().start_capitalized}</label>
   			${htmlForElements["startField"]} ${yearHint}
        </#if>
        <p></p>
        <#if htmlForElements?keys?seq_contains("endField")>
-  			<label class="dateTime" for="endField">${i18n().end_capitalized}</label>
+  			<label for="endField-year" class="dateTime" for="endField">${i18n().end_capitalized}</label>
   		 	${htmlForElements["endField"]} ${yearHint}
        </#if>
 

--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
@@ -164,7 +164,7 @@
         </#list>
 	</table>
 	<ul>
-		<li><a href="${urls.base}/research" alt="${i18n().view_all_research}">${i18n().view_all}</a></li>
+        <li><a href="${urls.base}/research" alt="${i18n().view_all_research}">${i18n().view_all_research?capitalize}...</a></li>
 	</ul>
 </#macro>
 

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -55,7 +55,7 @@ ${stylesheets.add(
     <div id="queryform">
         <p>
             <span>
-                <input name="query" id="query" size="34" value="" onfocus="" accesskey="q" onblur="" type="text" onkeydown="queryKeyDown(event);">
+                <input name="query" id="query" size="34" value="" onfocus="" accesskey="q" onblur="" type="text" onkeydown="queryKeyDown(event);" aria-label="${i18n().capability_map_input?js_string}">
                 <label id="cutofflabel" for="queryCutoff">Cutoff:</label>
                 <input id="queryCutoff" name="queryCutoff" type="text" title="Cutoff" size="4" value="10">
                 <input value="${i18n().cap_map_search}" type="submit" id="add" type="button" onclick="addKwd();">

--- a/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap.ftl
@@ -103,14 +103,18 @@ ${stylesheets.add(
 
         <div id="right-container">
             <div class="tabs">
-                <ul  class="titles">
-                    <li><a href="#demo">${i18n().cap_map_search_terms}</a></li>
-                    <li><a href="#logg">${i18n().cap_map_info}</a></li>
+                <ul  class="titles" role="tablist" aria-orientation="horizontal">
+                    <li>
+                        <a href="#tabpanel-demo" id="tab-demo" role="tab" aria-controls="tabpanel-demo" aria-selected="true" tabindex="0">${i18n().cap_map_search_terms}</a>
+                    </li>
+                    <li>
+                        <a href="#tabpanel-logg" id="tab-logg" role="tab" aria-controls="tabpanel-logg" aria-selected="false" tabindex="0">${i18n().cap_map_info}</a>
+                    </li>
                     <!-- li><a href="#extractData">Data</a></li -->
                 </ul>
 
                 <div class="result_body">
-                    <div class="result_section" id="demo">
+                    <div class="result_section" id="tabpanel-demo" role="tabpanel" aria-labelledby="tab-demo" tabindex="0">
                         <h2>${i18n().cap_map_cur_search_terms}</h2>
                         <ul id="log_printout">
                             <li>
@@ -126,7 +130,7 @@ ${stylesheets.add(
                         <div class="links4">${i18n().cap_map_key6}</div>
                         </p>
                     </div>
-                    <div class="result_section" id="logg">
+                    <div class="result_section" id="tabpanel-logg" role="tabpanel" aria-labelledby="tab-logg" tabindex="0" hidden>
                         <div id="inner-details">
                             <p>
                                 ${i18n().cap_map_text7}

--- a/webapp/src/main/webapp/templates/freemarker/visualization/coauthorship/coAuthorshipSparklineContent.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/coauthorship/coAuthorshipSparklineContent.ftl
@@ -179,7 +179,7 @@
                     }
 
                     if (totalPublicationCount) {
-                        sparksText += ' <br /><a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file_capitalized?js_string}">(.CSV ${i18n().file_capitalized})</a> ';
+                        sparksText += ' <br /><a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file_capitalized?js_string}"><span class="sr-only">' + pubDisplay + ' </span>(.CSV ${i18n().file_capitalized})</a> ';
                     }
 
                  </#if>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/collaboratorToActivityCountTable.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/collaboratorToActivityCountTable.ftl
@@ -2,7 +2,7 @@
 
 <table id='${tableID}'>
     <caption>
-    ${tableCaption} <a href="${fileDownloadLink}">(.CSV ${i18n().file_capitalized})</a>
+    ${tableCaption} <a href="${fileDownloadLink}" aria-label="${tableCaption} .CSV" >(.CSV ${i18n().file_capitalized})</a>
     </caption>
     <thead>
     <tr>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/copi/coInvestigationSparklineContent.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/copi/coInvestigationSparklineContent.ftl
@@ -181,7 +181,7 @@
                     }
 
                     if (totalGrantCount) {
-                        sparksText += '<br /> <a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file_capitalized}">(.CSV ${i18n().file_capitalized})</a> ';
+                        sparksText += '<br /> <a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file_capitalized}"><span class="sr-only">' + grantDisplay + ' </span>(.CSV ${i18n().file_capitalized})</a> ';
                     }
 
                  </#if>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/grant/personGrantSparklineContent.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/grant/personGrantSparklineContent.ftl
@@ -174,7 +174,7 @@
                     }
 
                     if (totalGrantCount) {
-                        sparksText += '<br /> <a href="${sparklineVO.downloadDataLink}"  title=".csv ${i18n().file}">(.CSV ${i18n().file_capitalized})</a> ';
+                        sparksText += '<br /> <a href="${sparklineVO.downloadDataLink}"  title=".csv ${i18n().file}"><span class="sr-only">' + grantDisplay + ' </span>(.CSV ${i18n().file_capitalized})</a> ';
                     }
 
                  </#if>

--- a/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationSparklineContent.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/publication/personPublicationSparklineContent.ftl
@@ -179,7 +179,7 @@
                     }
 
                     if (totalPublicationCount) {
-                        sparksText += ' <br /><a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file}">(.CSV ${i18n().file_capitalized})</a> ';
+                        sparksText += ' <br /><a href="${sparklineVO.downloadDataLink}" title="csv ${i18n().file}"><span class="sr-only">' + pubDisplay + ' </span>(.CSV ${i18n().file_capitalized})</a> ';
                     }
 
 

--- a/webapp/src/main/webapp/templates/freemarker/visualization/yearToActivityCountTable.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/visualization/yearToActivityCountTable.ftl
@@ -2,7 +2,7 @@
 
 <table id='${tableID}'>
     <caption>
-        ${tableCaption} <a href="${fileDownloadLink}">(.CSV ${i18n().file_capitalized})</a>
+        ${tableCaption} <a href="${fileDownloadLink}" aria-label="${tableCaption} .CSV" >(.CSV ${i18n().file_capitalized})</a>
     </caption>
     <thead>
         <tr>

--- a/webapp/src/main/webapp/themes/nemo/js/homePageUtils.js
+++ b/webapp/src/main/webapp/themes/nemo/js/homePageUtils.js
@@ -102,7 +102,7 @@ $(document).ready(function(){
                 
                     $.each($('div#research-faculty-mbrs div.item a.faculty-mbrs '), function() {
                         if ( $(this).children('img').length == 0 ) {
-                            var imgHtml = "<img class='img-circle' width='160' alt='" + i18nStrings.placeholderImage + "' src='" + urlsBase + "/images/placeholders/person.bordered.thumbnail.jpg'>";
+                            var imgHtml = "<img class='img-circle' width='160' alt='' src='" + urlsBase + "/images/placeholders/person.bordered.thumbnail.jpg'>";
                             $(this).prepend(imgHtml);
                         }
                         else { 
@@ -115,7 +115,7 @@ $(document).ready(function(){
                                 + urlsBase
                                 + "/people#http://vivoweb.org/ontology/core#FacultyMember' alt='" 
                                 + i18nStrings.viewAllFaculty + "'>"
-                                + i18nStrings.viewAllString + "</a></li></ul>";
+                                + i18nStrings.i18nStrings.viewAllFaculty.charAt(0).toUpperCase() + i18nStrings.viewAllFaculty.slice(1) + "...</a></li></ul>";
                     //var viewMore = "<ul id='viewMoreFac' style='list-style:none;margin:0;padding:0;'><li><a href='"
                     //    + urlsBase
                     //    + "/people#http://xmlns.com/foaf/0.1/Person' alt='" 
@@ -200,8 +200,8 @@ $(document).ready(function(){
           html += "<a href='" + urlsBase 
               + "/organizations#http://vivoweb.org/ontology/core#AcademicDepartment' alt='" 
               + i18nStrings.viewAllDepartments + "'>" 
-              + i18nStrings.viewAllString + "</a>"
-              + "</div>"
+              + i18nStrings.viewAllDepartments.charAt(0).toUpperCase() + i18nStrings.viewAllDepartments.slice(1) + "...</a>"
+              + "</div>";
           //<a href="${urls.base}/research" alt="${i18n().view_all_research}">${i18n().view_all}</a>
       }
         $('div#academic-depts').html(html);

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-academic-article.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-academic-article.ftl
@@ -87,7 +87,11 @@
 
                     <#--  Most-specific types -->
                     <@p.mostSpecificTypes individual />
-                    <span id="iconControlsVitro"><img id="uriIcon" title="${individual.uri}" class="middle" src="${urls.images}/individual/uriIcon.gif" alt="uri icon"/></span>
+                    <span id="iconControlsVitro">
+                    <button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+                        <img title="${individual.uri}" class="middle" src="${urls.images}/individual/uriIcon.gif" alt="uri icon" aria-hidden="true" />
+                    </button>
+                    </span>
                 </h1>
             </#if>
         </header>

--- a/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual--foaf-person.ftl
@@ -98,9 +98,13 @@ Add divs and wrapper to create funnelback basket controls. MUST BE REMOVED BEFOR
 						<!-- Contact Info -->
 						<div id="individual-tools-people">
 							<span id="iconControlsLeftSide">
-								<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+								<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+									<img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true" />
+								</button>
 								<#if checkNamesResult?has_content >
-									<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+									<button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+										<img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+									</button>
 									<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!} 
 										<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">
 											${i18n().close_capitalized}

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-custom-researchAreas.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-custom-researchAreas.ftl
@@ -7,7 +7,7 @@
     <#assign localName = researchAreas.localName>
     <h3 id="${localName}" class="mainPropGroup h4" title="${researchAreas.publicDescription!}">
         ${researchAreas.name?capitalize} 
-        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas}" />
+        <img id="researchAreaIcon" src="${urls.images}/individual/research-group-icon.png" alt="${i18n().research_areas_icon}" />
         <@p.addLink researchAreas editable /> <@p.verboseDisplay researchAreas />
     </h3>
     <ul id="individual-${localName}" role="list" >

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-menu.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-menu.ftl
@@ -26,7 +26,7 @@
 	    <form id="pageListForm" action="${urls.base}/editRequestDispatch" method="get">
 	        <input type="hidden" name="typeOfNew" value="http://vitro.mannlib.cornell.edu/ontologies/display/1.1#Page">              
 	        <input type="hidden" name="switchToDisplayModel" value="1">
-	        <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator" role="input">
+	        <input type="hidden" name="editForm" value="edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ManagePageGenerator">
 	   		<input type="hidden" name="addMenuItem" value="true" />
 	   		<input id="submit" value="Add new menu page" role="button" type="submit" >
 	   		<input type="hidden" name="returnURL" value="${returnURL?url}" />

--- a/webapp/src/main/webapp/themes/nemo/templates/individual-visualizationMapOfScience.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/individual-visualizationMapOfScience.ftl
@@ -4,7 +4,7 @@
 
 <div id="map-of-science" style="padding-bottom: 5px;">
 	<h4>
-		<img src="${urls.images}/visualization/mapofscience/scimap_icon.png" width="15" height="15"/>
+		<img src="${urls.images}/visualization/mapofscience/scimap_icon.png" alt="${i18n().map_of_science}" width="15" height="15"/>
 		&nbsp;
 		<a href="${individual.mapOfScienceUrl()}" title="${i18n().map_of_science}">${i18n().map_of_science_capitalized}</a>
 	</h4>

--- a/webapp/src/main/webapp/themes/nemo/templates/lib-home-page.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/lib-home-page.ftl
@@ -178,7 +178,7 @@
                             </a>
                     </#if>
                 </#list>
-                <a href="${urls.base}/research" alt="${i18n().view_all_research}">${i18n().view_all}</a>
+                <a href="${urls.base}/research" alt="${i18n().view_all_research}">${i18n().view_all_research?capitalize}...</a>
             </#if>
         </#list>
         <#if !foundClassGroup>

--- a/webapp/src/main/webapp/themes/nemo/templates/lib-properties.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/lib-properties.ftl
@@ -339,7 +339,7 @@
         <#local imageLabel><@addLinkWithLabel mainImage editable "${i18n().photo}" /></#local>
         ${imageLabel}
         <#if showPlaceholder == "always" || (showPlaceholder="with_add_link" && imageLabel?has_content)>
-            <img class="img-rounded" src="${placeholderImageUrl(individual.uri)}" title = "${i18n().no_image}" alt="${i18n().placeholder_image}" width="${imageWidth!}" />
+            <img class="img-rounded" src="${placeholderImageUrl(individual.uri)}" title = "${i18n().no_image}" alt="" width="${imageWidth!}" />
         </#if>
     </#if>
 </#macro>

--- a/webapp/src/main/webapp/themes/nemo/templates/menupage-browse.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/menupage-browse.ftl
@@ -34,10 +34,10 @@
                     <#assign alphabet = ["A", "B", "C", "D", "E", "F", "G" "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"] />
                     <ul id="alpha-browse-individuals">
                         <li>
-                            <a href="#" class="selected" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a>
+                            <a href="#" class="selected" aria-current="false" data-alpha="all" title="${i18n().select_all}">${i18n().all}</a>
                         </li>
                         <#list alphabet as letter>
-                            <li><a href="#" data-alpha="${letter?lower_case}" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
+                            <li><a href="#" data-alpha="${letter?lower_case}" aria-current="false" title="${i18n().browse_all_starts_with(letter)}">${letter}</a></li>
                         </#list>
                     </ul>
                 </div>

--- a/webapp/src/main/webapp/themes/nemo/templates/menupage-browse.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/menupage-browse.ftl
@@ -44,7 +44,8 @@
             </nav>
             <section id="individuals-in-class" role="region">
                 <ul role="list">
-
+                    <div aria-live="polite" id="individuals-list-info"></div>
+                    
                     <#-- Will be populated dynamically via AJAX request -->
                 </ul>
             </section>

--- a/webapp/src/main/webapp/themes/nemo/templates/propStatement-organizationForPosition.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/propStatement-organizationForPosition.ftl
@@ -33,7 +33,7 @@
 							</div>
 						<#else>
 							<div id="photo-wrapper">
-								<img width="190" title="no image" class="img-rounded" alt="placeholder image" src="/images/placeholders/person.thumbnail.jpg">
+								<img width="190" title="no image" class="img-rounded" alt="" src="/images/placeholders/person.thumbnail.jpg">
 							</div>
 						</#if>		
 					</div>

--- a/webapp/src/main/webapp/themes/nemo/templates/search.ftl
+++ b/webapp/src/main/webapp/themes/nemo/templates/search.ftl
@@ -8,7 +8,7 @@
 
         <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET"> 
             <div id="search-field">
-                <input type="text" name="querytext" id="filter_input_querytext" class="search-vivo" value="${querytext!?html}" autocapitalize="off" />
+                <input type="text" name="querytext" id="filter_input_querytext" class="search-vivo" aria-label="${i18n().search_form}" value="${querytext!?html}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="search">
             </div>
         </form>

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/individual--foaf-person.ftl
@@ -54,9 +54,13 @@
 			<div class="row title">
 				<div class="col-md-12">
 					<span id="iconControlsRightSide">
-						<img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+						<button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+							<img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true" />
+						</button>
 						<#if checkNamesResult?has_content >
-							<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+							<button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+							<img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+							</button>
 								<div id="qrCodeContainer">
 									<span id="qrCodeImage" class="bottomLeftAnchor hidden">${qrCodeLinkedImage!}
 										<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>

--- a/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/scratch.ftl
+++ b/webapp/src/main/webapp/themes/tenderfoot/templates/body/individual/scratch.ftl
@@ -17,9 +17,14 @@
         <!-- Contact Info -->
         <div id="individual-tools-people">
             <span id="iconControlsLeftSide">
-                <img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+                <button id="uriIcon" class="nostyle" aria-label="${i18n().qr_icon_label}">
+                    <img title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}" aria-hidden="true"/>
+                </button>
   				<#if checkNamesResult?has_content >
-					<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+					
+                    <button id="qrIcon" class="nostyle" aria-label="${i18n().uri_icon_label}">
+					    <img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+                    </button
                 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
 						<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
 					</span>

--- a/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/individual--foaf-person.ftl
@@ -44,11 +44,21 @@
         <!-- Contact Info -->
         <div id="individual-tools-people">
             <span id="iconControlsLeftSide">
-                <img id="uriIcon" title="${individual.uri}" src="${urls.images}/individual/uriIcon.gif" alt="${i18n().uri_icon}"/>
+                <button id="uriIcon"
+                        title="${individual.uri}"
+                        class="nostyle"
+                        aria-label="${i18n().uri_icon_label}">
+                    <img src="${urls.images}/individual/uriIcon.gif"
+                         alt="${i18n().uri_icon}"
+                         aria-hidden="true"/>
+                </button>
   				<#if checkNamesResult?has_content >
-					<img id="qrIcon"  src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" />
+                    <button id="qrIcon" title="${individual.uri}" class="nostyle" aria-label="${i18n().qr_icon_label}">
+					    <img src="${urls.images}/individual/qr_icon.png" alt="${i18n().qr_icon}" aria-hidden="true" />
+                    </button>
+
                 	<span id="qrCodeImage" class="hidden">${qrCodeLinkedImage!}
-						<a class="qrCloseLink" href="#"  title="${i18n().qr_code}">${i18n().close_capitalized}</a>
+						<a class="qrCloseLink" href="#" title="${i18n().qr_code}" aria-hidden="true">${i18n().close_capitalized}</a>
 					</span>
 				</#if>
             </span>

--- a/webapp/src/main/webapp/themes/wilma/templates/page-home.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/page-home.ftl
@@ -38,20 +38,20 @@
             <p>${i18n().intro_para2}</p>
 
             <section id="search-home" role="region">
-                <h3>${i18n().intro_searchvivo} <span class="search-filter-selected">filteredSearch</span></h3>
+                <h3 id="search-input-label">${i18n().intro_searchvivo} <span class="search-filter-selected">filteredSearch</span></h3>
 
                 <fieldset>
                     <legend>${i18n().search_form}</legend>
                     <form id="search-homepage" action="${urls.search}" name="search-home" role="search" method="GET" >
                         <div id="search-home-field">
-                            <input type="text" name="querytext" class="search-homepage" value="" autocapitalize="off" />
+                            <input type="text" name="querytext" aria-label="${i18n().search_vitro}" aria-labelledby="search-input-label" class="search-homepage" value="" autocapitalize="off" />
+                            <a class="filter-search filter-default" aria-expanded="false" href="#" title="${i18n().intro_filtersearch}">
+                                <span class="displace">${i18n().intro_filtersearch}</span>
+                            </a>
                             <input type="submit" value="${i18n().search_button}" class="search" />
                             <input type="hidden" name="filters_category"  value="" autocapitalize="off" />
                         </div>
-
-                        <a class="filter-search filter-default" href="#" title="${i18n().intro_filtersearch}">
-                            <span class="displace">${i18n().intro_filtersearch}</span>
-                        </a>
+                        
 
                         <ul id="filter-search-nav">
                             <li><a class="active" href="">${i18n().all_capitalized}</a></li>

--- a/webapp/src/main/webapp/themes/wilma/templates/search.ftl
+++ b/webapp/src/main/webapp/themes/wilma/templates/search.ftl
@@ -8,7 +8,7 @@
 
         <form id="search-form" action="${urls.search}" autocomplete="off" name="search" role="search" accept-charset="UTF-8" method="GET">
             <div id="search-field">
-                <input type="text" id="filter_input_querytext" name="querytext" class="search-vivo" value="${querytext!?html}" autocapitalize="off" />
+                <input type="text" id="filter_input_querytext" name="querytext" class="search-vivo" aria-label="${i18n().search_form}" value="${querytext!?html}" autocapitalize="off" />
                 <input type="submit" value="${i18n().search_button}" class="search">
             </div>
         </form>


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues/4099)**
**[Vitro PR](https://github.com/vivo-project/Vitro/pull/514)**

# What does this pull request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
1. Added aria-expanded
- Used on toggleable UI elements (e.g. filter/search dropdown).
- Why: Improves accessibility by exposing the current expanded/collapsed state to screen readers.

2. Improved aria-label usage
- Added descriptive labels for icon-only buttons (e.g. URI and QR code buttons).
- Why: Provides meaningful context for assistive technologies where visual labels are missing.

3. Added/verified aria-labelledby
- Linked input fields to their corresponding visible labels.
- Why: Ensures screen readers correctly associate inputs with their labels, improving form usability.

4. Introduced aria-live="polite" regions
- Used for dynamic content updates (e.g. search results or list updates).
- Why: Allows screen readers to announce updates without interrupting the user’s current task.

5. Ensured proper use of aria-hidden="true"
- Applied to purely decorative icons (e.g. images inside buttons where text alternatives already exist).
- Why: Prevents redundant or confusing announcements from screen readers.

6. Fixed and improved role attributes
- Defined semantic roles like region and list where appropriate. Removed redundant `role="input"` in input fields
- Why: Improves the structure of the page for assistive technologies.

7. Improved image alt attributes
- Ensured all meaningful images have descriptive alt text.
- Why: Provides equivalent information for users who cannot see images.

8. Added aria-current="page" in pagination
- Used to indicate the currently active page or navigation item.
- Why: Helps screen readers and assistive technologies understand the user’s current location in the app/navigation.

9. Added aria-atomic
- Applied to dynamic regions where updates should be read as a whole.
- Why: Ensures screen readers announce the entire updated content, not just the changed part (useful for status messages or result summaries).

10. aria-selected
- Used for selectable items (tabs, list items, options).
- Why: Communicates which item is currently selected in a group.

# How should this be tested?
Use a screen reader to verify accessibility behavior.
On macOS, enable VoiceOver with `Command + F5`


# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. HTML, CSS, JavaScript
1. Natural language knowledge
    1. English
    2. German
    3. Spanish
    4. French
    5. Portuguese
    6. Russian
    7. Serbian
