### PR TITLE
Fix Spanish labels - background and positions

### DIFF
--- a/home/src/main/resources/rdf/i18n/es/applicationMetadata/firsttime/propertygroups_labels.nt
+++ b/home/src/main/resources/rdf/i18n/es/applicationMetadata/firsttime/propertygroups_labels.nt
@@ -1,6 +1,6 @@
 <http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> <http://www.w3.org/2000/01/rdf-schema#label> "Identidad"@es .
 <http://vivoweb.org/ontology#vitroPropertyGroupbibliographiconline> <http://www.w3.org/2000/01/rdf-schema#label> "Documentos relacionados"@es .
-<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Antecedentes"@es .
+<http://vivoweb.org/ontology#vitroPropertyGroupbiography> <http://www.w3.org/2000/01/rdf-schema#label> "Formación"@es .
 <http://vivoweb.org/ontology#vitroPropertyGroupoutreach> <http://www.w3.org/2000/01/rdf-schema#label> "Servicio"@es .
 <http://vivoweb.org/ontology#vitroPropertyGroupbibobscure> <http://www.w3.org/2000/01/rdf-schema#label> "Informaci\u00F3n adicional de documento"@es .
 <http://vivoweb.org/ontology#vitroPropertyGrouplinks> <http://www.w3.org/2000/01/rdf-schema#label> "Enlaces"@es .

--- a/home/src/main/resources/rdf/i18n/es/display/firsttime/PropertyConfig.nt
+++ b/home/src/main/resources/rdf/i18n/es/display/firsttime/PropertyConfig.nt
@@ -1,4 +1,4 @@
-<http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/personInPositionConfig> <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#displayName> "posiciones"@es .
+<http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/personInPositionConfig> <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#displayName> "puestos"@es .
 <http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/organizationForPositionConfig> <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#displayName> "personas"@es .
 <http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/authorInAuthorshipConfig> <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#displayName> "publicaciones seleccionadas"@es .
 <http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/orgInAuthorshipConfig> <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#displayName> "publicaciones seleccionadas"@es .


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: #4151 

# What does this pull request do?
Fix Spanish translations reported from Manuel Hidalgo (a native speaker)

# How should this be tested?

- Enable es language in runtime.properties.
- Switch to Spanish in language selector at top of page.
- View background property tab and list of positions on a suitably populated profile page.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Natural language knowledge
    1. Spanish