### PR TITLE
Add ror id

### DIFF
--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_add_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_add_data_property.n3
@@ -158,6 +158,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_display_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_display_data_property.n3
@@ -81,6 +81,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_drop_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_drop_data_property.n3
@@ -158,6 +158,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_edit_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_edit_data_property.n3
@@ -158,6 +158,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_admin_publish_data_property.n3
@@ -165,6 +165,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_add_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_add_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_display_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_display_data_property.n3
@@ -80,6 +80,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_drop_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_drop_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_edit_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_edit_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_curator_publish_data_property.n3
@@ -164,6 +164,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_add_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_add_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_display_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_display_data_property.n3
@@ -80,6 +80,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_drop_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_drop_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_edit_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_edit_data_property.n3
@@ -157,6 +157,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_editor_publish_data_property.n3
@@ -164,6 +164,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_public_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_public_publish_data_property.n3
@@ -182,7 +182,7 @@
     vivo:rank ,
     vivo:reportId ,
     vivo:researchOverview ,
-    vivo:rodId ,
+    vivo:rorId ,
     vivo:seatingCapacity ,
     vivo:sponsorAwardId ,
     vivo:supplementalInformation ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_public_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_public_publish_data_property.n3
@@ -182,6 +182,7 @@
     vivo:rank ,
     vivo:reportId ,
     vivo:researchOverview ,
+    vivo:rodId ,
     vivo:seatingCapacity ,
     vivo:sponsorAwardId ,
     vivo:supplementalInformation ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_add_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_add_data_property.n3
@@ -155,6 +155,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_display_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_display_data_property.n3
@@ -79,6 +79,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_drop_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_drop_data_property.n3
@@ -155,6 +155,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_edit_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_edit_data_property.n3
@@ -155,6 +155,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_publish_data_property.n3
+++ b/home/src/main/resources/rdf/accessControl/firsttime/allowed_entities_self_editor_publish_data_property.n3
@@ -163,6 +163,7 @@
     <http://vivoweb.org/ontology/core#reportId> ,
     <http://vivoweb.org/ontology/core#researchOverview> ,
     <http://vivoweb.org/ontology/core#researcherId> ,
+    <http://vivoweb.org/ontology/core#rorId> ,
     <http://vivoweb.org/ontology/core#scopusId> ,
     <http://vivoweb.org/ontology/core#seatingCapacity> ,
     <http://vivoweb.org/ontology/core#sponsorAwardId> ,

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -4766,7 +4766,8 @@ use one freetextKeyword assertion for each keyword or phrase.</obo:IAO_0000112>
 Definition source: https://ror.org/about/</obo:IAO_0000112>
         <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
-    </owl:DatatypeProperty>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string" />
+</owl:DatatypeProperty>
 
     <!-- http://vivoweb.org/ontology/core#researcherId -->
 

--- a/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/vivo.owl
@@ -4758,7 +4758,15 @@ use one freetextKeyword assertion for each keyword or phrase.</obo:IAO_0000112>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
     </owl:DatatypeProperty>
 
+    <!-- http://vivoweb.org/ontology/core#rorId -->
 
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#rorId">
+        <rdfs:label xml:lang="en">ROR ID</rdfs:label>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The ROR ID is a unique identifier for organizations in the Research Organization Registry (ROR), which is a global, community-led registry of open persistent identifiers for research organizations.
+Definition source: https://ror.org/about/</obo:IAO_0000112>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    </owl:DatatypeProperty>
 
     <!-- http://vivoweb.org/ontology/core#researcherId -->
 

--- a/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
+++ b/home/src/main/resources/rdf/tbox/firsttime/vitroAnnotations.n3
@@ -5169,6 +5169,16 @@ vivo:researchOverview
       vitro:editing
               "HTML"^^xsd:string .
 
+vivo:rorId
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:hiddenFromPublishBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot
+              <http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
+
 obo:ERO_0000390
       vitro:displayLimitAnnot
               "3"^^xsd:int ;


### PR DESCRIPTION
**[VIVO GitHub issue](https://github.com/vivo-project/VIVO/issues)**: #4158 

# What does this pull request do?
Add support for cataloguing ROR identifier linked with an organisation.  

# What's new?
rorId data property copied from [vivo-ontology repository](https://github.com/vivo-ontologies/vivo-ontology/pull/56) into vivo.owl file used in the VIVO platform. 

The property is displayed in the Identity tab. The label for the property is ROR ID for all languages!

# How should this be tested?
1. Run VIVO with sample data
2. Log in as an admin
3. Open landing page of Harvard university in VIVO
4. Add ROR identifier - 03vek6s52
5. Check whether it is displayed

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers

# Reviewers' expertise

Candidates for reviewing this PR should have some of the following expertises:
1. Ontologies
